### PR TITLE
fix: unblock make test (Gatekeeper go.sum + assorted)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,12 +91,15 @@ test-security: ## Run security tests
 ##@ Testing & Quality
 
 .PHONY: test
+# -tags nohs matches the Docker build (docker/Dockerfile:19) and swaps
+# Hyperscan for the regexp engine, so contributors without libhyperscan
+# installed locally can still run the test suite.
 test: ## Run all tests
-	go test ./... -v
+	go test -tags nohs ./... -v
 
 .PHONY: test-coverage
 test-coverage: ## Generate test coverage report
-	go test ./... -coverprofile=coverage.out
+	go test -tags nohs ./... -coverprofile=coverage.out
 	go tool cover -html=coverage.out -o coverage.html
 	@echo "📊 Coverage report generated: coverage.html"
 

--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,18 @@ require (
 
 replace github.com/Tributary-ai-services/Gatekeeper => ../Gatekeeper
 
+// Mirror Gatekeeper's replace directive so its transitive dependency
+// on aether-shared/go-events resolves to the same local path. Without
+// this, `go build ./internal/server/...` and `make test` fail with
+// "missing go.sum entry for module providing package
+// github.com/Tributary-ai-services/aether-shared/go-events" because
+// replace directives in a dependency don't propagate to the parent
+// module's go.sum.
+replace github.com/Tributary-ai-services/aether-shared/go-events => ../aether-shared/go-events
+
 require (
 	github.com/IBM/sarama v1.46.3 // indirect
+	github.com/Tributary-ai-services/aether-shared/go-events v0.0.0-00010101000000-000000000000 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/eapache/go-resiliency v1.7.0 // indirect
 	github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 // indirect

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -95,7 +95,9 @@ func TestLoadConfig_Validation(t *testing.T) {
 			},
 			cleanup: func() {},
 			wantErr: true,
-			errMsg:  "OpenAI API key is required",
+			// LoadConfig now requires at least one provider rather than
+			// specifically OpenAI; the message reflects that.
+			errMsg:  "at least one provider must be configured",
 		},
 		{
 			name: "Invalid log level",

--- a/providers_test.go
+++ b/providers_test.go
@@ -258,7 +258,4 @@ func TestBothProvidersComparison(t *testing.T) {
 	})
 }
 
-// Helper function
-func intPtr(i int) *int {
-	return &i
-}
+// intPtr lives in test_openai_basic.go; both files share package main.


### PR DESCRIPTION
## Summary
Four small fixes that together restore green `make test` from a fresh checkout. None affect production code paths. With these merged, the AIQG MVP wire-up (PRs #14–#19) is actually compile-verifiable in CI for the first time.

## The four fixes

### 1. `go.mod` — mirror Gatekeeper's `replace` directive
Adds:
```go
replace github.com/Tributary-ai-services/aether-shared/go-events => ../aether-shared/go-events
```
Replace directives in a dependency module **don't** propagate to the parent module's `go.sum`. Gatekeeper has this replace locally, but tas-llm-router didn't carry the same line, so every transitive import path that hit `aether-shared/go-events` failed with `missing go.sum entry`. This blocked `internal/server`, `internal/config`, `internal/integration`, `internal/gatekeeper`, and `cmd/llm-router`.

### 2. `Makefile` — add `-tags nohs` to test targets
Matches `docker/Dockerfile:19` which already builds with `-tags nohs` to swap Hyperscan for the regexp engine. Contributors without `libhyperscan` installed locally couldn't run the suite (the `gohs` cgo bindings need `pkg-config` + the native lib). Production Docker builds already use this tag.

### 3. `providers_test.go` — remove duplicate `intPtr`
`func intPtr(i int) *int` was defined in **both** `providers_test.go:262` and `test_openai_basic.go:76` (also `package main`), causing `intPtr redeclared in this block` at test-compile time. The non-test file's definition is reachable from both, so deleting the test-file copy resolves the conflict without losing functionality.

### 4. `internal/config/config_test.go` — fix stale `TestLoadConfig_Validation` expectation
Test asserted error contains `"OpenAI API key is required"`. Code now returns `"at least one provider must be configured"` — a relaxation that lets Anthropic-only deployments work. Test was stale relative to the code; no production behavior change.

## Before / after

| Package | Before | After |
|---|---|---|
| `github.com/tributary-ai/llm-router-waf` (root) | build failed (duplicate `intPtr`) | ✅ ok |
| `internal/config` | TestLoadConfig_Validation failed | ✅ ok |
| `internal/gatekeeper` | setup failed (go.sum) | ✅ ok |
| `internal/integration` | setup failed (go.sum) | ✅ ok |
| `cmd/llm-router` | setup failed (go.sum) | ✅ ok |
| (others) | ✅ ok | ✅ ok |

## Test plan
- [x] `make test` from a clean checkout — every package returns `ok` or `[no test files]`
- [x] No production behavior change (config-test fix is a string assertion adjustment; helper-dedupe + replace-directive are scaffolding)
- [x] AIQG MVP packages (instrumentation, middleware, events, clear) still pass with `-race`

🤖 Generated with [Claude Code](https://claude.com/claude-code)