### PR TITLE
fix: make Anthropic health check model configurable

### DIFF
--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -261,9 +261,13 @@ func (p *AnthropicProvider) EstimateCost(req *types.ChatRequest) (*types.CostEst
 
 // HealthCheck performs a health check on the Anthropic API
 func (p *AnthropicProvider) HealthCheck(ctx context.Context) error {
-	// Simple health check using a minimal message
+	model := p.pickHealthCheckModel()
+	if model == "" {
+		return fmt.Errorf("anthropic health check skipped: no models configured")
+	}
+
 	testReq := anthropic.MessageNewParams{
-		Model: anthropic.Model("claude-3-haiku-20240307"), // Use cheapest model for health check
+		Model: anthropic.Model(model),
 		Messages: []anthropic.MessageParam{
 			anthropic.NewUserMessage(anthropic.NewTextBlock("test")),
 		},
@@ -278,6 +282,22 @@ func (p *AnthropicProvider) HealthCheck(ctx context.Context) error {
 
 	p.logger.Debug("Anthropic health check passed")
 	return nil
+}
+
+// pickHealthCheckModel chooses a currently-configured model for the health
+// probe. We can't hardcode a model name — Anthropic deprecates dated snapshots
+// and the probe then 404s, marking the whole provider unhealthy. Prefer a
+// Haiku-family model (cheapest), fall back to the first configured model.
+func (p *AnthropicProvider) pickHealthCheckModel() string {
+	if len(p.config.Models) == 0 {
+		return ""
+	}
+	for _, m := range p.config.Models {
+		if strings.Contains(strings.ToLower(m.Name), "haiku") {
+			return m.Name
+		}
+	}
+	return p.config.Models[0].Name
 }
 
 // Interface implementations for advanced features


### PR DESCRIPTION
## Summary
- Removes the hardcoded `claude-3-haiku-20240307` health-check model from the Anthropic provider; now picks the cheapest configured model (Haiku tier preferred, otherwise the first model from `Models`).
- When the deprecated snapshot was retired by Anthropic, the provider's background health probe started failing 404, the router marked the entire `anthropic` provider unhealthy, and downstream agent-builder calls returned 500. This fix makes the health probe track whatever the operator has actually configured.

## Test plan
- [x] Unit selection logic returns Haiku model when present, otherwise first configured
- [x] Live cluster: rebuilt + rolled out llm-router, health endpoint reports anthropic healthy
- [x] HOA notebook chat (the original failure) sends successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)