### PR TITLE
feat: AIQG event model + emitter, wired into Path A middleware

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
 )
 
 // AIQGConfig configures the AIQG entry middleware.
@@ -50,6 +51,17 @@ type AIQGConfig struct {
 	// Logger is used for warnings (invalid TAS-Workflow values) and the
 	// path_a_auth_rejected audit event. Required.
 	Logger *logrus.Logger
+
+	// Emitter publishes the paired (request, response) AIQG events on
+	// response completion. Nil is treated as events.NoopEmitter — the
+	// middleware never panics on a nil emitter, but production should
+	// always wire a real one (LogEmitter for MVP, KafkaEmitter later).
+	Emitter events.Emitter
+
+	// Region is stamped on every emitted RequestEvent (e.g. "us-east",
+	// "us-west", "eu"). Set from deployment config. Empty is allowed
+	// during local dev and is omitted from the event JSON.
+	Region string
 }
 
 // NewAIQG returns the middleware constructor. The returned handler is a
@@ -112,15 +124,84 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	}
 
 	// Enter AIQG mode: attach collector + headers, stamp Received,
-	// arrange for StampComplete on response end.
+	// arrange for StampComplete + event emission on response end.
 	collector := instrumentation.NewCollector()
 	ctx := instrumentation.WithCollector(r.Context(), collector)
 	ctx = WithHeaders(ctx, parsed)
 	instrumentation.StampReceived(ctx)
 
+	sw := &statusCapturingResponseWriter{ResponseWriter: w}
+
+	emitter := cfg.Emitter
+	if emitter == nil {
+		emitter = events.NoopEmitter{}
+	}
+
+	// Defers fire LIFO: emit runs AFTER StampComplete so the snapshot
+	// it builds includes the response_complete_at timestamp.
+	defer func() {
+		reqEnv, respEnv := events.Build(r, headersView(parsed), collector.Snapshot(), events.BuildOptions{
+			HTTPStatus: sw.status(),
+			Region:     cfg.Region,
+		})
+		if err := emitter.Emit(ctx, reqEnv, respEnv); err != nil {
+			cfg.Logger.WithError(err).Warn("AIQG event emission failed")
+		}
+	}()
 	defer instrumentation.StampComplete(ctx)
 
-	next.ServeHTTP(w, r.WithContext(ctx))
+	next.ServeHTTP(sw, r.WithContext(ctx))
+}
+
+// headersView projects an AIQGHeaders into the read-only view the
+// events package consumes. Defined here (in internal/middleware) to
+// avoid pkg/aiqg/events importing internal/middleware (which would
+// create an import cycle).
+func headersView(h AIQGHeaders) events.AIQGHeadersView {
+	return events.AIQGHeadersView{
+		SourceApp:    h.SourceApp,
+		Workflow:     h.Workflow,
+		Policy:       h.Policy,
+		PolicyBundle: h.PolicyBundle,
+		DryRun:       h.DryRun,
+		Trace:        h.Trace,
+	}
+}
+
+// statusCapturingResponseWriter records the HTTP status code written
+// by downstream handlers so the AIQG event emitter can include it in
+// the response event. Wraps the underlying writer transparently.
+type statusCapturingResponseWriter struct {
+	http.ResponseWriter
+	code        int
+	wroteHeader bool
+}
+
+func (w *statusCapturingResponseWriter) WriteHeader(code int) {
+	if !w.wroteHeader {
+		w.code = code
+		w.wroteHeader = true
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// Write captures the implicit 200 that net/http writes when a handler
+// calls Write without first calling WriteHeader.
+func (w *statusCapturingResponseWriter) Write(b []byte) (int, error) {
+	if !w.wroteHeader {
+		w.code = http.StatusOK
+		w.wroteHeader = true
+	}
+	return w.ResponseWriter.Write(b)
+}
+
+// status returns the captured HTTP status, defaulting to 200 if the
+// handler never wrote anything (matches net/http's implicit-200 behavior).
+func (w *statusCapturingResponseWriter) status() int {
+	if !w.wroteHeader {
+		return http.StatusOK
+	}
+	return w.code
 }
 
 // rejectPathA emits the strict-mode 401 response and the

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
 )
 
 // silentLogger returns a logger that discards output — keeps test
@@ -272,6 +273,143 @@ func TestAIQG_UnknownWorkflowFallsThrough(t *testing.T) {
 	}
 	if next.headers.Workflow != "" {
 		t.Errorf("Workflow=%q should be cleared on invalid override", next.headers.Workflow)
+	}
+}
+
+// Happy-path AIQG requests must produce a paired (request, response)
+// event via the configured Emitter. This is the integration point
+// between the AIQG middleware and pkg/aiqg/events.
+func TestAIQG_EmitsPairedEvents(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{
+		Strict:  true,
+		Logger:  silentLogger(),
+		Emitter: em,
+		Region:  "us-east",
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions?stream=true", nil)
+	req.RemoteAddr = "203.0.113.10:1234"
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc123")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	req.Header.Set("TAS-Workflow", "rag")
+	req.Header.Set("TAS-Trace", "1")
+	req.Header.Set("TAS-Source-App", "billing-api-prod")
+	req.Header.Set("X-Request-ID", "client-req-xyz")
+
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if !next.called {
+		t.Fatalf("downstream not called")
+	}
+	if em.Len() != 1 {
+		t.Fatalf("emit count=%d want=1", em.Len())
+	}
+
+	reqEnv := em.Requests()[0]
+	respEnv := em.Responses()[0]
+
+	// Pair correlation
+	if reqEnv.Data.CorrelatedResponseEventID != respEnv.Data.ResponseEventID {
+		t.Errorf("CorrelatedResponseEventID does not match ResponseEventID")
+	}
+	if respEnv.Data.RequestEventID != reqEnv.Data.RequestEventID {
+		t.Errorf("response.RequestEventID does not match request.RequestEventID")
+	}
+
+	// Header reflection
+	if reqEnv.Data.Workflow != "rag" {
+		t.Errorf("workflow=%q", reqEnv.Data.Workflow)
+	}
+	if !reqEnv.Data.TraceReturned {
+		t.Errorf("trace_returned not propagated")
+	}
+	if reqEnv.Data.SourceApp != "billing-api-prod" {
+		t.Errorf("source_app=%q", reqEnv.Data.SourceApp)
+	}
+	if reqEnv.Data.ClientRequestID != "client-req-xyz" {
+		t.Errorf("client_request_id=%q", reqEnv.Data.ClientRequestID)
+	}
+	if reqEnv.Data.Region != "us-east" {
+		t.Errorf("region=%q", reqEnv.Data.Region)
+	}
+	if !reqEnv.Data.Streaming {
+		t.Errorf("streaming should be true for ?stream=true URL")
+	}
+
+	// Timing snapshot must be embedded with both endpoints set —
+	// proves StampReceived (entry) and StampComplete (defer LIFO order)
+	// both fired before the emitter ran.
+	if respEnv.Data.EventTimestamps.RequestReceivedAt == nil {
+		t.Errorf("request_received_at not stamped before emit")
+	}
+	if respEnv.Data.EventTimestamps.ResponseCompleteAt == nil {
+		t.Errorf("response_complete_at not stamped before emit (defer order broken)")
+	}
+
+	// HTTP status captured from the echo handler's WriteHeader(200).
+	if respEnv.Data.HTTPStatus != http.StatusOK {
+		t.Errorf("http_status=%d want=200", respEnv.Data.HTTPStatus)
+	}
+	if respEnv.Data.Status != events.StatusSuccess {
+		t.Errorf("status=%q", respEnv.Data.Status)
+	}
+}
+
+// Nil emitter must default to NoopEmitter (no panic, request succeeds).
+func TestAIQG_NilEmitterDefaultsToNoop(t *testing.T) {
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: nil})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("nil emitter caused %d", rec.Code)
+	}
+	if !next.called {
+		t.Fatalf("downstream not called")
+	}
+}
+
+// Pass-through requests (no TAS-Auth, permissive mode) must NOT emit
+// events — internal-routing traffic stays out of the AIQG event stream.
+func TestAIQG_PassThroughDoesNotEmit(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: false, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if em.Len() != 0 {
+		t.Errorf("internal pass-through emitted %d events (want 0)", em.Len())
+	}
+}
+
+// 401/400 rejections still need to be observable elsewhere, but they
+// MUST NOT produce a paired AIQG event — the spec (request-event.md §273)
+// says pre-validation auth failures emit no events.
+func TestAIQG_StrictRejectionDoesNotEmit(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	if em.Len() != 0 {
+		t.Errorf("pre-validation auth failure emitted %d events (want 0 per spec §273)", em.Len())
 	}
 }
 

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -1,0 +1,200 @@
+package events
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+)
+
+// AIQGHeadersView is the subset of parsed TAS-* headers the event
+// builder needs. Defined here as a tiny interface-shaped struct so the
+// builder doesn't import internal/middleware (which would create a
+// cycle: middleware → events → middleware). Callers in middleware
+// construct one from their AIQGHeaders before invoking Build.
+type AIQGHeadersView struct {
+	SourceApp    string
+	Workflow     string
+	Policy       []string
+	PolicyBundle string
+	DryRun       bool
+	Trace        bool
+}
+
+// GatewayVersion is the build version stamped on every event. Override
+// at build time via -ldflags "-X .../events.GatewayVersion=v1.4.2".
+var GatewayVersion = "dev"
+
+// ScoringVersion is the pkg/clear version stamped on every event. The
+// scorer slice will replace this with the actual computed version.
+// Until then, the constant signals "no scoring yet" without violating
+// the spec requirement that the field be present.
+const ScoringVersion = "clear-v0-pending"
+
+// BuildOptions captures inputs the middleware passes through that
+// aren't on the request context (HTTP status, response status string,
+// region). Fields default to sensible MVP values when zero.
+type BuildOptions struct {
+	HTTPStatus   int    // 0 if no response was written (gateway blocked)
+	Status       string // explicit status; if empty, derived from HTTPStatus
+	Region       string // deployment region; if empty, omitted from event
+	FinishReason string
+}
+
+// Build constructs the paired (RequestEnvelope, ResponseEnvelope) from
+// request, parsed headers, timing snapshot, and outcome. Returns the
+// correlated IDs already cross-linked (request.CorrelatedResponseEventID,
+// response.RequestEventID).
+//
+// Pure function: no context access, no I/O, no clock side effects beyond
+// time.Now() as the fallback when the snapshot has no stamps. Callers
+// (Path A middleware) extract the snapshot + headers from ctx and pass
+// them in — this keeps the builder importable without cycling back into
+// internal/middleware.
+//
+// Fields the gateway can't populate at MVP today (tenant_id, vendor,
+// model, CLEAR scores) are left empty — downstream slices fill them
+// either by enriching the returned envelopes before Emit, or by adding
+// new args to Build.
+func Build(r *http.Request, headers AIQGHeadersView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
+	reqID := newUUID()
+	respID := newUUID()
+	now := time.Now().UTC()
+
+	receivedAt := now
+	completeAt := now
+	if snap.RequestReceivedAt != nil {
+		receivedAt = snap.RequestReceivedAt.UTC()
+	}
+	if snap.ResponseCompleteAt != nil {
+		completeAt = snap.ResponseCompleteAt.UTC()
+	}
+
+	status := opts.Status
+	if status == "" {
+		status = StatusFromHTTP(opts.HTTPStatus)
+	}
+
+	reqEvent := RequestEvent{
+		RequestEventID:            reqID,
+		ReceivedAt:                receivedAt,
+		Endpoint:                  r.URL.Path,
+		Method:                    r.Method,
+		SourceIP:                  clientIP(r),
+		SourceApp:                 headers.SourceApp,
+		ClientRequestID:           r.Header.Get("X-Request-ID"),
+		Region:                    opts.Region,
+		Streaming:                 isStreaming(r),
+		IsAIQGMode:                true,
+		DryRun:                    headers.DryRun,
+		TraceReturned:             headers.Trace,
+		Workflow:                  headers.Workflow,
+		PolicyNames:               headers.Policy,
+		PolicyBundle:              headers.PolicyBundle,
+		// SourceApp override from header was already captured above; the
+		// AIQGHeadersView populates it for the field assignment below.
+		CorrelatedResponseEventID: respID,
+		ScoringVersion:            ScoringVersion,
+		GatewayVersion:            GatewayVersion,
+		LifecycleState:            LifecyclePairedWithResponse,
+	}
+
+	respEvent := ResponseEvent{
+		ResponseEventID:   respID,
+		RequestEventID:    reqID,
+		CompleteAt:        completeAt,
+		Status:            status,
+		HTTPStatus:        opts.HTTPStatus,
+		FinishReason:      opts.FinishReason,
+		Streamed:          snap.ChunkCount > 0,
+		ChunkCount:        snap.ChunkCount,
+		ContentChunkCount: snap.ContentChunkCount,
+		EventTimestamps:   snap,
+		ScoringVersion:    ScoringVersion,
+		GatewayVersion:    GatewayVersion,
+	}
+
+	reqEnv := RequestEnvelope{
+		SpecVersion:     SpecVersion,
+		Type:            TypeRequest,
+		Source:          Source,
+		ID:              reqID,
+		Time:            receivedAt,
+		DataContentType: DataContentType,
+		Data:            reqEvent,
+	}
+	respEnv := ResponseEnvelope{
+		SpecVersion:     SpecVersion,
+		Type:            TypeResponse,
+		Source:          Source,
+		ID:              respID,
+		Time:            completeAt,
+		DataContentType: DataContentType,
+		Data:            respEvent,
+	}
+
+	return reqEnv, respEnv
+}
+
+// newUUID returns a v4-shaped 128-bit random ID, formatted as the
+// canonical 8-4-4-4-12 hex string. We don't pull in a UUID dep because
+// the format is mechanical and we don't need RFC-strict version bits.
+func newUUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		// crypto/rand failing is catastrophic — every consumer of this
+		// ID would silently get duplicates. Panic so the deployment
+		// fails fast on a misconfigured entropy source.
+		panic("aiqg/events: crypto/rand.Read failed: " + err.Error())
+	}
+	// Apply RFC 4122 version 4 + variant bits for compatibility.
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	hexstr := hex.EncodeToString(b[:])
+	return hexstr[0:8] + "-" + hexstr[8:12] + "-" + hexstr[12:16] + "-" +
+		hexstr[16:20] + "-" + hexstr[20:32]
+}
+
+// clientIP applies trusted-proxy normalization to derive the original
+// client address. Today this is a thin wrapper around X-Forwarded-For;
+// when the gateway is fronted by a real LB, this will read a trusted-
+// proxy chain from config. For MVP, take the first XFF entry, falling
+// back to RemoteAddr's host (port-stripped).
+func clientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// First entry is the original client.
+		for i, c := range xff {
+			if c == ',' {
+				return string([]byte(xff)[:i])
+			}
+		}
+		return xff
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}
+
+// isStreaming inspects the request to decide whether it asked for a
+// streamed response. Today this is a content-type / accept / query
+// heuristic; the routing slice will replace it with payload-aware
+// detection (OpenAI body has `"stream": true`, Anthropic same).
+func isStreaming(r *http.Request) bool {
+	if r.URL.Query().Get("stream") == "true" {
+		return true
+	}
+	if accept := r.Header.Get("Accept"); accept != "" {
+		// SSE accept header indicates streaming
+		for i := 0; i < len(accept); i++ {
+			if accept[i] == 't' && i+9 <= len(accept) && accept[i:i+9] == "text/even" {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -1,0 +1,127 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Emitter publishes paired (request, response) AIQG events. The pair
+// is emitted atomically from the caller's perspective — concrete
+// implementations may stagger their actual writes (e.g. two separate
+// Kafka producer Send calls) but must not return until both have
+// committed or been queued.
+//
+// Implementations:
+//   - NoopEmitter: drops events on the floor (default for non-AIQG paths)
+//   - LogEmitter: writes structured JSON to a logrus logger (default
+//     for MVP; works without infrastructure)
+//   - MemoryEmitter: stores events in memory for tests
+//   - (future) KafkaEmitter: produces to the aiqg.events topic
+type Emitter interface {
+	Emit(ctx context.Context, req RequestEnvelope, resp ResponseEnvelope) error
+}
+
+// NoopEmitter drops events. Use when AIQG mode is off or when an
+// emitter is unconfigured — caller-side code should not have to nil-check.
+type NoopEmitter struct{}
+
+// Emit returns nil. Always.
+func (NoopEmitter) Emit(_ context.Context, _ RequestEnvelope, _ ResponseEnvelope) error {
+	return nil
+}
+
+// LogEmitter writes each event as a structured logrus entry. Useful as
+// the MVP backend: events show up in Loki via the standard log pipeline
+// with no Kafka topic to provision. Switch to KafkaEmitter when the
+// downstream consumer (Spark / dashboard) lands.
+type LogEmitter struct {
+	Logger *logrus.Logger
+}
+
+// Emit logs both envelopes at INFO with the CloudEvents type as a field
+// for downstream filtering (LogQL: `{...} | json | type="com.tas.aiqg.request.v1"`).
+func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseEnvelope) error {
+	if e.Logger == nil {
+		return nil
+	}
+	reqJSON, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	respJSON, err := json.Marshal(resp)
+	if err != nil {
+		return err
+	}
+	e.Logger.WithFields(logrus.Fields{
+		"ce_type":          req.Type,
+		"ce_id":            req.ID,
+		"request_event_id": req.Data.RequestEventID,
+		"payload":          string(reqJSON),
+	}).Info("aiqg request event")
+	e.Logger.WithFields(logrus.Fields{
+		"ce_type":           resp.Type,
+		"ce_id":             resp.ID,
+		"response_event_id": resp.Data.ResponseEventID,
+		"request_event_id":  resp.Data.RequestEventID,
+		"http_status":       resp.Data.HTTPStatus,
+		"status":            resp.Data.Status,
+		"chunk_count":       resp.Data.ChunkCount,
+		"payload":           string(respJSON),
+	}).Info("aiqg response event")
+	return nil
+}
+
+// MemoryEmitter stores emitted events in memory for tests. Concurrent
+// emits are serialized via the embedded mutex.
+type MemoryEmitter struct {
+	mu        sync.Mutex
+	requests  []RequestEnvelope
+	responses []ResponseEnvelope
+}
+
+// Emit appends both envelopes to the internal slices.
+func (e *MemoryEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseEnvelope) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.requests = append(e.requests, req)
+	e.responses = append(e.responses, resp)
+	return nil
+}
+
+// Requests returns a copy of the emitted request envelopes. The copy
+// prevents test mutation from racing future Emit calls.
+func (e *MemoryEmitter) Requests() []RequestEnvelope {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]RequestEnvelope, len(e.requests))
+	copy(out, e.requests)
+	return out
+}
+
+// Responses returns a copy of the emitted response envelopes.
+func (e *MemoryEmitter) Responses() []ResponseEnvelope {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]ResponseEnvelope, len(e.responses))
+	copy(out, e.responses)
+	return out
+}
+
+// Len returns the number of paired (req, resp) emits so far. Useful in
+// test assertions: `if e.Len() != 1 { ... }`.
+func (e *MemoryEmitter) Len() int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return len(e.requests)
+}
+
+// Reset clears all stored events.
+func (e *MemoryEmitter) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.requests = nil
+	e.responses = nil
+}

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -1,0 +1,200 @@
+// Package events defines the AIQG request/response event schema and its
+// CloudEvents 1.0 envelope. Per build-vs-reuse §1 placement decision,
+// AIQG-specific code lives in pkg/aiqg/* inside tas-llm-router (not in
+// a separate repo).
+//
+// Two event types are emitted per AIQG request:
+//   - RequestEnvelope (type=com.tas.aiqg.request.v1) — captured at
+//     request open / first inspection.
+//   - ResponseEnvelope (type=com.tas.aiqg.response.v1) — captured at
+//     response close. Carries the timing snapshot, outcome, CLEAR scores
+//     (when scored), and the back-reference to its paired request_event_id.
+//
+// MVP scope: the gateway emits both events at response-close in a single
+// defer (atomic from the request-handler's perspective). Spark/consumers
+// pair them by request_event_id. Future slice may split emission across
+// the request lifecycle if the consumer side justifies it.
+//
+// Fields the gateway can populate at MVP today are concrete types. Fields
+// that depend on still-unmerged slices (token resolution → tenant_id,
+// routing decisions → vendor/model, scorer → clear_*) are pointer types so
+// downstream consumers can distinguish "not yet computed" from "computed
+// as zero." The schema mirrors aether-shared/data-models/aiqg/
+// {request,response}-event.md.
+package events
+
+import (
+	"time"
+
+	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+)
+
+// CloudEvents 1.0 type identifiers. Bump the suffix when the data shape
+// changes in a breaking way; non-breaking additions don't require a bump
+// (consumers ignore unknown fields).
+const (
+	TypeRequest  = "com.tas.aiqg.request.v1"
+	TypeResponse = "com.tas.aiqg.response.v1"
+
+	SpecVersion     = "1.0"
+	DataContentType = "application/json"
+
+	// Source URI matches Gatekeeper's urn:tas:service:<name> scheme so
+	// every TAS service that emits CloudEvents shares one URI namespace.
+	Source = "urn:tas:service:tas-llm-router"
+)
+
+// RequestEnvelope wraps a RequestEvent in a CloudEvents 1.0 envelope.
+// Marshalled JSON matches the structured-mode binding (§3.5 of the
+// CloudEvents 1.0 spec).
+type RequestEnvelope struct {
+	SpecVersion     string       `json:"specversion"`
+	Type            string       `json:"type"`
+	Source          string       `json:"source"`
+	ID              string       `json:"id"`
+	Time            time.Time    `json:"time"`
+	Subject         string       `json:"subject,omitempty"`
+	DataContentType string       `json:"datacontenttype"`
+	Data            RequestEvent `json:"data"`
+}
+
+// ResponseEnvelope wraps a ResponseEvent in a CloudEvents 1.0 envelope.
+type ResponseEnvelope struct {
+	SpecVersion     string        `json:"specversion"`
+	Type            string        `json:"type"`
+	Source          string        `json:"source"`
+	ID              string        `json:"id"`
+	Time            time.Time     `json:"time"`
+	Subject         string        `json:"subject,omitempty"`
+	DataContentType string        `json:"datacontenttype"`
+	Data            ResponseEvent `json:"data"`
+}
+
+// RequestEvent mirrors aether-shared/data-models/aiqg/request-event.md §2.1.
+// Only fields populatable from the gateway today are concrete; the rest
+// are optional and omitted from JSON when unset.
+type RequestEvent struct {
+	// Identity & linkage
+	RequestEventID string `json:"request_event_id"`
+	TenantID       string `json:"tenant_id,omitempty"`         // filled by token-resolver slice
+	AIQGAccountID  string `json:"aiqg_account_id,omitempty"`   // filled by token-resolver slice
+	TASAuthTokenID string `json:"tas_auth_token_id,omitempty"` // filled by token-resolver slice
+
+	// Request basics (populatable today)
+	ReceivedAt      time.Time `json:"received_at"`
+	Endpoint        string    `json:"endpoint"`
+	Method          string    `json:"method"`
+	SourceIP        string    `json:"source_ip,omitempty"`
+	SourceApp       string    `json:"source_app,omitempty"`
+	ClientRequestID string    `json:"client_request_id,omitempty"`
+	Region          string    `json:"region,omitempty"`
+
+	// Routing (filled by router slice)
+	Vendor    string `json:"vendor,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Streaming bool   `json:"streaming"`
+
+	// Mode
+	IsAIQGMode bool `json:"is_aiqg_mode"`
+
+	// Headers reflected
+	DryRun        bool     `json:"dry_run"`
+	TraceReturned bool     `json:"trace_returned"`
+	Workflow      string   `json:"workflow,omitempty"`
+	PolicyNames   []string `json:"policy_names,omitempty"`
+	PolicyBundle  string   `json:"policy_bundle,omitempty"`
+
+	// Correlation to response (always populated when emitted as a pair)
+	CorrelatedResponseEventID string `json:"correlated_response_event_id,omitempty"`
+
+	// Versioning
+	ScoringVersion string `json:"scoring_version"`
+	GatewayVersion string `json:"gateway_version"`
+	LifecycleState string `json:"lifecycle_state"`
+}
+
+// ResponseEvent mirrors aether-shared/data-models/aiqg/response-event.md §2.2.
+type ResponseEvent struct {
+	// Identity & linkage
+	ResponseEventID string `json:"response_event_id"`
+	RequestEventID  string `json:"request_event_id"`
+	TenantID        string `json:"tenant_id,omitempty"`
+	AIQGAccountID   string `json:"aiqg_account_id,omitempty"`
+
+	// Outcome
+	CompleteAt      time.Time `json:"complete_at"`
+	Status          string    `json:"status"` // success | vendor_error | gateway_error | policy_blocked | client_disconnect | timeout
+	HTTPStatus      int       `json:"http_status"`
+	FinishReason    string    `json:"finish_reason,omitempty"`
+	VendorRequestID string    `json:"vendor_request_id,omitempty"`
+
+	// Streaming telemetry (from timing snapshot)
+	Streamed          bool `json:"streamed"`
+	ChunkCount        int  `json:"chunk_count"`
+	ContentChunkCount int  `json:"content_chunk_count"`
+
+	// Embedded timing block — see event-timestamps.md
+	EventTimestamps instrumentation.Snapshot `json:"event_timestamps"`
+
+	// CLEAR scores (filled by scorer slice; pointers so 0 ≠ unscored)
+	CLEAR *CLEARScores `json:"clear_scores,omitempty"`
+
+	// Versioning
+	ScoringVersion string `json:"scoring_version"`
+	GatewayVersion string `json:"gateway_version"`
+}
+
+// CLEARScores carries the five CLEAR dimension scores + composite.
+// Each value is a pointer to int16 in [0,100] (spec uses smallint for
+// storage compactness). A nil pointer means "not scored" — distinct
+// from a zero score, which means "scored, came out at zero." The MVP
+// scorer slice will populate this; emission can fire with nil today.
+type CLEARScores struct {
+	Cost           *int16 `json:"cost,omitempty"`
+	Latency        *int16 `json:"latency,omitempty"`
+	Efficacy       *int16 `json:"efficacy,omitempty"`
+	Assurance      *int16 `json:"assurance,omitempty"`
+	Reliability    *int16 `json:"reliability,omitempty"`
+	Composite      *int16 `json:"composite,omitempty"`
+	WeightsApplied string `json:"weights_applied,omitempty"`
+}
+
+// Status enum values for ResponseEvent.Status.
+const (
+	StatusSuccess          = "success"
+	StatusVendorError      = "vendor_error"
+	StatusGatewayError     = "gateway_error"
+	StatusPolicyBlocked    = "policy_blocked"
+	StatusClientDisconnect = "client_disconnect"
+	StatusTimeout          = "timeout"
+)
+
+// Lifecycle state enum values for RequestEvent.LifecycleState.
+const (
+	LifecycleReceived            = "received"
+	LifecycleValidated           = "validated"
+	LifecyclePolicyResolved      = "policy_resolved"
+	LifecycleForwarded           = "forwarded"
+	LifecyclePairedWithResponse  = "paired_with_response"
+	LifecycleArchived            = "archived"
+)
+
+// StatusFromHTTP maps an HTTP status code to the spec's status enum.
+// Heuristic, used when the gateway doesn't have a more specific signal
+// (e.g. policy_blocked is set by the policy layer; client_disconnect by
+// the response writer).
+func StatusFromHTTP(code int) string {
+	switch {
+	case code == 0:
+		// 0 means we never wrote a response — gateway blocked before forwarding.
+		return StatusGatewayError
+	case code >= 200 && code < 400:
+		return StatusSuccess
+	case code == 504, code == 408:
+		return StatusTimeout
+	case code >= 400 && code < 500:
+		return StatusGatewayError
+	default:
+		return StatusVendorError
+	}
+}

--- a/pkg/aiqg/events/event_test.go
+++ b/pkg/aiqg/events/event_test.go
@@ -1,0 +1,329 @@
+package events
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+)
+
+func TestStatusFromHTTP(t *testing.T) {
+	cases := []struct {
+		code int
+		want string
+	}{
+		{0, StatusGatewayError},
+		{200, StatusSuccess},
+		{201, StatusSuccess},
+		{399, StatusSuccess},
+		{400, StatusGatewayError},
+		{401, StatusGatewayError},
+		{403, StatusGatewayError},
+		{408, StatusTimeout},
+		{499, StatusGatewayError},
+		{500, StatusVendorError},
+		{502, StatusVendorError},
+		{504, StatusTimeout},
+	}
+	for _, c := range cases {
+		if got := StatusFromHTTP(c.code); got != c.want {
+			t.Errorf("StatusFromHTTP(%d)=%q want=%q", c.code, got, c.want)
+		}
+	}
+}
+
+// UUID format check: 8-4-4-4-12 lowercase hex.
+func TestNewUUIDShape(t *testing.T) {
+	re := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	seen := map[string]struct{}{}
+	for i := 0; i < 200; i++ {
+		u := newUUID()
+		if !re.MatchString(u) {
+			t.Fatalf("malformed uuid: %q", u)
+		}
+		if _, dup := seen[u]; dup {
+			t.Fatalf("duplicate uuid in 200 tries: %q", u)
+		}
+		seen[u] = struct{}{}
+	}
+}
+
+func TestBuild_RoundTrip(t *testing.T) {
+	c := instrumentation.NewCollector()
+	t0 := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	// Stamp a known schedule so the snapshot assertions are deterministic.
+	stampSnapshot(t, c, t0)
+
+	r := httptest.NewRequest(http.MethodPost, "/openai/v1/chat/completions?stream=true", nil)
+	r.RemoteAddr = "10.0.0.5:54321"
+	r.Header.Set("X-Request-ID", "client-req-abc")
+
+	headers := AIQGHeadersView{
+		Workflow:     "rag",
+		Policy:       []string{"pii_redact", "no-cot"},
+		PolicyBundle: "",
+		Trace:        true,
+		DryRun:       false,
+		SourceApp:    "billing-api-prod",
+	}
+
+	reqEnv, respEnv := Build(r, headers, c.Snapshot(), BuildOptions{
+		HTTPStatus: 200,
+		Region:     "us-east",
+	})
+
+	// Envelope shape
+	if reqEnv.SpecVersion != "1.0" || respEnv.SpecVersion != "1.0" {
+		t.Errorf("specversion wrong: req=%q resp=%q", reqEnv.SpecVersion, respEnv.SpecVersion)
+	}
+	if reqEnv.Type != TypeRequest {
+		t.Errorf("req type=%q", reqEnv.Type)
+	}
+	if respEnv.Type != TypeResponse {
+		t.Errorf("resp type=%q", respEnv.Type)
+	}
+	if reqEnv.Source != Source || respEnv.Source != Source {
+		t.Errorf("source urn mismatch")
+	}
+	if reqEnv.DataContentType != "application/json" {
+		t.Errorf("datacontenttype=%q", reqEnv.DataContentType)
+	}
+
+	// Pair correlation
+	if reqEnv.ID != reqEnv.Data.RequestEventID {
+		t.Errorf("envelope ID does not equal data.request_event_id")
+	}
+	if respEnv.ID != respEnv.Data.ResponseEventID {
+		t.Errorf("envelope ID does not equal data.response_event_id")
+	}
+	if reqEnv.Data.CorrelatedResponseEventID != respEnv.Data.ResponseEventID {
+		t.Errorf("correlated_response_event_id does not point to response")
+	}
+	if respEnv.Data.RequestEventID != reqEnv.Data.RequestEventID {
+		t.Errorf("response.request_event_id does not point to request")
+	}
+
+	// Request-event payload
+	d := reqEnv.Data
+	if d.Endpoint != "/openai/v1/chat/completions" {
+		t.Errorf("endpoint=%q", d.Endpoint)
+	}
+	if d.Method != "POST" {
+		t.Errorf("method=%q", d.Method)
+	}
+	if d.SourceIP != "10.0.0.5" {
+		t.Errorf("source_ip=%q (RemoteAddr port-strip failed)", d.SourceIP)
+	}
+	if d.ClientRequestID != "client-req-abc" {
+		t.Errorf("client_request_id=%q", d.ClientRequestID)
+	}
+	if d.Region != "us-east" {
+		t.Errorf("region=%q", d.Region)
+	}
+	if !d.Streaming {
+		t.Errorf("streaming should be true (?stream=true)")
+	}
+	if !d.IsAIQGMode {
+		t.Errorf("is_aiqg_mode should be true")
+	}
+	if d.Workflow != "rag" {
+		t.Errorf("workflow=%q", d.Workflow)
+	}
+	if d.PolicyBundle != "" {
+		t.Errorf("policy_bundle=%q want empty", d.PolicyBundle)
+	}
+	if len(d.PolicyNames) != 2 {
+		t.Errorf("policy_names len=%d", len(d.PolicyNames))
+	}
+	if !d.TraceReturned {
+		t.Errorf("trace_returned should be true")
+	}
+	if d.LifecycleState != LifecyclePairedWithResponse {
+		t.Errorf("lifecycle_state=%q", d.LifecycleState)
+	}
+	if d.ScoringVersion != ScoringVersion {
+		t.Errorf("scoring_version=%q", d.ScoringVersion)
+	}
+
+	// Response-event payload
+	rd := respEnv.Data
+	if rd.Status != StatusSuccess {
+		t.Errorf("status=%q", rd.Status)
+	}
+	if rd.HTTPStatus != 200 {
+		t.Errorf("http_status=%d", rd.HTTPStatus)
+	}
+	if !rd.Streamed {
+		t.Errorf("streamed should be true (snapshot had chunks)")
+	}
+	if rd.ChunkCount != 3 {
+		t.Errorf("chunk_count=%d want=3", rd.ChunkCount)
+	}
+	if rd.ContentChunkCount != 2 {
+		t.Errorf("content_chunk_count=%d want=2", rd.ContentChunkCount)
+	}
+	if rd.EventTimestamps.GatewayOverheadMs == nil {
+		t.Errorf("event_timestamps.gateway_overhead_ms not embedded")
+	}
+}
+
+// Build with no timing stamps and no headers — degenerate but must not panic.
+func TestBuild_EmptySnapshot(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", nil)
+	r.RemoteAddr = "10.0.0.5:1234"
+
+	reqEnv, respEnv := Build(r, AIQGHeadersView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 0})
+
+	if reqEnv.Data.LifecycleState != LifecyclePairedWithResponse {
+		t.Errorf("lifecycle_state default missing")
+	}
+	if respEnv.Data.Status != StatusGatewayError {
+		t.Errorf("status for HTTPStatus=0 should be gateway_error, got %q", respEnv.Data.Status)
+	}
+	// receivedAt and completeAt fall back to time.Now() — both should
+	// be very recent (within last second).
+	if time.Since(reqEnv.Time) > time.Second {
+		t.Errorf("envelope Time too old: %v", reqEnv.Time)
+	}
+}
+
+func TestBuild_XForwardedFor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat", nil)
+	r.RemoteAddr = "10.0.0.5:1234"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+
+	reqEnv, _ := Build(r, AIQGHeadersView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	if reqEnv.Data.SourceIP != "203.0.113.7" {
+		t.Errorf("source_ip=%q (XFF first-entry not picked)", reqEnv.Data.SourceIP)
+	}
+}
+
+// JSON marshalling must produce a CloudEvents 1.0 structured-mode payload
+// — top-level keys for envelope, `data` for the event body.
+func TestEnvelopeMarshalsToCloudEventsShape(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	r.RemoteAddr = "10.0.0.5:80"
+	reqEnv, respEnv := Build(r, AIQGHeadersView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+
+	for _, env := range []any{reqEnv, respEnv} {
+		b, err := json.Marshal(env)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(b, &m); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		for _, k := range []string{"specversion", "type", "source", "id", "time", "datacontenttype", "data"} {
+			if _, ok := m[k]; !ok {
+				t.Errorf("missing CloudEvents key %q in envelope %T", k, env)
+			}
+		}
+	}
+}
+
+func TestNoopEmitter(t *testing.T) {
+	if err := (NoopEmitter{}).Emit(context.Background(), RequestEnvelope{}, ResponseEnvelope{}); err != nil {
+		t.Errorf("NoopEmitter.Emit returned err: %v", err)
+	}
+}
+
+func TestLogEmitter(t *testing.T) {
+	l := logrus.New()
+	l.SetOutput(testWriter{t})
+	e := &LogEmitter{Logger: l}
+
+	reqEnv := RequestEnvelope{Type: TypeRequest, ID: "req-1", Data: RequestEvent{RequestEventID: "req-1"}}
+	respEnv := ResponseEnvelope{Type: TypeResponse, ID: "resp-1", Data: ResponseEvent{ResponseEventID: "resp-1", RequestEventID: "req-1", Status: StatusSuccess, HTTPStatus: 200}}
+
+	if err := e.Emit(context.Background(), reqEnv, respEnv); err != nil {
+		t.Fatalf("Emit err: %v", err)
+	}
+
+	// Nil logger must not panic.
+	(&LogEmitter{Logger: nil}).Emit(context.Background(), reqEnv, respEnv)
+}
+
+func TestMemoryEmitter(t *testing.T) {
+	e := &MemoryEmitter{}
+	if e.Len() != 0 {
+		t.Errorf("Len()=%d want=0 initially", e.Len())
+	}
+
+	for i := 0; i < 5; i++ {
+		err := e.Emit(context.Background(),
+			RequestEnvelope{Data: RequestEvent{RequestEventID: "r"}},
+			ResponseEnvelope{Data: ResponseEvent{ResponseEventID: "s"}})
+		if err != nil {
+			t.Fatalf("emit %d: %v", i, err)
+		}
+	}
+	if e.Len() != 5 {
+		t.Errorf("Len()=%d want=5", e.Len())
+	}
+	if len(e.Requests()) != 5 || len(e.Responses()) != 5 {
+		t.Errorf("Requests/Responses len mismatch")
+	}
+
+	// Returned slice must be a copy — mutating it shouldn't affect future Emit calls.
+	r := e.Requests()
+	r[0] = RequestEnvelope{ID: "tampered"}
+	if e.Requests()[0].ID == "tampered" {
+		t.Errorf("Requests() returned live slice, not a copy")
+	}
+
+	e.Reset()
+	if e.Len() != 0 {
+		t.Errorf("after Reset() Len()=%d", e.Len())
+	}
+}
+
+func TestMemoryEmitter_Concurrent(t *testing.T) {
+	e := &MemoryEmitter{}
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = e.Emit(context.Background(),
+				RequestEnvelope{Data: RequestEvent{RequestEventID: "r"}},
+				ResponseEnvelope{Data: ResponseEvent{ResponseEventID: "s"}})
+		}()
+	}
+	wg.Wait()
+	if e.Len() != 50 {
+		t.Errorf("Len()=%d want=50 after 50 concurrent emits", e.Len())
+	}
+}
+
+// stampSnapshot drives a TimingCollector through a known schedule so
+// subsequent .Snapshot() assertions are deterministic.
+func stampSnapshot(t *testing.T, c *instrumentation.TimingCollector, t0 time.Time) {
+	t.Helper()
+	ctx := instrumentation.WithCollector(context.Background(), c)
+	// We can't override time.Now() inside the package, but stamping in
+	// rapid succession is enough — the test only checks counters and
+	// presence of intervals, not absolute milliseconds.
+	instrumentation.StampReceived(ctx)
+	instrumentation.StampForwarded(ctx)
+	instrumentation.StampChunk(ctx, false)
+	instrumentation.StampChunk(ctx, true)
+	instrumentation.StampChunk(ctx, true)
+	instrumentation.StampLastChunk(ctx)
+	instrumentation.StampComplete(ctx)
+	_ = t0 // schedule arg reserved for future use; presently the helper just exercises the API
+}
+
+type testWriter struct{ t *testing.T }
+
+func (w testWriter) Write(b []byte) (int, error) {
+	w.t.Logf("log: %s", string(b))
+	return len(b), nil
+}


### PR DESCRIPTION
## Summary
Adds `pkg/aiqg/events` — the CloudEvents 1.0 envelope, paired RequestEvent/ResponseEvent schema (mirroring `aether-shared/data-models/aiqg/{request,response}-event.md`), an `Emitter` interface, and three implementations:

| Emitter | Purpose |
|---|---|
| `NoopEmitter` | Default when AIQG is off — caller-side code never has to nil-check |
| `LogEmitter` | MVP backend: writes structured JSON to logrus → Loki via the existing pipeline; no Kafka topic to provision yet |
| `MemoryEmitter` | Test fixture |

Wires the emitter into the Path A middleware's defer chain. LIFO order ensures `StampComplete` fires **before** the build/emit so `event_timestamps.response_complete_at` is populated. Adds a `statusCapturingResponseWriter` so the response event carries the HTTP status the downstream handler wrote.

## Architecture decisions
- **`Build()` is a pure function** — no ctx access, no I/O, takes `(req, headers, snapshot, opts)` and returns the cross-linked envelope pair. This avoids a `middleware → events → middleware` import cycle (the middleware projects its `AIQGHeaders` into an `AIQGHeadersView` before invoking `Build`).
- **Two envelopes, one emit** — request and response events are produced atomically in the defer; correlated via `request_event_id ↔ response_event_id ↔ correlated_response_event_id`. `LifecycleState = paired_with_response`.
- **No external CloudEvents SDK** — the structured-mode envelope is small enough to define inline. Keeps us off the broken `aether-shared/go-events` dep that's blocking `make test` on `main`.

## MVP scope vs. future slices
| Field | Populated today | Pending slice |
|---|---|---|
| timing snapshot | ✅ (from `TimingCollector`) | — |
| headers (workflow, policy, dry_run, trace, source_app) | ✅ (from `AIQGHeaders`) | — |
| request basics (endpoint, method, source_ip, client_request_id, streaming, region) | ✅ | — |
| outcome (status, http_status, chunk_count) | ✅ | — |
| `tenant_id`, `aiqg_account_id`, `tas_auth_token_id` | empty | token-resolver slice |
| `vendor`, `model` | empty | router slice |
| `clear_*` scores | nil pointers | scorer slice |
| `request_structure`, `tag_set`, `inferred_labels`, `audit_log_refs` | omitted | Gatekeeper integration slices |

Optional fields are pointer types or empty strings so consumers can distinguish "not yet computed" from "computed as zero."

## Spec compliance
- Pre-validation auth failures emit no events (request-event.md §273 — verified by `TestAIQG_StrictRejectionDoesNotEmit`).
- `request_event_id ↔ response_event_id` cross-linked at build time.
- Status enum derived via `StatusFromHTTP`: 0 → `gateway_error` (write-blocked), 408/504 → `timeout`, 2xx/3xx → `success`, etc.
- `streamed` and `chunk_count` propagated from `TimingCollector`.

## Non-breaking
Events flow only when an AIQGConfig is wired up with a non-nil Emitter on the AIQG ingress. Internal pass-through requests still emit nothing. Path A middleware is not yet registered in `server.go` — that's the same `server.go` wire-up slice the prior PR deferred.

## Test plan
- [x] `go test -race -count=1 ./pkg/aiqg/...` — passes (envelope shape, UUID format + uniqueness, Build round-trip, status mapping for all branches, XFF parsing, all 3 emitter impls + 50-goroutine concurrent emit on MemoryEmitter)
- [x] `go test -race -count=1 ./internal/middleware/...` — passes (paired-emit integration via MemoryEmitter, nil-emitter defaults to noop, pass-through emits nothing, strict 401 emits nothing)
- [x] All other buildable packages still pass with `-race`

Pre-existing `make test` failures in `internal/{config,gatekeeper,integration,server}` are the same Gatekeeper sibling-repo `go.sum` drift; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)