### PR TITLE
fix: bump Dockerfile Go version to 1.24

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 WORKDIR /build
 


### PR DESCRIPTION
## Summary
- Bump Dockerfile base image from `golang:1.23-alpine` to `golang:1.24-alpine` to match `go.mod` requirement (`go 1.24.0`)
- Without this fix, Docker builds fail with `go.mod requires go >= 1.24.0 (running go 1.23.12)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)