### PR TITLE
feat: configurable timeouts and fix streaming tool call deltas

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -260,9 +260,27 @@ func (c *Config) loadFromEnv() {
 		c.Logging.Format = format
 	}
 
+	// Server timeout configuration
+	if rt := os.Getenv("SERVER_READ_TIMEOUT"); rt != "" {
+		if d, err := time.ParseDuration(rt); err == nil {
+			c.Server.ReadTimeout = d
+		}
+	}
+	if wt := os.Getenv("SERVER_WRITE_TIMEOUT"); wt != "" {
+		if d, err := time.ParseDuration(wt); err == nil {
+			c.Server.WriteTimeout = d
+		}
+	}
+
 	// Router configuration
 	if strategy := os.Getenv("LLM_ROUTER_DEFAULT_STRATEGY"); strategy != "" {
 		c.Router.DefaultStrategy = strategy
+	}
+
+	if rt := os.Getenv("ROUTER_REQUEST_TIMEOUT"); rt != "" {
+		if d, err := time.ParseDuration(rt); err == nil {
+			c.Router.RequestTimeout = d
+		}
 	}
 }
 

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -376,8 +376,9 @@ func (p *OpenAIProvider) convertToOpenAIRequest(req *types.ChatRequest) (*openai
 	var messages []openai.ChatCompletionMessage
 	for _, msg := range req.Messages {
 		openaiMsg := openai.ChatCompletionMessage{
-			Role: msg.Role,
-			Name: msg.Name,
+			Role:       msg.Role,
+			Name:       msg.Name,
+			ToolCallID: msg.ToolCallID,
 		}
 
 		// Handle content (string or multipart)
@@ -408,7 +409,7 @@ func (p *OpenAIProvider) convertToOpenAIRequest(req *types.ChatRequest) (*openai
 			openaiMsg.MultiContent = multiContent
 		}
 
-		// Handle tool calls
+		// Handle tool calls on assistant messages
 		if len(msg.ToolCalls) > 0 {
 			var toolCalls []openai.ToolCall
 			for _, tc := range msg.ToolCalls {
@@ -417,7 +418,7 @@ func (p *OpenAIProvider) convertToOpenAIRequest(req *types.ChatRequest) (*openai
 					Type: openai.ToolType(tc.Type),
 					Function: openai.FunctionCall{
 						Name:      tc.Function.Name,
-						Arguments: fmt.Sprintf("%v", tc.Function.Parameters),
+						Arguments: tc.Function.Arguments,
 					},
 				})
 			}
@@ -528,9 +529,8 @@ func (p *OpenAIProvider) convertFromOpenAIResponse(resp *openai.ChatCompletionRe
 					ID:   tc.ID,
 					Type: string(tc.Type),
 					Function: types.Function{
-						Name:        tc.Function.Name,
-						Description: "", // Not provided in response
-						Parameters:  map[string]interface{}{"arguments": tc.Function.Arguments},
+						Name:      tc.Function.Name,
+						Arguments: tc.Function.Arguments,
 					},
 				})
 			}

--- a/internal/types/requests.go
+++ b/internal/types/requests.go
@@ -39,10 +39,11 @@ type ChatRequest struct {
 }
 
 type Message struct {
-	Role      string      `json:"role"`
-	Content   interface{} `json:"content"` // string or []ContentPart for multimodal
-	Name      string      `json:"name,omitempty"`
-	ToolCalls []ToolCall  `json:"tool_calls,omitempty"`
+	Role       string      `json:"role"`
+	Content    interface{} `json:"content"` // string or []ContentPart for multimodal
+	Name       string      `json:"name,omitempty"`
+	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
+	ToolCallID string      `json:"tool_call_id,omitempty"` // For tool result messages (role=tool)
 }
 
 type ContentPart struct {
@@ -60,6 +61,7 @@ type Function struct {
 	Name        string      `json:"name"`
 	Description string      `json:"description,omitempty"`
 	Parameters  interface{} `json:"parameters,omitempty"`
+	Arguments   string      `json:"arguments,omitempty"` // Used in tool_call responses (JSON string of args)
 }
 
 type Tool struct {


### PR DESCRIPTION
## Summary
- Add `SERVER_READ_TIMEOUT`, `SERVER_WRITE_TIMEOUT`, `ROUTER_REQUEST_TIMEOUT` env var support for configurable server and router timeouts
- Fix streaming delta conversion to include argument-only tool call fragments (previously dropped when delta had no content or role)
- Use `Function.Arguments` field directly instead of embedding in Parameters map

## Test plan
- [x] Verify configurable timeouts are read from env vars
- [x] Verify streaming tool calls with argument fragments are correctly forwarded
- [x] Build and deploy to K3s successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)