### PR TITLE
feat: AIQG TAS-* header taxonomy parser

### DIFF
--- a/internal/middleware/aiqg_headers.go
+++ b/internal/middleware/aiqg_headers.go
@@ -1,0 +1,206 @@
+// Package middleware: AIQG header taxonomy parser.
+//
+// Implements the TAS-* request header set defined in
+// aether-shared/data-models/aiqg/source-spec-v0.2.md §3.5 and named as the
+// implementation site in event-timestamps.md §225
+// (`internal/middleware/aiqg_headers.go`). Headers parsed:
+//
+//	TAS-Auth                       Gateway auth token (tas_qg_live_*)
+//	TAS-Policy                     Comma-separated policy names
+//	TAS-Policy-Bundle              Named policy bundle (mutually exclusive with TAS-Policy)
+//	TAS-Workflow                   Customer-supplied workflow override (enum)
+//	TAS-Upstream-Authorization     Per-request vendor key override
+//	TAS-Trace                      "1" → return captured event as response header
+//	TAS-Dry-Run                    "1" → compute decisions but do not enforce
+//	TAS-Source-App                 Free-form source-app override (max 128 chars)
+//
+// All headers are optional from the parser's perspective — the Path A auth
+// slice will enforce TAS-Auth presence on the customer ingress. ParseHeaders
+// only fails on malformed values (TAS-Policy + TAS-Policy-Bundle both set,
+// TAS-Workflow not in the enum). Unknown TAS-* headers are ignored, not
+// rejected, so a future header addition doesn't break old gateways.
+//
+// The parsed AIQGHeaders are attached to request context via WithHeaders so
+// downstream consumers (workflow classifier, policy resolver, event emitter)
+// can read them without re-parsing. StripFromOutbound removes the TAS-*
+// headers from the request before it leaves the gateway — vendors must never
+// see TAS-* on the wire.
+package middleware
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// AIQGHeaders is the parsed view of TAS-* request headers. Zero-value is a
+// valid "no AIQG headers present" state — every field is optional at parse
+// time. Use IsZero to test whether the request carried any AIQG control
+// headers at all.
+type AIQGHeaders struct {
+	Auth                  string   // TAS-Auth (raw token; format-validated, not authenticated)
+	Policy                []string // TAS-Policy (comma-split, trimmed)
+	PolicyBundle          string   // TAS-Policy-Bundle
+	Workflow              string   // TAS-Workflow (validated against enum)
+	UpstreamAuthorization string   // TAS-Upstream-Authorization (raw, never logged)
+	Trace                 bool     // TAS-Trace=1
+	DryRun                bool     // TAS-Dry-Run=1
+	SourceApp             string   // TAS-Source-App (max 128 chars)
+}
+
+// IsZero reports whether any AIQG header was set. Used by the Path A
+// gating logic to decide whether to enter AIQG mode at all.
+func (h AIQGHeaders) IsZero() bool {
+	return h.Auth == "" && len(h.Policy) == 0 && h.PolicyBundle == "" &&
+		h.Workflow == "" && h.UpstreamAuthorization == "" &&
+		!h.Trace && !h.DryRun && h.SourceApp == ""
+}
+
+// canonicalHeaderNames is the closed set of inbound TAS-* headers we
+// recognize. StripFromOutbound iterates this list, so adding a new header
+// requires adding it here. Kept private; tests reference it via exported
+// helpers.
+var canonicalHeaderNames = []string{
+	"TAS-Auth",
+	"TAS-Policy",
+	"TAS-Policy-Bundle",
+	"TAS-Workflow",
+	"TAS-Upstream-Authorization",
+	"TAS-Trace",
+	"TAS-Dry-Run",
+	"TAS-Source-App",
+}
+
+// validWorkflows is the closed enum from
+// aether-shared/data-models/aiqg/workflow-classification.md §1.1.
+// `unknown` is intentionally excluded — a customer who genuinely doesn't
+// know their workflow should omit the header, not assert ignorance.
+var validWorkflows = map[string]struct{}{
+	"single_turn_qa":            {},
+	"rag":                       {},
+	"agentic":                   {},
+	"summarization":             {},
+	"code_generation":           {},
+	"classification_extraction": {},
+}
+
+// Maximum length for TAS-Source-App per request-event.md §80.
+const maxSourceAppLen = 128
+
+// authTokenPrefix is the prefix every customer-facing TAS-Auth token
+// carries (source-spec §3.5.1). Format check only; the auth-mode slice
+// will resolve the token to an account.
+const authTokenPrefix = "tas_qg_live_"
+
+// Errors returned by ParseHeaders. Callers map these to the appropriate
+// HTTP status (400 for malformed, 401 for missing auth — but missing auth
+// is the Path A slice's concern, not this one).
+var (
+	ErrPolicyConflict        = errors.New("aiqg: TAS-Policy and TAS-Policy-Bundle are mutually exclusive")
+	ErrAuthMalformed         = errors.New("aiqg: TAS-Auth token is malformed")
+	ErrSourceAppTooLong      = fmt.Errorf("aiqg: TAS-Source-App exceeds %d characters", maxSourceAppLen)
+	ErrUnknownWorkflowSilent = errors.New("aiqg: TAS-Workflow value is not in the enum (will fall through to heuristic)")
+)
+
+// ParseHeaders extracts the TAS-* header taxonomy from req. Returns a
+// populated AIQGHeaders on success.
+//
+// Validation rules (per source-spec §3.5):
+//   - TAS-Policy and TAS-Policy-Bundle are mutually exclusive (ErrPolicyConflict)
+//   - TAS-Auth, if present, must start with "tas_qg_live_" (ErrAuthMalformed)
+//   - TAS-Source-App, if present, must be ≤ 128 chars (ErrSourceAppTooLong)
+//   - TAS-Workflow: if the value isn't in the enum, the field is cleared
+//     and ErrUnknownWorkflowSilent is returned alongside the parsed
+//     headers — callers can choose to log and proceed (matches
+//     workflow-classification.md §3 "invalid override → log + fall through")
+//
+// All other malformations cause the function to return a partially
+// populated struct and the relevant error. A nil error guarantees the
+// returned headers are safe to attach via WithHeaders.
+func ParseHeaders(req *http.Request) (AIQGHeaders, error) {
+	h := AIQGHeaders{
+		Auth:                  strings.TrimSpace(req.Header.Get("TAS-Auth")),
+		PolicyBundle:          strings.TrimSpace(req.Header.Get("TAS-Policy-Bundle")),
+		Workflow:              strings.TrimSpace(req.Header.Get("TAS-Workflow")),
+		UpstreamAuthorization: req.Header.Get("TAS-Upstream-Authorization"),
+		Trace:                 req.Header.Get("TAS-Trace") == "1",
+		DryRun:                req.Header.Get("TAS-Dry-Run") == "1",
+		SourceApp:             strings.TrimSpace(req.Header.Get("TAS-Source-App")),
+	}
+
+	if raw := req.Header.Get("TAS-Policy"); raw != "" {
+		parts := strings.Split(raw, ",")
+		policies := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				policies = append(policies, p)
+			}
+		}
+		h.Policy = policies
+	}
+
+	if len(h.Policy) > 0 && h.PolicyBundle != "" {
+		return h, ErrPolicyConflict
+	}
+
+	if h.Auth != "" && !strings.HasPrefix(h.Auth, authTokenPrefix) {
+		return h, ErrAuthMalformed
+	}
+
+	if len(h.SourceApp) > maxSourceAppLen {
+		return h, ErrSourceAppTooLong
+	}
+
+	if h.Workflow != "" {
+		if _, ok := validWorkflows[h.Workflow]; !ok {
+			// Per spec: log + clear + fall through. The caller decides
+			// whether to log; we just return the soft error.
+			h.Workflow = ""
+			return h, ErrUnknownWorkflowSilent
+		}
+	}
+
+	return h, nil
+}
+
+// StripFromOutbound removes every TAS-* header from req.Header. Call this
+// on the outbound request before forwarding to the vendor — TAS-* headers
+// must never reach OpenAI/Anthropic. Idempotent; safe to call on a
+// request with no TAS-* headers.
+//
+// Also strips TAS-Upstream-Authorization specifically — the Path A slice
+// will copy its value into the outbound Authorization header BEFORE
+// calling this, so by the time we strip, the value is already where it
+// needs to go.
+func StripFromOutbound(req *http.Request) {
+	for _, name := range canonicalHeaderNames {
+		req.Header.Del(name)
+	}
+}
+
+// Context plumbing — same shape as instrumentation.WithCollector, so
+// downstream consumers learn one pattern.
+
+type ctxKey struct{}
+
+var headersKey = ctxKey{}
+
+// WithHeaders attaches parsed AIQG headers to ctx. Downstream consumers
+// (policy resolver, workflow classifier, event emitter) call FromContext
+// to read them back.
+func WithHeaders(ctx context.Context, h AIQGHeaders) context.Context {
+	return context.WithValue(ctx, headersKey, h)
+}
+
+// FromContext returns the AIQG headers attached to ctx. The second return
+// is false when no headers were attached — callers should treat this as
+// "non-AIQG request" and skip AIQG-specific work entirely.
+func FromContext(ctx context.Context) (AIQGHeaders, bool) {
+	if ctx == nil {
+		return AIQGHeaders{}, false
+	}
+	h, ok := ctx.Value(headersKey).(AIQGHeaders)
+	return h, ok
+}

--- a/internal/middleware/aiqg_headers_test.go
+++ b/internal/middleware/aiqg_headers_test.go
@@ -1,0 +1,387 @@
+package middleware
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newReq(t *testing.T, headers map[string]string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "https://gateway.aiqg.tas.io/v1/chat/completions", nil)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	return req
+}
+
+func TestParseHeaders_AllFields(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Auth":                   "tas_qg_live_abc123",
+		"TAS-Policy-Bundle":          "prod-strict",
+		"TAS-Workflow":               "rag",
+		"TAS-Upstream-Authorization": "Bearer sk-real-vendor-key",
+		"TAS-Trace":                  "1",
+		"TAS-Dry-Run":                "1",
+		"TAS-Source-App":             "billing-api-prod",
+	})
+
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("ParseHeaders err: %v", err)
+	}
+	if h.Auth != "tas_qg_live_abc123" {
+		t.Errorf("Auth=%q", h.Auth)
+	}
+	if h.PolicyBundle != "prod-strict" {
+		t.Errorf("PolicyBundle=%q", h.PolicyBundle)
+	}
+	if h.Workflow != "rag" {
+		t.Errorf("Workflow=%q", h.Workflow)
+	}
+	if h.UpstreamAuthorization != "Bearer sk-real-vendor-key" {
+		t.Errorf("UpstreamAuthorization=%q", h.UpstreamAuthorization)
+	}
+	if !h.Trace {
+		t.Errorf("Trace not set")
+	}
+	if !h.DryRun {
+		t.Errorf("DryRun not set")
+	}
+	if h.SourceApp != "billing-api-prod" {
+		t.Errorf("SourceApp=%q", h.SourceApp)
+	}
+	if len(h.Policy) != 0 {
+		t.Errorf("Policy should be empty when only PolicyBundle set, got %v", h.Policy)
+	}
+	if h.IsZero() {
+		t.Errorf("IsZero=true with all fields populated")
+	}
+}
+
+func TestParseHeaders_EmptyRequest(t *testing.T) {
+	req := newReq(t, nil)
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("ParseHeaders on empty: %v", err)
+	}
+	if !h.IsZero() {
+		t.Errorf("IsZero=false with no headers, got %#v", h)
+	}
+}
+
+func TestParseHeaders_PolicySplit(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Policy": "pii_redact, prompt_injection,   no-cot ",
+	})
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"pii_redact", "prompt_injection", "no-cot"}
+	if len(h.Policy) != len(want) {
+		t.Fatalf("len(Policy)=%d want=%d (%v)", len(h.Policy), len(want), h.Policy)
+	}
+	for i, v := range want {
+		if h.Policy[i] != v {
+			t.Errorf("Policy[%d]=%q want=%q", i, h.Policy[i], v)
+		}
+	}
+}
+
+func TestParseHeaders_PolicyAndBundleConflict(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Policy":        "pii_redact",
+		"TAS-Policy-Bundle": "prod-strict",
+	})
+	h, err := ParseHeaders(req)
+	if !errors.Is(err, ErrPolicyConflict) {
+		t.Fatalf("expected ErrPolicyConflict, got %v", err)
+	}
+	// The returned struct should still be populated so callers can log
+	// both values when constructing the 400 response.
+	if h.PolicyBundle != "prod-strict" || len(h.Policy) != 1 {
+		t.Errorf("expected both populated, got %#v", h)
+	}
+}
+
+func TestParseHeaders_AuthMalformed(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Auth": "wrong-prefix-token",
+	})
+	h, err := ParseHeaders(req)
+	if !errors.Is(err, ErrAuthMalformed) {
+		t.Fatalf("expected ErrAuthMalformed, got %v", err)
+	}
+	if h.Auth != "wrong-prefix-token" {
+		t.Errorf("Auth should be preserved for logging, got %q", h.Auth)
+	}
+}
+
+func TestParseHeaders_AuthAccepted(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Auth": "tas_qg_live_abcdef0123456789",
+	})
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.Auth == "" {
+		t.Errorf("Auth not parsed")
+	}
+}
+
+func TestParseHeaders_SourceAppTooLong(t *testing.T) {
+	long := strings.Repeat("a", maxSourceAppLen+1)
+	req := newReq(t, map[string]string{"TAS-Source-App": long})
+	_, err := ParseHeaders(req)
+	if !errors.Is(err, ErrSourceAppTooLong) {
+		t.Fatalf("expected ErrSourceAppTooLong, got %v", err)
+	}
+
+	atLimit := strings.Repeat("a", maxSourceAppLen)
+	req = newReq(t, map[string]string{"TAS-Source-App": atLimit})
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("at-limit length should pass: %v", err)
+	}
+	if h.SourceApp != atLimit {
+		t.Errorf("SourceApp not preserved")
+	}
+}
+
+func TestParseHeaders_WorkflowEnum(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      string
+		wantSet  bool
+		wantSoft bool
+	}{
+		{"valid_rag", "rag", true, false},
+		{"valid_agentic", "agentic", true, false},
+		{"valid_single_turn_qa", "single_turn_qa", true, false},
+		{"valid_summarization", "summarization", true, false},
+		{"valid_code_generation", "code_generation", true, false},
+		{"valid_classification_extraction", "classification_extraction", true, false},
+		// `unknown` is intentionally NOT accepted — customer should omit
+		// the header rather than assert ignorance.
+		{"reject_unknown", "unknown", false, true},
+		{"reject_misspelled", "ragg", false, true},
+		{"reject_empty_unset", "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hdrs := map[string]string{}
+			if tt.val != "" {
+				hdrs["TAS-Workflow"] = tt.val
+			}
+			req := newReq(t, hdrs)
+			h, err := ParseHeaders(req)
+			gotSoft := errors.Is(err, ErrUnknownWorkflowSilent)
+			if gotSoft != tt.wantSoft {
+				t.Errorf("ErrUnknownWorkflowSilent=%v want=%v (err=%v)", gotSoft, tt.wantSoft, err)
+			}
+			if err != nil && !tt.wantSoft {
+				t.Errorf("unexpected hard error: %v", err)
+			}
+			gotSet := h.Workflow != ""
+			if gotSet != tt.wantSet {
+				t.Errorf("Workflow set=%v want=%v (val=%q)", gotSet, tt.wantSet, h.Workflow)
+			}
+			// On soft error the field MUST be cleared so downstream code
+			// never trusts an unvalidated value.
+			if tt.wantSoft && h.Workflow != "" {
+				t.Errorf("invalid workflow not cleared: %q", h.Workflow)
+			}
+		})
+	}
+}
+
+func TestParseHeaders_BoolNotOne(t *testing.T) {
+	// Only literal "1" turns the bool on — "true", "yes", " 1" must not.
+	tests := []struct {
+		name     string
+		hdr      string
+		val      string
+		readBack func(AIQGHeaders) bool
+	}{
+		{"trace_true_string", "TAS-Trace", "true", func(h AIQGHeaders) bool { return h.Trace }},
+		{"trace_yes", "TAS-Trace", "yes", func(h AIQGHeaders) bool { return h.Trace }},
+		{"trace_padded_one", "TAS-Trace", " 1", func(h AIQGHeaders) bool { return h.Trace }},
+		{"dry_run_zero", "TAS-Dry-Run", "0", func(h AIQGHeaders) bool { return h.DryRun }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := newReq(t, map[string]string{tt.hdr: tt.val})
+			h, err := ParseHeaders(req)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if tt.readBack(h) {
+				t.Errorf("bool=true for non-canonical %q=%q", tt.hdr, tt.val)
+			}
+		})
+	}
+}
+
+func TestParseHeaders_TrimsAuthAndBundle(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Auth":          "  tas_qg_live_xyz  ",
+		"TAS-Policy-Bundle": "  prod-strict  ",
+		"TAS-Workflow":      "  rag  ",
+		"TAS-Source-App":    "  billing  ",
+	})
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if h.Auth != "tas_qg_live_xyz" {
+		t.Errorf("Auth not trimmed: %q", h.Auth)
+	}
+	if h.PolicyBundle != "prod-strict" {
+		t.Errorf("PolicyBundle not trimmed: %q", h.PolicyBundle)
+	}
+	if h.Workflow != "rag" {
+		t.Errorf("Workflow not trimmed: %q", h.Workflow)
+	}
+	if h.SourceApp != "billing" {
+		t.Errorf("SourceApp not trimmed: %q", h.SourceApp)
+	}
+}
+
+func TestParseHeaders_PolicyEmptyStringsDropped(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Policy": "a,,b,  ,c",
+	})
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	want := []string{"a", "b", "c"}
+	if len(h.Policy) != len(want) {
+		t.Fatalf("len=%d want=%d (%v)", len(h.Policy), len(want), h.Policy)
+	}
+}
+
+func TestStripFromOutbound(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Auth":                   "tas_qg_live_abc",
+		"TAS-Policy":                 "pii_redact",
+		"TAS-Policy-Bundle":          "prod-strict",
+		"TAS-Workflow":               "rag",
+		"TAS-Upstream-Authorization": "Bearer sk-real",
+		"TAS-Trace":                  "1",
+		"TAS-Dry-Run":                "1",
+		"TAS-Source-App":             "billing",
+		// Non-TAS headers must survive.
+		"Authorization": "Bearer sk-customer",
+		"Content-Type":  "application/json",
+		"X-Request-ID":  "req-123",
+	})
+
+	StripFromOutbound(req)
+
+	for _, name := range canonicalHeaderNames {
+		if v := req.Header.Get(name); v != "" {
+			t.Errorf("%s not stripped (=%q)", name, v)
+		}
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer sk-customer" {
+		t.Errorf("Authorization wiped: %q", got)
+	}
+	if got := req.Header.Get("Content-Type"); got != "application/json" {
+		t.Errorf("Content-Type wiped: %q", got)
+	}
+	if got := req.Header.Get("X-Request-ID"); got != "req-123" {
+		t.Errorf("X-Request-ID wiped: %q", got)
+	}
+}
+
+func TestStripFromOutbound_Idempotent(t *testing.T) {
+	req := newReq(t, map[string]string{"TAS-Auth": "tas_qg_live_x"})
+	StripFromOutbound(req)
+	// Second call must not panic and must leave the request alone.
+	StripFromOutbound(req)
+	if v := req.Header.Get("TAS-Auth"); v != "" {
+		t.Errorf("TAS-Auth survived second strip: %q", v)
+	}
+}
+
+func TestStripFromOutbound_NoTASHeaders(t *testing.T) {
+	req := newReq(t, map[string]string{"Authorization": "Bearer sk"})
+	StripFromOutbound(req)
+	if v := req.Header.Get("Authorization"); v != "Bearer sk" {
+		t.Errorf("Authorization wiped on no-op strip: %q", v)
+	}
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	src := AIQGHeaders{
+		Auth:         "tas_qg_live_abc",
+		PolicyBundle: "prod",
+		Workflow:     "rag",
+		Trace:        true,
+	}
+	ctx := WithHeaders(context.Background(), src)
+	got, ok := FromContext(ctx)
+	if !ok {
+		t.Fatalf("FromContext returned ok=false after WithHeaders")
+	}
+	if got.Auth != src.Auth || got.PolicyBundle != src.PolicyBundle ||
+		got.Workflow != src.Workflow || got.Trace != src.Trace {
+		t.Errorf("round trip mismatch: got=%#v want=%#v", got, src)
+	}
+}
+
+func TestContextMissing(t *testing.T) {
+	_, ok := FromContext(context.Background())
+	if ok {
+		t.Errorf("FromContext returned ok=true on bare context")
+	}
+	var nilCtx context.Context
+	_, ok = FromContext(nilCtx)
+	if ok {
+		t.Errorf("FromContext returned ok=true on nil context")
+	}
+}
+
+func TestIsZero(t *testing.T) {
+	if !(AIQGHeaders{}).IsZero() {
+		t.Errorf("zero value not IsZero")
+	}
+	if (AIQGHeaders{Trace: true}).IsZero() {
+		t.Errorf("Trace-only IsZero=true")
+	}
+	if (AIQGHeaders{Policy: []string{"a"}}).IsZero() {
+		t.Errorf("Policy-only IsZero=true")
+	}
+	if (AIQGHeaders{SourceApp: "x"}).IsZero() {
+		t.Errorf("SourceApp-only IsZero=true")
+	}
+}
+
+// Canonical header list must not accidentally lose entries during refactors.
+// If you legitimately add a header, update this test alongside the slice.
+func TestCanonicalHeaderListExhaustive(t *testing.T) {
+	expected := map[string]struct{}{
+		"TAS-Auth":                   {},
+		"TAS-Policy":                 {},
+		"TAS-Policy-Bundle":          {},
+		"TAS-Workflow":               {},
+		"TAS-Upstream-Authorization": {},
+		"TAS-Trace":                  {},
+		"TAS-Dry-Run":                {},
+		"TAS-Source-App":             {},
+	}
+	if len(canonicalHeaderNames) != len(expected) {
+		t.Fatalf("canonicalHeaderNames len=%d want=%d", len(canonicalHeaderNames), len(expected))
+	}
+	for _, n := range canonicalHeaderNames {
+		if _, ok := expected[n]; !ok {
+			t.Errorf("unexpected header in canonical list: %q", n)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Adds `internal/middleware/aiqg_headers.go` — the parser/validator/stripper for the 8 inbound TAS-* control headers defined in source-spec §3.5 and named as the implementation site in event-timestamps.md §225.

Headers in scope:
| Header | Purpose |
|---|---|
| `TAS-Auth` | Gateway auth token (`tas_qg_live_*`) — format-checked here, resolved in the auth slice |
| `TAS-Policy` | Comma-separated policy names |
| `TAS-Policy-Bundle` | Named bundle (mutually exclusive with TAS-Policy) |
| `TAS-Workflow` | Customer workflow override (validated against the closed enum) |
| `TAS-Upstream-Authorization` | Per-request vendor key override |
| `TAS-Trace` | `1` → return captured event as response header |
| `TAS-Dry-Run` | `1` → compute decisions, don't enforce |
| `TAS-Source-App` | Free-form source-app override (≤128 chars per request-event.md §80) |

## Validation rules
- `TAS-Policy` + `TAS-Policy-Bundle` simultaneously → `ErrPolicyConflict` (400 candidate).
- `TAS-Auth` without the `tas_qg_live_` prefix → `ErrAuthMalformed`.
- `TAS-Source-App` > 128 chars → `ErrSourceAppTooLong`.
- `TAS-Workflow` value not in the workflow-classification.md §1.1 enum → field is **cleared** and `ErrUnknownWorkflowSilent` is returned, matching the spec's "invalid override → log + fall through" rule. Callers can log and proceed.

## Stripping
`StripFromOutbound` removes every TAS-* header from a request before it's forwarded to the vendor. Idempotent. Driven off a `canonicalHeaderNames` list with an exhaustiveness test guarding it.

## Context plumbing
`WithHeaders` / `FromContext` follow the same sidecar pattern as the per-chunk-timing slice (PR #14), so downstream consumers (workflow classifier, policy resolver, event emitter) learn one pattern.

## Non-breaking
Nothing here is wired into the request pipeline yet. The Path A auth slice will be the first caller — until then, no behavior changes for any existing request. Matches build-vs-reuse §1.2.

## Test plan
- [x] `go test -race -count=1 ./internal/middleware/...` passes (table-driven coverage of every validation branch, strip idempotence, context round-trip, workflow enum boundary, canonical-list exhaustiveness)
- [x] `go test -race` across all other buildable packages — no regressions
- [ ] Wired into the actual ingress pipeline (deferred to Path A auth slice)

Pre-existing `make test` failures in `internal/{config,gatekeeper,integration,server}` and at repo root (Gatekeeper sibling-repo go.sum drift, duplicate `intPtr` in repo-root test files) are unrelated and present on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)