### PR TITLE
feat: wire AIQG ingress into server.go

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/routing"
 	"github.com/tributary-ai/llm-router-waf/internal/security"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
 )
 
 // Server represents the HTTP server
@@ -31,16 +32,40 @@ type Server struct {
 	gatekeeperConfig     *gatekeeper.Config
 	bypassManager        *gatekeeper.BypassManager
 	bypassHandler        *gatekeeper.BypassHandler
+
+	// AIQG ingress wire-up. aiqgMiddleware is nil when AIQG is disabled
+	// in config, in which case completion handlers register unwrapped
+	// and there is zero behavior change for existing traffic.
+	aiqgMiddleware func(http.Handler) http.Handler
+	aiqgEmitter    events.Emitter
 }
 
 // ServerConfig holds server configuration
 type ServerConfig struct {
-	Port           string                            `yaml:"port"`
-	ReadTimeout    time.Duration                     `yaml:"read_timeout"`
-	WriteTimeout   time.Duration                     `yaml:"write_timeout"`
-	MaxHeaderBytes int                               `yaml:"max_header_bytes"`
+	Port           string                               `yaml:"port"`
+	ReadTimeout    time.Duration                        `yaml:"read_timeout"`
+	WriteTimeout   time.Duration                        `yaml:"write_timeout"`
+	MaxHeaderBytes int                                  `yaml:"max_header_bytes"`
 	Security       *middleware.SecurityMiddlewareConfig `yaml:"security"`
-	Validation     *middleware.ValidationConfig     `yaml:"validation"`
+	Validation     *middleware.ValidationConfig         `yaml:"validation"`
+	AIQG           *AIQGServerConfig                    `yaml:"aiqg"`
+}
+
+// AIQGServerConfig configures the AIQG ingress wire-up.
+//
+// In permissive mode (Strict=false), the middleware mounts on the three
+// completion endpoints (/chat/completions, /completions, /messages) and
+// only activates when an inbound request carries TAS-Auth. Internal
+// callers without TAS-Auth pass through untouched — zero behavior change
+// for today's traffic.
+//
+// In strict mode (Strict=true), the same routes return 401 to any
+// request missing TAS-Auth or Authorization. Use for a customer-facing
+// ingress (`gateway.aiqg.tas.io`) per build-vs-reuse §7.3.
+type AIQGServerConfig struct {
+	Enabled bool   `yaml:"enabled"`
+	Strict  bool   `yaml:"strict"`
+	Region  string `yaml:"region"`
 }
 
 // NewServer creates a new server instance
@@ -50,7 +75,7 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 		logger: logger,
 		config: config,
 	}
-	
+
 	// Initialize security middleware if configured
 	if config.Security != nil {
 		securityMiddleware, err := middleware.NewSecurityMiddleware(config.Security, logger)
@@ -59,7 +84,7 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 		}
 		server.securityMiddleware = securityMiddleware
 	}
-	
+
 	// Initialize validation middleware if configured
 	if config.Validation != nil {
 		validationMiddleware, err := middleware.NewValidationMiddleware(config.Validation, logger)
@@ -68,7 +93,27 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 		}
 		server.validationMiddleware = validationMiddleware
 	}
-	
+
+	// Initialize AIQG ingress wire-up if enabled. Permissive mode (the
+	// MVP default) leaves internal callers untouched — they don't carry
+	// TAS-Auth, so the middleware passes them through. Customer-facing
+	// requests with TAS-Auth + Authorization enter Path A: timing
+	// collector + parsed headers attached to ctx, paired CloudEvents
+	// emitted on response completion via LogEmitter → logrus → Loki.
+	if config.AIQG != nil && config.AIQG.Enabled {
+		server.aiqgEmitter = &events.LogEmitter{Logger: logger}
+		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{
+			Strict:  config.AIQG.Strict,
+			Logger:  logger,
+			Emitter: server.aiqgEmitter,
+			Region:  config.AIQG.Region,
+		})
+		logger.WithFields(logrus.Fields{
+			"strict": config.AIQG.Strict,
+			"region": config.AIQG.Region,
+		}).Info("AIQG ingress enabled on completion routes")
+	}
+
 	return server, nil
 }
 
@@ -125,7 +170,7 @@ func (s *Server) setupRoutes() *mux.Router {
 	if s.securityMiddleware != nil {
 		r.Use(s.securityMiddleware.Handler())
 	}
-	
+
 	// Add validation middleware (if enabled)
 	if s.validationMiddleware != nil {
 		r.Use(s.validationMiddleware.Middleware)
@@ -139,12 +184,23 @@ func (s *Server) setupRoutes() *mux.Router {
 	// API routes
 	api := r.PathPrefix("/v1").Subrouter()
 
+	// Wrap the three LLM completion handlers in the AIQG ingress
+	// middleware when enabled. Management/health/metrics routes are NOT
+	// wrapped — they're internal-only and don't need TAS-* parsing or
+	// timing capture. Returns the handler verbatim when AIQG is disabled.
+	wrapAIQG := func(h http.HandlerFunc) http.Handler {
+		if s.aiqgMiddleware == nil {
+			return h
+		}
+		return s.aiqgMiddleware(h)
+	}
+
 	// OpenAI compatible endpoints
-	api.HandleFunc("/chat/completions", s.handleChatCompletion).Methods("POST")
-	api.HandleFunc("/completions", s.handleCompletion).Methods("POST")
+	api.Handle("/chat/completions", wrapAIQG(s.handleChatCompletion)).Methods("POST")
+	api.Handle("/completions", wrapAIQG(s.handleCompletion)).Methods("POST")
 
 	// Anthropic compatible endpoints
-	api.HandleFunc("/messages", s.handleMessages).Methods("POST")
+	api.Handle("/messages", wrapAIQG(s.handleMessages)).Methods("POST")
 
 	// Router management endpoints
 	api.HandleFunc("/providers", s.handleListProviders).Methods("GET")
@@ -161,10 +217,10 @@ func (s *Server) setupRoutes() *mux.Router {
 
 	// Health check endpoint (no /v1 prefix)
 	r.HandleFunc("/health", s.handleHealthCheck).Methods("GET")
-	
+
 	// Metrics endpoint for Prometheus scraping
 	r.HandleFunc("/metrics", s.handleMetrics).Methods("GET")
-	
+
 	// Swagger UI documentation endpoints
 	s.setupSwaggerRoutes(r)
 
@@ -176,12 +232,12 @@ func (s *Server) setupRoutes() *mux.Router {
 func (s *Server) loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		
+
 		// Create a custom response writer to capture status code
 		wrapped := &responseWriter{ResponseWriter: w, statusCode: 200}
-		
+
 		next.ServeHTTP(wrapped, r)
-		
+
 		s.logger.WithFields(logrus.Fields{
 			"method":      r.Method,
 			"path":        r.URL.Path,
@@ -198,12 +254,12 @@ func (s *Server) corsMiddleware(next http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-API-Key")
-		
+
 		if r.Method == "OPTIONS" {
 			w.WriteHeader(http.StatusOK)
 			return
 		}
-		
+
 		next.ServeHTTP(w, r)
 	})
 }
@@ -374,7 +430,7 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 		Model:          req.Model,
 		RouterMetadata: metadata,
 	}
-	
+
 	data, _ := json.Marshal(metadataChunk)
 	fmt.Fprintf(w, "data: %s\n\n", data)
 	w.(http.Flusher).Flush()
@@ -386,7 +442,7 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 			s.logger.WithError(err).Error("Failed to marshal chunk")
 			continue
 		}
-		
+
 		fmt.Fprintf(w, "data: %s\n\n", data)
 		w.(http.Flusher).Flush()
 	}
@@ -466,7 +522,7 @@ func (s *Server) handleStreamingCompletionWithRetry(w http.ResponseWriter, r *ht
 	// For streaming, we'll use the first successful provider (no mid-stream retry)
 	var chunks <-chan *types.ChatChunk
 	var err error
-	
+
 	chunks, err = s.attemptStreamingWithFallback(r.Context(), req, initialProvider, metadata)
 	if err != nil {
 		s.logger.WithError(err).WithField("provider", metadata.Provider).Error("All streaming attempts failed")
@@ -488,7 +544,7 @@ func (s *Server) handleStreamingCompletionWithRetry(w http.ResponseWriter, r *ht
 		Model:          req.Model,
 		RouterMetadata: metadata,
 	}
-	
+
 	data, _ := json.Marshal(metadataChunk)
 	fmt.Fprintf(w, "data: %s\n\n", data)
 	w.(http.Flusher).Flush()
@@ -500,7 +556,7 @@ func (s *Server) handleStreamingCompletionWithRetry(w http.ResponseWriter, r *ht
 			s.logger.WithError(err).Error("Failed to marshal chunk")
 			continue
 		}
-		
+
 		fmt.Fprintf(w, "data: %s\n\n", data)
 		w.(http.Flusher).Flush()
 	}
@@ -517,15 +573,15 @@ func (s *Server) attemptCompletionWithRetryAndFallback(ctx context.Context, req 
 	if err == nil {
 		return resp, nil
 	}
-	
+
 	// Add initial provider to failed list
 	metadata.FailedProviders = append(metadata.FailedProviders, metadata.Provider)
-	
+
 	// Try fallback if configured
 	if req.FallbackConfig != nil && req.FallbackConfig.Enabled {
 		return s.attemptCompletionFallback(ctx, req, metadata)
 	}
-	
+
 	return nil, err
 }
 
@@ -536,15 +592,15 @@ func (s *Server) attemptStreamingWithFallback(ctx context.Context, req *types.Ch
 	if err == nil {
 		return chunks, nil
 	}
-	
+
 	// Add initial provider to failed list
 	metadata.FailedProviders = append(metadata.FailedProviders, metadata.Provider)
-	
+
 	// Try fallback if configured
 	if req.FallbackConfig != nil && req.FallbackConfig.Enabled {
 		return s.attemptStreamingFallback(ctx, req, metadata)
 	}
-	
+
 	return nil, err
 }
 
@@ -557,9 +613,9 @@ func (s *Server) attemptCompletionWithRetry(ctx context.Context, req *types.Chat
 			maxAttempts = 1
 		}
 	}
-	
+
 	var lastError error
-	
+
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		// Apply backoff delay for retries
 		if attempt > 1 && retryConfig != nil {
@@ -569,7 +625,7 @@ func (s *Server) attemptCompletionWithRetry(ctx context.Context, req *types.Chat
 				"attempt":  attempt,
 				"delay_ms": delay.Milliseconds(),
 			}).Debug("Retrying completion after backoff")
-			
+
 			select {
 			case <-time.After(delay):
 				// Continue with retry
@@ -577,27 +633,27 @@ func (s *Server) attemptCompletionWithRetry(ctx context.Context, req *types.Chat
 				return nil, fmt.Errorf("request cancelled during retry: %w", ctx.Err())
 			}
 		}
-		
+
 		// Attempt completion
 		resp, err := provider.ChatCompletion(ctx, req)
 		if err == nil {
 			return resp, nil
 		}
-		
+
 		lastError = err
 		s.logger.WithFields(logrus.Fields{
 			"provider": providerName,
 			"attempt":  attempt,
 			"error":    err.Error(),
 		}).Warn("Completion attempt failed")
-		
+
 		// Check if error is retryable
 		if retryConfig != nil && !s.isRetryableError(err, retryConfig) {
 			s.logger.WithField("provider", providerName).Debug("Error not retryable, stopping retries")
 			break
 		}
 	}
-	
+
 	return nil, lastError
 }
 
@@ -605,19 +661,19 @@ func (s *Server) attemptCompletionWithRetry(ctx context.Context, req *types.Chat
 func (s *Server) attemptCompletionFallback(ctx context.Context, req *types.ChatRequest, metadata *types.RouterMetadata) (*types.ChatResponse, error) {
 	// Get fallback providers from router (this would need to be implemented)
 	fallbackProviders := s.getFallbackProviders(req, metadata)
-	
+
 	for _, providerName := range fallbackProviders {
 		if contains(metadata.FailedProviders, providerName) {
 			continue
 		}
-		
+
 		provider, exists := s.router.GetProvider(providerName)
 		if !exists {
 			continue
 		}
-		
+
 		s.logger.WithField("fallback_provider", providerName).Info("Trying fallback provider")
-		
+
 		resp, err := s.attemptCompletionWithRetry(ctx, req, provider, providerName, req.RetryConfig)
 		if err == nil {
 			metadata.Provider = providerName
@@ -625,29 +681,29 @@ func (s *Server) attemptCompletionFallback(ctx context.Context, req *types.ChatR
 			metadata.RoutingReason = append(metadata.RoutingReason, fmt.Sprintf("Fallback to %s", providerName))
 			return resp, nil
 		}
-		
+
 		metadata.FailedProviders = append(metadata.FailedProviders, providerName)
 	}
-	
+
 	return nil, fmt.Errorf("all fallback providers failed")
 }
 
 // attemptStreamingFallback tries fallback providers for streaming
 func (s *Server) attemptStreamingFallback(ctx context.Context, req *types.ChatRequest, metadata *types.RouterMetadata) (<-chan *types.ChatChunk, error) {
 	fallbackProviders := s.getFallbackProviders(req, metadata)
-	
+
 	for _, providerName := range fallbackProviders {
 		if contains(metadata.FailedProviders, providerName) {
 			continue
 		}
-		
+
 		provider, exists := s.router.GetProvider(providerName)
 		if !exists {
 			continue
 		}
-		
+
 		s.logger.WithField("fallback_provider", providerName).Info("Trying fallback streaming provider")
-		
+
 		chunks, err := provider.StreamCompletion(ctx, req)
 		if err == nil {
 			metadata.Provider = providerName
@@ -655,17 +711,17 @@ func (s *Server) attemptStreamingFallback(ctx context.Context, req *types.ChatRe
 			metadata.RoutingReason = append(metadata.RoutingReason, fmt.Sprintf("Fallback to %s", providerName))
 			return chunks, nil
 		}
-		
+
 		metadata.FailedProviders = append(metadata.FailedProviders, providerName)
 	}
-	
+
 	return nil, fmt.Errorf("all streaming fallback providers failed")
 }
 
 // calculateRetryDelay calculates delay for retry attempts
 func (s *Server) calculateRetryDelay(config *types.RetryConfig, attempt int) time.Duration {
 	var delay time.Duration
-	
+
 	switch config.BackoffType {
 	case "exponential":
 		multiplier := float64(uint(1) << uint(attempt)) // 2^attempt
@@ -677,12 +733,12 @@ func (s *Server) calculateRetryDelay(config *types.RetryConfig, attempt int) tim
 		multiplier := float64(uint(1) << uint(attempt))
 		delay = time.Duration(float64(config.BaseDelay) * multiplier)
 	}
-	
+
 	// Cap at MaxDelay
 	if config.MaxDelay > 0 && delay > config.MaxDelay {
 		delay = config.MaxDelay
 	}
-	
+
 	return delay
 }
 
@@ -696,7 +752,7 @@ func (s *Server) isRetryableError(err error, config *types.RetryConfig) bool {
 			strings.Contains(errStr, "unavailable") ||
 			strings.Contains(errStr, "rate limit")
 	}
-	
+
 	errStr := err.Error()
 	for _, retryableError := range config.RetryableErrors {
 		if strings.Contains(errStr, retryableError) {
@@ -712,7 +768,7 @@ func (s *Server) getFallbackProviders(req *types.ChatRequest, metadata *types.Ro
 	// In practice, this should use the router's fallback chain logic
 	providers := s.router.ListProviders()
 	var fallbacks []string
-	
+
 	for _, provider := range providers {
 		if provider != metadata.Provider {
 			fallbacks = append(fallbacks, provider)
@@ -734,12 +790,12 @@ func contains(slice []string, value string) bool {
 // handleListProviders lists all registered providers
 func (s *Server) handleListProviders(w http.ResponseWriter, r *http.Request) {
 	providers := s.router.ListProviders()
-	
+
 	response := map[string]interface{}{
 		"providers": providers,
 		"count":     len(providers),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -748,19 +804,19 @@ func (s *Server) handleListProviders(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleGetProvider(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["name"]
-	
+
 	provider, exists := s.router.GetProvider(name)
 	if !exists {
 		s.writeErrorResponse(w, http.StatusNotFound, fmt.Sprintf("Provider %s not found", name))
 		return
 	}
-	
+
 	response := map[string]interface{}{
 		"name":         name,
 		"provider":     provider.GetProviderName(),
 		"capabilities": provider.GetCapabilities(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -768,7 +824,7 @@ func (s *Server) handleGetProvider(w http.ResponseWriter, r *http.Request) {
 // handleHealthCheck returns overall health status
 func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 	health := s.router.GetHealthStatus()
-	
+
 	overallHealthy := true
 	for _, status := range health {
 		if status.Status != "healthy" {
@@ -776,18 +832,24 @@ func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 			break
 		}
 	}
-	
+
 	response := map[string]interface{}{
-		"status":    func() string { if overallHealthy { return "healthy" } else { return "degraded" } }(),
+		"status": func() string {
+			if overallHealthy {
+				return "healthy"
+			} else {
+				return "degraded"
+			}
+		}(),
 		"providers": health,
 		"timestamp": time.Now().Unix(),
 	}
-	
+
 	statusCode := http.StatusOK
 	if !overallHealthy {
 		statusCode = http.StatusServiceUnavailable
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
 	json.NewEncoder(w).Encode(response)
@@ -797,20 +859,20 @@ func (s *Server) handleHealthCheck(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleProviderHealth(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["name"]
-	
+
 	health := s.router.GetHealthStatus()
 	providerHealth, exists := health[name]
 	if !exists {
 		s.writeErrorResponse(w, http.StatusNotFound, fmt.Sprintf("Provider %s not found", name))
 		return
 	}
-	
+
 	response := map[string]interface{}{
-		"provider": name,
-		"status":   providerHealth,
+		"provider":  name,
+		"status":    providerHealth,
 		"timestamp": time.Now().Unix(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -818,12 +880,12 @@ func (s *Server) handleProviderHealth(w http.ResponseWriter, r *http.Request) {
 // handleCapabilities returns capabilities of all providers
 func (s *Server) handleCapabilities(w http.ResponseWriter, r *http.Request) {
 	capabilities := s.router.GetCapabilities()
-	
+
 	response := map[string]interface{}{
 		"capabilities": capabilities,
 		"timestamp":    time.Now().Unix(),
 	}
-	
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
@@ -858,7 +920,7 @@ func (s *Server) handleRoutingDecision(w http.ResponseWriter, r *http.Request) {
 func (s *Server) writeErrorResponse(w http.ResponseWriter, statusCode int, message string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(statusCode)
-	
+
 	errorResp := map[string]interface{}{
 		"error": map[string]interface{}{
 			"message": message,
@@ -867,7 +929,7 @@ func (s *Server) writeErrorResponse(w http.ResponseWriter, statusCode int, messa
 		},
 		"timestamp": time.Now().Unix(),
 	}
-	
+
 	json.NewEncoder(w).Encode(errorResp)
 }
 
@@ -892,18 +954,18 @@ func (rw *responseWriter) Flush() {
 // handleMetrics serves Prometheus metrics endpoint
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-	
+
 	// Basic metrics in Prometheus format
 	// This is a minimal implementation for demo purposes
 	// In production, this should use the prometheus/client_golang library
-	
+
 	// Get provider health status
 	healthStatus := s.router.GetHealthStatus()
-	
+
 	// Generate basic metrics
 	metrics := "# HELP llm_router_provider_health Provider health status (1=healthy, 0=unhealthy)\n"
 	metrics += "# TYPE llm_router_provider_health gauge\n"
-	
+
 	for provider, health := range healthStatus {
 		status := 0
 		if health.Status == "healthy" {
@@ -911,16 +973,16 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		}
 		metrics += fmt.Sprintf("llm_router_provider_health{service=\"llm-router\",provider=\"%s\"} %d\n", provider, status)
 	}
-	
+
 	// Active connections (mock data for now)
 	metrics += "\n# HELP llm_router_active_connections Current number of active connections\n"
 	metrics += "# TYPE llm_router_active_connections gauge\n"
 	metrics += "llm_router_active_connections{service=\"llm-router\"} 5\n"
-	
+
 	// Request count (incremental mock data based on time)
 	now := time.Now().Unix()
 	baseRequests := now / 10 // Increments every 10 seconds
-	
+
 	metrics += "\n# HELP llm_router_requests_total Total number of requests\n"
 	metrics += "# TYPE llm_router_requests_total counter\n"
 	metrics += fmt.Sprintf("llm_router_requests_total{service=\"llm-router\",provider=\"openai\",method=\"POST\",status_code=\"200\",client_ip=\"192.168.1.100\"} %d\n", 150+baseRequests*3)
@@ -928,7 +990,7 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	metrics += fmt.Sprintf("llm_router_requests_total{service=\"llm-router\",provider=\"openai\",method=\"POST\",status_code=\"400\",client_ip=\"10.0.0.50\"} %d\n", 5+baseRequests/10)
 	metrics += fmt.Sprintf("llm_router_requests_total{service=\"llm-router\",provider=\"openai\",method=\"POST\",status_code=\"200\",client_ip=\"172.16.0.25\"} %d\n", 80+baseRequests*2)
 	metrics += fmt.Sprintf("llm_router_requests_total{service=\"llm-router\",provider=\"anthropic\",method=\"POST\",status_code=\"200\",client_ip=\"10.0.0.75\"} %d\n", 45+baseRequests)
-	
+
 	// Token usage (incremental mock data based on time)
 	metrics += "\n# HELP llm_router_tokens_total Total number of tokens processed\n"
 	metrics += "# TYPE llm_router_tokens_total counter\n"
@@ -936,80 +998,80 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	metrics += fmt.Sprintf("llm_router_tokens_total{service=\"llm-router\",provider=\"openai\",type=\"output\"} %d\n", 15000+baseRequests*300)
 	metrics += fmt.Sprintf("llm_router_tokens_total{service=\"llm-router\",provider=\"anthropic\",type=\"input\"} %d\n", 12000+baseRequests*250)
 	metrics += fmt.Sprintf("llm_router_tokens_total{service=\"llm-router\",provider=\"anthropic\",type=\"output\"} %d\n", 8000+baseRequests*150)
-	
+
 	// Cost tracking (incremental mock data based on time)
 	metrics += "\n# HELP llm_router_cost_total Total cost in USD\n"
 	metrics += "# TYPE llm_router_cost_total counter\n"
 	metrics += fmt.Sprintf("llm_router_cost_total{service=\"llm-router\",provider=\"openai\",model=\"gpt-4o\"} %.2f\n", 12.50+float64(baseRequests)*0.05)
 	metrics += fmt.Sprintf("llm_router_cost_total{service=\"llm-router\",provider=\"anthropic\",model=\"claude-3-sonnet\"} %.2f\n", 8.75+float64(baseRequests)*0.03)
-	
+
 	// Error tracking (mock data)
 	metrics += "\n# HELP llm_router_errors_total Total number of errors\n"
 	metrics += "# TYPE llm_router_errors_total counter\n"
 	metrics += "llm_router_errors_total{service=\"llm-router\",provider=\"openai\",error_type=\"timeout\"} 2\n"
 	metrics += "llm_router_errors_total{service=\"llm-router\",provider=\"anthropic\",error_type=\"rate_limit\"} 1\n"
-	
+
 	// Rate limiting (mock data)
 	metrics += "\n# HELP llm_router_rate_limit_usage Rate limit usage as fraction (0-1)\n"
 	metrics += "# TYPE llm_router_rate_limit_usage gauge\n"
 	metrics += "llm_router_rate_limit_usage{service=\"llm-router\",provider=\"openai\"} 0.65\n"
 	metrics += "llm_router_rate_limit_usage{service=\"llm-router\",provider=\"anthropic\"} 0.32\n"
-	
+
 	// Security metrics (incremental mock data)
 	metrics += "\n# HELP llm_router_auth_attempts_total Total authentication attempts\n"
 	metrics += "# TYPE llm_router_auth_attempts_total counter\n"
 	metrics += fmt.Sprintf("llm_router_auth_attempts_total{service=\"llm-router\",result=\"success\"} %d\n", 220+baseRequests*8)
 	metrics += fmt.Sprintf("llm_router_auth_attempts_total{service=\"llm-router\",result=\"failure\"} %d\n", 8+baseRequests/15)
-	
+
 	// Security score (mock data)
 	metrics += "\n# HELP llm_router_security_score Security score (0-100)\n"
 	metrics += "# TYPE llm_router_security_score gauge\n"
 	metrics += "llm_router_security_score{service=\"llm-router\"} 85\n"
-	
+
 	// Threat level (mock data)
 	metrics += "\n# HELP llm_router_threat_level Current threat level (0-3)\n"
 	metrics += "# TYPE llm_router_threat_level gauge\n"
 	metrics += "llm_router_threat_level{service=\"llm-router\"} 0\n"
-	
+
 	// Rate limiting hits (incremental mock data)
 	metrics += "\n# HELP llm_router_rate_limit_hits_total Total rate limit hits\n"
 	metrics += "# TYPE llm_router_rate_limit_hits_total counter\n"
 	metrics += fmt.Sprintf("llm_router_rate_limit_hits_total{service=\"llm-router\",tier=\"premium\"} %d\n", 10+baseRequests/20)
 	metrics += fmt.Sprintf("llm_router_rate_limit_hits_total{service=\"llm-router\",tier=\"standard\"} %d\n", 25+baseRequests/10)
-	
+
 	// Blocked requests (incremental mock data)
 	metrics += "\n# HELP llm_router_blocked_requests_total Total blocked requests\n"
 	metrics += "# TYPE llm_router_blocked_requests_total counter\n"
 	metrics += fmt.Sprintf("llm_router_blocked_requests_total{service=\"llm-router\",reason=\"rate_limit\"} %d\n", 5+baseRequests/30)
 	metrics += fmt.Sprintf("llm_router_blocked_requests_total{service=\"llm-router\",reason=\"auth_failure\"} %d\n", 3+baseRequests/50)
-	
+
 	// Security events (incremental mock data)
 	metrics += "\n# HELP llm_router_security_events_total Total security events\n"
 	metrics += "# TYPE llm_router_security_events_total counter\n"
 	metrics += fmt.Sprintf("llm_router_security_events_total{service=\"llm-router\",event_type=\"suspicious_activity\",severity=\"medium\"} %d\n", 2+baseRequests/100)
 	metrics += fmt.Sprintf("llm_router_security_events_total{service=\"llm-router\",event_type=\"malicious_input\",severity=\"high\"} %d\n", 1+baseRequests/200)
-	
+
 	// Validation failures (incremental mock data)
 	metrics += "\n# HELP llm_router_validation_failures_total Total validation failures\n"
 	metrics += "# TYPE llm_router_validation_failures_total counter\n"
 	metrics += fmt.Sprintf("llm_router_validation_failures_total{service=\"llm-router\",type=\"schema\"} %d\n", 8+baseRequests/25)
 	metrics += fmt.Sprintf("llm_router_validation_failures_total{service=\"llm-router\",type=\"content\"} %d\n", 12+baseRequests/15)
-	
+
 	// Input sanitization (incremental mock data)
 	metrics += "\n# HELP llm_router_input_sanitized_total Total inputs sanitized\n"
 	metrics += "# TYPE llm_router_input_sanitized_total counter\n"
 	metrics += fmt.Sprintf("llm_router_input_sanitized_total{service=\"llm-router\"} %d\n", 45+baseRequests*2)
-	
+
 	// Audit events (incremental mock data)
 	metrics += "\n# HELP llm_router_audit_events_total Total audit events\n"
 	metrics += "# TYPE llm_router_audit_events_total counter\n"
 	metrics += fmt.Sprintf("llm_router_audit_events_total{service=\"llm-router\",event_type=\"api_key_usage\",severity=\"low\",user_id=\"user123\"} %d\n", 150+baseRequests*5)
 	metrics += fmt.Sprintf("llm_router_audit_events_total{service=\"llm-router\",event_type=\"config_change\",severity=\"medium\",user_id=\"admin\"} %d\n", 3+baseRequests/50)
-	
+
 	// Active API keys (mock data)
 	metrics += "\n# HELP llm_router_active_api_keys Number of active API keys\n"
 	metrics += "# TYPE llm_router_active_api_keys gauge\n"
 	metrics += "llm_router_active_api_keys{service=\"llm-router\"} 12\n"
-	
+
 	fmt.Fprint(w, metrics)
 }


### PR DESCRIPTION
## Summary
Mounts the AIQG middleware on the three LLM completion routes (`/v1/chat/completions`, `/v1/completions`, `/v1/messages`) in **permissive mode by default**. Internal callers without `TAS-Auth` pass through untouched — zero behavior change for today's traffic. Customer-facing requests with `TAS-Auth` + `Authorization` enter Path A: timing collector + parsed TAS-\* headers attached to ctx, paired CloudEvents emitted on response completion via `LogEmitter → logrus → Loki`.

Management routes (`/v1/providers`, `/v1/health`, `/v1/capabilities`, `/v1/routing/decision`) and the top-level `/health` + `/metrics` are NOT wrapped — they're internal-only and don't need TAS-\* parsing or timing capture.

## Config
New `AIQGServerConfig` block on `ServerConfig`:
```yaml
aiqg:
  enabled: true     # default false — opt-in
  strict: false     # default false — permissive (recommended for shared ingress)
  region: us-east   # stamped on every emitted RequestEvent
```

## Implementation
- `server.aiqgMiddleware` is a `func(http.Handler) http.Handler` — nil when AIQG is disabled.
- `wrapAIQG` helper returns the handler verbatim when middleware is nil, so the wire-up is a no-op at runtime when config doesn't enable it.
- `LogEmitter` writes structured JSON via the existing logrus → Alloy → Loki pipeline; no Kafka topic to provision yet (matches the MVP backend choice from PR #17).

## Deployment topology
Per build-vs-reuse §7.3, future production uses one binary behind two Ingresses:

| Ingress | AIQG config |
|---|---|
| Internal cluster DNS | `{enabled: true, strict: false}` |
| `gateway.aiqg.tas.io` | `{enabled: true, strict: true}` — rejects requests missing TAS-Auth or Authorization with a diagnostic 401 |

## Closes out the AIQG MVP plan
1. ✅ PR #14 — Per-chunk timing
2. ✅ PR #15 — TAS-* headers
3. ✅ PR #16 — Path A middleware
4. ✅ PR #17 — Event emission
5. ✅ PR #18 — CLEAR scorer
6. ✅ **PR #19 (this) — server.go wire-up**

With this merged, AIQG-mode requests flow end-to-end on the existing ingress as soon as the config opts in.

## Test plan
- [x] `go test -race -count=1` across all buildable packages — passes (no regressions in middleware, events, clear, instrumentation, providers)
- [x] `gofmt -l` clean
- [ ] `go build ./internal/server/...` — **blocked by pre-existing `../Gatekeeper/pkg/stream/cloudevents.go` go.sum drift** (the missing `aether-shared/go-events` go.sum entries in the sibling Gatekeeper repo). This is unrelated to the AIQG slices and present on main; tracked separately. The wire-up changes are mechanically reviewable: a config struct, a `Server` field, init code, and a route-wrap helper, all calling into known-tested types from the previous 5 AIQG PRs.

Pre-existing `make test` failures in `internal/{config,gatekeeper,integration,server}` and at repo root are the same Gatekeeper sibling-repo `go.sum` drift; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)