### PR TITLE
feat: AIQG Path A entry middleware

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -1,0 +1,163 @@
+// Package middleware: AIQG mode entry — Path A auth wire-up.
+//
+// This middleware is the front door for AIQG mode. It runs before any
+// other handler on the customer-facing ingress and decides whether a
+// request enters AIQG processing.
+//
+// Decision logic (per build-vs-reuse §2.2 + §7.3 strict resolution):
+//
+//   1. Both TAS-Auth and Authorization present → enter Path A:
+//      - parse the TAS-* header taxonomy and attach to ctx
+//      - create a TimingCollector and attach to ctx
+//      - stamp StampReceived on entry, StampComplete on response end
+//      - hand off to the downstream chain
+//   2. TAS-Auth present but Authorization missing → 401 (cfg.Strict only)
+//   3. TAS-Auth missing → depends on cfg.Strict:
+//      - Strict (customer-facing ingress): 401, diagnostic body
+//      - Permissive (internal ingress): pass through unchanged, no
+//        AIQG state attached — preserves existing internal-routing behavior
+//
+// The middleware never persists Authorization. The header value is
+// already in r.Header for the rest of the chain; Path A's promise
+// ("we never hold your keys") is enforced by the *absence* of storage
+// code, not by anything this middleware does. The strip-from-outbound
+// step happens at the proxy/SDK boundary, not here.
+//
+// Validation errors on the TAS-* taxonomy (e.g. TAS-Policy and
+// TAS-Policy-Bundle both set) return 400 with a diagnostic body.
+// ErrUnknownWorkflowSilent is logged but does not fail the request —
+// the workflow field is already cleared by the parser and the heuristic
+// classifier will fill it in.
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+)
+
+// AIQGConfig configures the AIQG entry middleware.
+type AIQGConfig struct {
+	// Strict makes missing TAS-Auth (or missing Authorization when
+	// TAS-Auth is present) return 401. Use on the customer-facing
+	// ingress (gateway.aiqg.tas.io). Leave false on the internal
+	// ingress so internal callers continue to use stored vendor keys.
+	Strict bool
+
+	// Logger is used for warnings (invalid TAS-Workflow values) and the
+	// path_a_auth_rejected audit event. Required.
+	Logger *logrus.Logger
+}
+
+// NewAIQG returns the middleware constructor. The returned handler is a
+// standard http.Handler decorator compatible with gorilla/mux's
+// Router.Use.
+//
+// Panics on a nil logger — middleware misconfiguration should fail at
+// boot, not in production.
+func NewAIQG(cfg AIQGConfig) func(http.Handler) http.Handler {
+	if cfg.Logger == nil {
+		panic("middleware.NewAIQG: Logger is required")
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handleAIQG(cfg, next, w, r)
+		})
+	}
+}
+
+func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *http.Request) {
+	tasAuth := r.Header.Get("TAS-Auth")
+	customerAuth := r.Header.Get("Authorization")
+
+	// Case 1: no TAS-Auth. Either reject (strict ingress) or pass
+	// through untouched (internal ingress; preserves existing behavior).
+	if tasAuth == "" {
+		if cfg.Strict {
+			rejectPathA(cfg.Logger, w, r, "TAS-Auth")
+			return
+		}
+		next.ServeHTTP(w, r)
+		return
+	}
+
+	// Case 2: TAS-Auth set, Authorization missing. Path A explicitly
+	// requires both — there's no fallback to stored keys on AIQG
+	// ingress (build-vs-reuse §7.3 strict resolution). This is
+	// rejected in BOTH strict and permissive modes because once a
+	// caller asserts TAS-Auth they've opted into Path A semantics.
+	if customerAuth == "" {
+		rejectPathA(cfg.Logger, w, r, "Authorization")
+		return
+	}
+
+	// Case 3: both headers present. Parse the TAS-* taxonomy.
+	parsed, err := ParseHeaders(r)
+	switch {
+	case err == nil:
+		// happy path
+	case errors.Is(err, ErrUnknownWorkflowSilent):
+		// Per spec: log and fall through. parsed.Workflow has been cleared.
+		cfg.Logger.WithFields(logrus.Fields{
+			"event":          "aiqg.workflow_override_invalid",
+			"workflow_value": r.Header.Get("TAS-Workflow"),
+			"path":           r.URL.Path,
+		}).Warn("TAS-Workflow value not in enum; falling through to heuristic")
+	default:
+		writeValidationError(cfg.Logger, w, r, err)
+		return
+	}
+
+	// Enter AIQG mode: attach collector + headers, stamp Received,
+	// arrange for StampComplete on response end.
+	collector := instrumentation.NewCollector()
+	ctx := instrumentation.WithCollector(r.Context(), collector)
+	ctx = WithHeaders(ctx, parsed)
+	instrumentation.StampReceived(ctx)
+
+	defer instrumentation.StampComplete(ctx)
+
+	next.ServeHTTP(w, r.WithContext(ctx))
+}
+
+// rejectPathA emits the strict-mode 401 response and the
+// path_a_auth_rejected audit event (per audit-log-entry.md §97). The
+// response body names the missing header so customers can self-diagnose
+// without contacting support (per §7.3 mitigation).
+func rejectPathA(log *logrus.Logger, w http.ResponseWriter, r *http.Request, missing string) {
+	log.WithFields(logrus.Fields{
+		"event":          "aiqg.path_a_auth_rejected",
+		"missing_header": missing,
+		"path":           r.URL.Path,
+		"method":         r.Method,
+		"remote_addr":    r.RemoteAddr,
+	}).Warn("Path A auth rejected")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", `TAS realm="aiqg"`)
+	w.WriteHeader(http.StatusUnauthorized)
+
+	body := fmt.Sprintf(`{"error":{"code":"path_a_auth_required","message":"AIQG ingress requires both TAS-Auth and Authorization headers; %s is missing","missing_header":%q,"docs":"https://docs.tas.scharber.com/aiqg/auth"}}`, missing, missing)
+	_, _ = w.Write([]byte(body))
+}
+
+// writeValidationError emits 400 when the TAS-* header taxonomy fails
+// schema validation (ErrPolicyConflict, ErrAuthMalformed,
+// ErrSourceAppTooLong). The error.Error() text is safe to return —
+// none of these errors contain customer-controlled values.
+func writeValidationError(log *logrus.Logger, w http.ResponseWriter, r *http.Request, err error) {
+	log.WithFields(logrus.Fields{
+		"event": "aiqg.header_validation_failed",
+		"path":  r.URL.Path,
+		"err":   err.Error(),
+	}).Warn("AIQG header validation failed")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+
+	body := fmt.Sprintf(`{"error":{"code":"aiqg_header_invalid","message":%q}}`, err.Error())
+	_, _ = w.Write([]byte(body))
+}

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -1,0 +1,300 @@
+package middleware
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+)
+
+// silentLogger returns a logger that discards output — keeps test
+// output clean while exercising every code path that logs.
+func silentLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+// echoHandler is a downstream handler that records whether it ran and
+// what the AIQG state in the request context looked like at the time.
+type echoHandler struct {
+	called      bool
+	headers     AIQGHeaders
+	headersOK   bool
+	hasTimings  bool
+	requestSeen *http.Request
+}
+
+func (e *echoHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	e.called = true
+	e.requestSeen = r
+	e.headers, e.headersOK = FromContext(r.Context())
+	if c := instrumentation.FromContext(r.Context()); c != nil {
+		e.hasTimings = true
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func TestNewAIQG_PanicsOnNilLogger(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic on nil logger")
+		}
+	}()
+	NewAIQG(AIQGConfig{Strict: true, Logger: nil})
+}
+
+// Permissive mode + no TAS-Auth = pass-through. The downstream handler
+// runs, and there is NO AIQG state on the context — internal-routing
+// callers must look identical to today.
+func TestAIQG_PermissivePassThrough(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: false, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if !next.called {
+		t.Fatalf("downstream handler not called in permissive pass-through")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d want=200", rec.Code)
+	}
+	if next.headersOK {
+		t.Errorf("AIQG headers attached on a pass-through request: %#v", next.headers)
+	}
+	if next.hasTimings {
+		t.Errorf("TimingCollector attached on a pass-through request")
+	}
+}
+
+// Strict mode + no TAS-Auth = 401 with diagnostic body.
+func TestAIQG_StrictRejectsMissingTASAuth(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if next.called {
+		t.Fatalf("downstream called despite 401")
+	}
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("code=%d want=401", rec.Code)
+	}
+	if got := rec.Header().Get("WWW-Authenticate"); !strings.Contains(got, "aiqg") {
+		t.Errorf("WWW-Authenticate=%q missing aiqg realm", got)
+	}
+
+	var body struct {
+		Error struct {
+			Code          string `json:"code"`
+			Message       string `json:"message"`
+			MissingHeader string `json:"missing_header"`
+			Docs          string `json:"docs"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v\nbody=%s", err, rec.Body.String())
+	}
+	if body.Error.Code != "path_a_auth_required" {
+		t.Errorf("error.code=%q", body.Error.Code)
+	}
+	if body.Error.MissingHeader != "TAS-Auth" {
+		t.Errorf("missing_header=%q want=TAS-Auth", body.Error.MissingHeader)
+	}
+	if body.Error.Docs == "" {
+		t.Errorf("docs link should be present for self-service diagnosis")
+	}
+}
+
+// TAS-Auth set, Authorization missing = 401 regardless of strict — once
+// a caller asserts TAS-Auth they've opted into Path A semantics, and
+// Path A requires the customer's vendor key in Authorization.
+func TestAIQG_RejectsTASAuthWithoutAuthorization(t *testing.T) {
+	for _, strict := range []bool{true, false} {
+		next := &echoHandler{}
+		mw := NewAIQG(AIQGConfig{Strict: strict, Logger: silentLogger()})
+
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+		req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+		rec := httptest.NewRecorder()
+		mw(next).ServeHTTP(rec, req)
+
+		if next.called {
+			t.Fatalf("strict=%v: downstream called despite 401", strict)
+		}
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("strict=%v: code=%d want=401", strict, rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "Authorization") {
+			t.Errorf("strict=%v: body should name Authorization as missing", strict)
+		}
+	}
+}
+
+// Happy path: both headers present, validation passes, downstream runs
+// with AIQG state attached.
+func TestAIQG_HappyPathAttachesContextAndStamps(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc123")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	req.Header.Set("TAS-Workflow", "rag")
+	req.Header.Set("TAS-Trace", "1")
+	req.Header.Set("TAS-Policy-Bundle", "prod-strict")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if !next.called {
+		t.Fatalf("downstream not called on happy path")
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d want=200", rec.Code)
+	}
+	if !next.headersOK {
+		t.Fatalf("AIQG headers not attached to ctx")
+	}
+	if next.headers.Workflow != "rag" {
+		t.Errorf("Workflow=%q want=rag", next.headers.Workflow)
+	}
+	if !next.headers.Trace {
+		t.Errorf("Trace not propagated")
+	}
+	if next.headers.PolicyBundle != "prod-strict" {
+		t.Errorf("PolicyBundle=%q", next.headers.PolicyBundle)
+	}
+	if !next.hasTimings {
+		t.Fatalf("TimingCollector not attached")
+	}
+
+	// StampReceived must have fired before downstream ran. We can verify
+	// by snapshotting the collector after the middleware returns and
+	// checking RequestReceivedAt is populated.
+	c := instrumentation.FromContext(next.requestSeen.Context())
+	if c == nil {
+		t.Fatalf("no collector on captured request ctx")
+	}
+	s := c.Snapshot()
+	if s.RequestReceivedAt == nil {
+		t.Errorf("StampReceived did not fire on entry")
+	}
+	if s.ResponseCompleteAt == nil {
+		t.Errorf("StampComplete did not fire on exit")
+	}
+}
+
+// Validation errors (TAS-Policy + TAS-Policy-Bundle conflict) → 400.
+func TestAIQG_PolicyConflictReturns400(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	req.Header.Set("TAS-Policy", "pii_redact")
+	req.Header.Set("TAS-Policy-Bundle", "prod-strict")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if next.called {
+		t.Fatalf("downstream called despite 400")
+	}
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d want=400", rec.Code)
+	}
+
+	var body struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if body.Error.Code != "aiqg_header_invalid" {
+		t.Errorf("error.code=%q", body.Error.Code)
+	}
+	if !strings.Contains(body.Error.Message, "mutually exclusive") {
+		t.Errorf("message=%q should mention mutually exclusive", body.Error.Message)
+	}
+}
+
+func TestAIQG_AuthMalformedReturns400(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "not-a-valid-token-prefix")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d want=400", rec.Code)
+	}
+	if next.called {
+		t.Errorf("downstream called despite malformed auth")
+	}
+}
+
+// Soft error (unknown workflow): logged, field cleared, request proceeds.
+func TestAIQG_UnknownWorkflowFallsThrough(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	req.Header.Set("TAS-Workflow", "rag-bogus") // invalid
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d want=200 (soft error should not block)", rec.Code)
+	}
+	if !next.called {
+		t.Fatalf("downstream not called")
+	}
+	if !next.headersOK {
+		t.Fatalf("headers not attached")
+	}
+	if next.headers.Workflow != "" {
+		t.Errorf("Workflow=%q should be cleared on invalid override", next.headers.Workflow)
+	}
+}
+
+// The middleware must not touch any non-TAS header on a pass-through
+// request — internal callers' Authorization to the stored-key vendor
+// path must survive verbatim.
+func TestAIQG_PassThroughPreservesHeaders(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: false, Logger: silentLogger()})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("Authorization", "Bearer sk-internal")
+	req.Header.Set("X-Tenant-ID", "tenant-7")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if !next.called {
+		t.Fatalf("downstream not called")
+	}
+	if got := next.requestSeen.Header.Get("Authorization"); got != "Bearer sk-internal" {
+		t.Errorf("Authorization mangled in pass-through: %q", got)
+	}
+	if got := next.requestSeen.Header.Get("X-Tenant-ID"); got != "tenant-7" {
+		t.Errorf("X-Tenant-ID mangled: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
Wires the two prior slices ([per-chunk timing](https://github.com/Tributary-ai-services/tas-llm-router/pull/14) + [TAS-* header parser](https://github.com/Tributary-ai-services/tas-llm-router/pull/15)) into a single `http.Handler` middleware that gates the AIQG ingress.

## Decision logic (build-vs-reuse §2.2 + §7.3 strict resolution)
| Inbound state | Strict (`gateway.aiqg.tas.io`) | Permissive (internal) |
|---|---|---|
| **Both** TAS-Auth + Authorization present | Enter Path A → attach collector + headers → stamp Received/Complete | Same |
| TAS-Auth set, Authorization missing | 401 — Path A requires both | 401 (same — asserting TAS-Auth opts in) |
| TAS-Auth missing | 401 with diagnostic body naming missing header | Pass through unchanged, no AIQG state attached |

The diagnostic 401 body names the missing header (`{"error":{"code":"path_a_auth_required","missing_header":"TAS-Auth",...}}`) per §7.3 mitigation. Internal-routing callers continue to use stored vendor keys exactly as today — they never carry TAS-Auth, so the middleware is a no-op for them.

## Soft errors
- `ErrUnknownWorkflowSilent` → logged at warn, workflow field cleared by the parser, request proceeds to the heuristic classifier (matches workflow-classification.md §3).
- Hard validation errors (TAS-Policy + TAS-Policy-Bundle conflict, TAS-Auth malformed, TAS-Source-App too long) → 400 with the parser's error message.

## Stamping
`StampReceived` fires at entry, `StampComplete` fires via defer on response end. Both prior slices' no-op machinery now actually does work for AIQG requests.

## Non-breaking
The middleware is built but not yet registered in `server.go` — that's a separate slice that needs route-layout decisions (one binary, two ingresses vs. config-driven per-route gating). Until then, no production behavior changes. Matches build-vs-reuse §1.2.

## Test plan
- [x] `go test -race -count=1 ./internal/middleware/...` — passes (panic on nil logger; permissive pass-through; strict 401 missing TAS-Auth with WWW-Authenticate header + JSON body; 401 missing Authorization in both modes; happy path attaches both context values + stamps; 400 on policy conflict; 400 on malformed auth; soft fall-through on unknown workflow; pass-through preserves non-TAS headers verbatim)
- [x] `go test -race` across all other buildable packages — no regressions
- [ ] Wired into `server.go` ingress (deferred — separate slice)

Pre-existing `make test` failures in `internal/{config,gatekeeper,integration,server}` and at repo root are unrelated, present on `main`, and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)