### PR TITLE
feat: stamp vendor + model onto AIQG events from routing decision

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -123,11 +123,16 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Enter AIQG mode: attach collector + headers, stamp Received,
-	// arrange for StampComplete + event emission on response end.
+	// Enter AIQG mode: attach collector + headers + routing sidecar,
+	// stamp Received, arrange for StampComplete + event emission on
+	// response end. The routing sidecar is empty here; the completion
+	// handlers populate it via StampVendor / StampModel / StampStreaming
+	// as those decisions are made.
 	collector := instrumentation.NewCollector()
+	routing := NewRouting()
 	ctx := instrumentation.WithCollector(r.Context(), collector)
 	ctx = WithHeaders(ctx, parsed)
+	ctx = WithRouting(ctx, routing)
 	instrumentation.StampReceived(ctx)
 
 	sw := &statusCapturingResponseWriter{ResponseWriter: w}
@@ -138,9 +143,11 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	}
 
 	// Defers fire LIFO: emit runs AFTER StampComplete so the snapshot
-	// it builds includes the response_complete_at timestamp.
+	// it builds includes the response_complete_at timestamp. The
+	// routing sidecar is read at the same moment, so any vendor/model
+	// stamps made by the handler reach the event.
 	defer func() {
-		reqEnv, respEnv := events.Build(r, headersView(parsed), collector.Snapshot(), events.BuildOptions{
+		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), collector.Snapshot(), events.BuildOptions{
 			HTTPStatus: sw.status(),
 			Region:     cfg.Region,
 		})
@@ -165,6 +172,23 @@ func headersView(h AIQGHeaders) events.AIQGHeadersView {
 		PolicyBundle: h.PolicyBundle,
 		DryRun:       h.DryRun,
 		Trace:        h.Trace,
+	}
+}
+
+// routingView snapshots the mutable Routing sidecar into the read-only
+// shape events.Build expects. Same anti-cycle motivation as headersView.
+// Tolerates a nil collector (returns the zero view) so the middleware
+// doesn't have to nil-check before passing it to Build.
+func routingView(r *Routing) events.RoutingView {
+	if r == nil {
+		return events.RoutingView{}
+	}
+	s := r.Snapshot()
+	return events.RoutingView{
+		Vendor:       s.Vendor,
+		Model:        s.Model,
+		Streaming:    s.Streaming,
+		StreamingSet: s.StreamingSet,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -1,0 +1,129 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+)
+
+// Routing carries the routing-layer decision (vendor, model, streaming
+// flag) for an in-flight AIQG request. It's a context-scoped mutable
+// sidecar — same pattern as instrumentation.TimingCollector — so the
+// chat-completion handlers can stamp the decision as it becomes known
+// (model from the inbound body, vendor from router.Route, streaming
+// from the request body) without having to thread a new ctx through
+// every call site.
+//
+// Concurrent-safe: in practice the stampers all run in the request
+// goroutine, but the mutex is cheap and futureproofs against stream
+// consumers that might stamp from a different goroutine.
+//
+// All stamps are first-write-wins (idempotent) so a later code path
+// can't accidentally overwrite an earlier decision with a fallback
+// guess.
+type Routing struct {
+	mu        sync.Mutex
+	vendor    string
+	model     string
+	streaming bool
+	streamSet bool
+}
+
+// NewRouting returns an empty Routing. Attach to ctx via WithRouting.
+func NewRouting() *Routing {
+	return &Routing{}
+}
+
+// RoutingSnapshot is the marshalable read-only view returned by
+// Routing.Snapshot. Construction is the only thread-safe way to read
+// the underlying fields.
+type RoutingSnapshot struct {
+	Vendor    string
+	Model     string
+	Streaming bool
+	// StreamingSet distinguishes "explicitly stamped streaming=false"
+	// from "never stamped" — the events package uses this to decide
+	// whether to fall back to its URL-query heuristic.
+	StreamingSet bool
+}
+
+// Snapshot returns a read-only view of the current routing state.
+func (r *Routing) Snapshot() RoutingSnapshot {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return RoutingSnapshot{
+		Vendor:       r.vendor,
+		Model:        r.model,
+		Streaming:    r.streaming,
+		StreamingSet: r.streamSet,
+	}
+}
+
+type routingCtxKey struct{}
+
+var routingKey = routingCtxKey{}
+
+// WithRouting attaches a Routing to ctx. The Path A middleware does
+// this on AIQG-mode requests; non-AIQG requests carry no Routing and
+// every Stamp* helper below no-ops.
+func WithRouting(ctx context.Context, r *Routing) context.Context {
+	return context.WithValue(ctx, routingKey, r)
+}
+
+// RoutingFromContext returns the Routing attached to ctx, or nil.
+// Callers stamping fields should prefer the package-level Stamp*
+// helpers below — they handle the nil case.
+func RoutingFromContext(ctx context.Context) *Routing {
+	if ctx == nil {
+		return nil
+	}
+	r, _ := ctx.Value(routingKey).(*Routing)
+	return r
+}
+
+// StampVendor records the chosen provider's name (e.g. "openai",
+// "anthropic"). Called by the completion handlers after router.Route
+// returns the selected provider. First write wins.
+func StampVendor(ctx context.Context, vendor string) {
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.vendor == "" {
+		r.vendor = vendor
+	}
+}
+
+// StampModel records the vendor-side model identifier requested
+// (e.g. "gpt-4o-mini", "claude-3-7-sonnet-20250219"). Called by the
+// completion handlers after they decode the inbound JSON body. First
+// write wins.
+func StampModel(ctx context.Context, model string) {
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.model == "" {
+		r.model = model
+	}
+}
+
+// StampStreaming records whether the inbound request asked for a
+// streamed response. Unlike Vendor/Model where "" means "not set",
+// streaming has a meaningful false value, so we track set-ness
+// separately via StreamingSet. First call wins.
+func StampStreaming(ctx context.Context, streaming bool) {
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.streamSet {
+		r.streaming = streaming
+		r.streamSet = true
+	}
+}

--- a/internal/middleware/aiqg_routing_test.go
+++ b/internal/middleware/aiqg_routing_test.go
@@ -1,0 +1,108 @@
+package middleware
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestRouting_NilSafeNoCollector(t *testing.T) {
+	ctx := context.Background()
+
+	// All stampers must tolerate a context with no Routing attached.
+	StampVendor(ctx, "openai")
+	StampModel(ctx, "gpt-4o-mini")
+	StampStreaming(ctx, true)
+
+	if got := RoutingFromContext(ctx); got != nil {
+		t.Errorf("RoutingFromContext returned non-nil for bare context: %#v", got)
+	}
+	var nilCtx context.Context
+	if got := RoutingFromContext(nilCtx); got != nil {
+		t.Errorf("RoutingFromContext(nil ctx) returned non-nil")
+	}
+}
+
+func TestRouting_StampAndSnapshot(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	StampVendor(ctx, "anthropic")
+	StampModel(ctx, "claude-3-7-sonnet")
+	StampStreaming(ctx, true)
+
+	s := r.Snapshot()
+	if s.Vendor != "anthropic" {
+		t.Errorf("Vendor=%q", s.Vendor)
+	}
+	if s.Model != "claude-3-7-sonnet" {
+		t.Errorf("Model=%q", s.Model)
+	}
+	if !s.Streaming || !s.StreamingSet {
+		t.Errorf("Streaming=%v StreamingSet=%v", s.Streaming, s.StreamingSet)
+	}
+}
+
+// First-write-wins: a fallback later in the request must not overwrite
+// the authoritative value the handler stamped early.
+func TestRouting_IdempotentStamps(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	StampVendor(ctx, "openai")
+	StampVendor(ctx, "anthropic") // ignored
+	StampModel(ctx, "gpt-4o-mini")
+	StampModel(ctx, "fallback-model") // ignored
+	StampStreaming(ctx, true)
+	StampStreaming(ctx, false) // ignored
+
+	s := r.Snapshot()
+	if s.Vendor != "openai" {
+		t.Errorf("Vendor not idempotent: %q", s.Vendor)
+	}
+	if s.Model != "gpt-4o-mini" {
+		t.Errorf("Model not idempotent: %q", s.Model)
+	}
+	if !s.Streaming {
+		t.Errorf("Streaming not idempotent: %v", s.Streaming)
+	}
+}
+
+// StreamingSet must distinguish "never stamped" from "explicitly false".
+func TestRouting_StreamingSetSemantic(t *testing.T) {
+	r := NewRouting()
+	// Never stamped.
+	s := r.Snapshot()
+	if s.StreamingSet {
+		t.Errorf("StreamingSet=true before any stamp")
+	}
+
+	// Stamp false — StreamingSet must flip to true.
+	r2 := NewRouting()
+	ctx := WithRouting(context.Background(), r2)
+	StampStreaming(ctx, false)
+	s2 := r2.Snapshot()
+	if !s2.StreamingSet {
+		t.Errorf("StreamingSet=false after explicit StampStreaming(false)")
+	}
+	if s2.Streaming {
+		t.Errorf("Streaming=true after StampStreaming(false)")
+	}
+}
+
+func TestRouting_ConcurrentStamps(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(3)
+		go func() { defer wg.Done(); StampVendor(ctx, "openai") }()
+		go func() { defer wg.Done(); StampModel(ctx, "gpt-4o-mini") }()
+		go func() { defer wg.Done(); StampStreaming(ctx, true) }()
+	}
+	wg.Wait()
+	s := r.Snapshot()
+	if s.Vendor != "openai" || s.Model != "gpt-4o-mini" || !s.Streaming {
+		t.Errorf("concurrent stamps produced inconsistent state: %#v", s)
+	}
+}

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -358,6 +358,45 @@ func TestAIQG_EmitsPairedEvents(t *testing.T) {
 	}
 }
 
+// Vendor/Model stamps made by the downstream handler must reach the
+// emitted event. Proves the Routing sidecar (attached by middleware) +
+// the deferred snapshot read both work end-to-end.
+func TestAIQG_VendorModelStampedReachEmittedEvent(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampVendor(r.Context(), "anthropic")
+		StampModel(r.Context(), "claude-3-7-sonnet-20250219")
+		StampStreaming(r.Context(), true)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewAIQG(AIQGConfig{
+		Strict:  true,
+		Logger:  silentLogger(),
+		Emitter: em,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	if em.Len() != 1 {
+		t.Fatalf("emit count=%d want=1", em.Len())
+	}
+	got := em.Requests()[0].Data
+	if got.Vendor != "anthropic" {
+		t.Errorf("Vendor=%q want=anthropic", got.Vendor)
+	}
+	if got.Model != "claude-3-7-sonnet-20250219" {
+		t.Errorf("Model=%q want=claude-3-7-sonnet-20250219", got.Model)
+	}
+	if !got.Streaming {
+		t.Errorf("Streaming=false despite explicit stamp")
+	}
+}
+
 // The emitted response event must carry a populated CLEAR scores
 // block — at MVP, that means Latency + Composite are non-nil and the
 // other dimensions are nil. End-to-end check of the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -293,6 +293,11 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Timestamp = time.Now()
 
+	// AIQG: stamp the requested model + streaming flag onto the routing
+	// sidecar so the response event carries them. No-op outside AIQG mode.
+	middleware.StampModel(r.Context(), req.Model)
+	middleware.StampStreaming(r.Context(), req.Stream)
+
 	// Gatekeeper: check bypass token
 	scanBypassed := false
 	if bypassToken := r.Header.Get("X-TAS-Scan-Bypass"); bypassToken != "" && s.bypassManager != nil {
@@ -346,6 +351,11 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 		s.writeErrorResponse(w, http.StatusServiceUnavailable, fmt.Sprintf("Routing failed: %v", err))
 		return
 	}
+
+	// AIQG: stamp the chosen provider's name onto the routing sidecar.
+	// Done here (not in router.Route) so AIQG plumbing stays in the
+	// server/middleware layer and doesn't leak into the routing package.
+	middleware.StampVendor(r.Context(), provider.GetProviderName())
 
 	// Handle streaming vs non-streaming with retry/fallback support
 	if req.Stream {

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -25,6 +25,21 @@ type AIQGHeadersView struct {
 	Trace        bool
 }
 
+// RoutingView is the subset of routing-layer state the event builder
+// needs. Same anti-cycle motivation as AIQGHeadersView — the middleware
+// projects its mutable middleware.Routing into this read-only struct
+// before invoking Build.
+//
+// Fields default to zero-value when unset; the builder then falls back
+// to its URL/method heuristics (e.g. Streaming reads the ?stream=true
+// query param when StreamingSet is false).
+type RoutingView struct {
+	Vendor       string
+	Model        string
+	Streaming    bool
+	StreamingSet bool
+}
+
 // GatewayVersion is the build version stamped on every event. Override
 // at build time via -ldflags "-X .../events.GatewayVersion=v1.4.2".
 var GatewayVersion = "dev"
@@ -56,11 +71,16 @@ type BuildOptions struct {
 // them in — this keeps the builder importable without cycling back into
 // internal/middleware.
 //
-// Fields the gateway can't populate at MVP today (tenant_id, vendor,
-// model, CLEAR scores) are left empty — downstream slices fill them
+// Fields the gateway can't populate at MVP today (tenant_id, CLEAR
+// scores beyond Latency) are left empty — downstream slices fill them
 // either by enriching the returned envelopes before Emit, or by adding
 // new args to Build.
-func Build(r *http.Request, headers AIQGHeadersView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
+//
+// routing carries the vendor/model decision and the authoritative
+// streaming flag. When routing.StreamingSet is false, the builder
+// falls back to the URL-query heuristic — handy for tests but the
+// completion handlers in production always stamp it explicitly.
+func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
 	reqID := newUUID()
 	respID := newUUID()
 	now := time.Now().UTC()
@@ -79,6 +99,11 @@ func Build(r *http.Request, headers AIQGHeadersView, snap instrumentation.Snapsh
 		status = StatusFromHTTP(opts.HTTPStatus)
 	}
 
+	streaming := isStreaming(r)
+	if routing.StreamingSet {
+		streaming = routing.Streaming
+	}
+
 	reqEvent := RequestEvent{
 		RequestEventID:            reqID,
 		ReceivedAt:                receivedAt,
@@ -88,7 +113,9 @@ func Build(r *http.Request, headers AIQGHeadersView, snap instrumentation.Snapsh
 		SourceApp:                 headers.SourceApp,
 		ClientRequestID:           r.Header.Get("X-Request-ID"),
 		Region:                    opts.Region,
-		Streaming:                 isStreaming(r),
+		Vendor:                    routing.Vendor,
+		Model:                     routing.Model,
+		Streaming:                 streaming,
 		IsAIQGMode:                true,
 		DryRun:                    headers.DryRun,
 		TraceReturned:             headers.Trace,

--- a/pkg/aiqg/events/event_test.go
+++ b/pkg/aiqg/events/event_test.go
@@ -74,7 +74,12 @@ func TestBuild_RoundTrip(t *testing.T) {
 		SourceApp:    "billing-api-prod",
 	}
 
-	reqEnv, respEnv := Build(r, headers, c.Snapshot(), BuildOptions{
+	reqEnv, respEnv := Build(r, headers, RoutingView{
+		Vendor:       "openai",
+		Model:        "gpt-4o-mini",
+		Streaming:    true,
+		StreamingSet: true,
+	}, c.Snapshot(), BuildOptions{
 		HTTPStatus: 200,
 		Region:     "us-east",
 	})
@@ -127,8 +132,14 @@ func TestBuild_RoundTrip(t *testing.T) {
 	if d.Region != "us-east" {
 		t.Errorf("region=%q", d.Region)
 	}
+	if d.Vendor != "openai" {
+		t.Errorf("vendor=%q want=openai (from RoutingView)", d.Vendor)
+	}
+	if d.Model != "gpt-4o-mini" {
+		t.Errorf("model=%q want=gpt-4o-mini (from RoutingView)", d.Model)
+	}
 	if !d.Streaming {
-		t.Errorf("streaming should be true (?stream=true)")
+		t.Errorf("streaming should be true (RoutingView authoritative)")
 	}
 	if !d.IsAIQGMode {
 		t.Errorf("is_aiqg_mode should be true")
@@ -179,7 +190,7 @@ func TestBuild_EmptySnapshot(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", nil)
 	r.RemoteAddr = "10.0.0.5:1234"
 
-	reqEnv, respEnv := Build(r, AIQGHeadersView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 0})
+	reqEnv, respEnv := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 0})
 
 	if reqEnv.Data.LifecycleState != LifecyclePairedWithResponse {
 		t.Errorf("lifecycle_state default missing")
@@ -199,7 +210,7 @@ func TestBuild_XForwardedFor(t *testing.T) {
 	r.RemoteAddr = "10.0.0.5:1234"
 	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
 
-	reqEnv, _ := Build(r, AIQGHeadersView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	reqEnv, _ := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 	if reqEnv.Data.SourceIP != "203.0.113.7" {
 		t.Errorf("source_ip=%q (XFF first-entry not picked)", reqEnv.Data.SourceIP)
 	}
@@ -210,7 +221,7 @@ func TestBuild_XForwardedFor(t *testing.T) {
 func TestEnvelopeMarshalsToCloudEventsShape(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
 	r.RemoteAddr = "10.0.0.5:80"
-	reqEnv, respEnv := Build(r, AIQGHeadersView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	reqEnv, respEnv := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 
 	for _, env := range []any{reqEnv, respEnv} {
 		b, err := json.Marshal(env)
@@ -226,6 +237,52 @@ func TestEnvelopeMarshalsToCloudEventsShape(t *testing.T) {
 				t.Errorf("missing CloudEvents key %q in envelope %T", k, env)
 			}
 		}
+	}
+}
+
+// RoutingView.Streaming must override the URL-query heuristic only
+// when StreamingSet=true; otherwise the heuristic wins.
+func TestBuild_StreamingPrecedence(t *testing.T) {
+	cases := []struct {
+		name      string
+		url       string
+		view      RoutingView
+		want      bool
+	}{
+		{"url_says_yes_view_unset", "/v1/chat/completions?stream=true", RoutingView{}, true},
+		{"url_says_no_view_unset", "/v1/chat/completions", RoutingView{}, false},
+		{"view_overrides_url_true_to_false", "/v1/chat/completions?stream=true", RoutingView{StreamingSet: true, Streaming: false}, false},
+		{"view_overrides_url_false_to_true", "/v1/chat/completions", RoutingView{StreamingSet: true, Streaming: true}, true},
+		{"view_set_matches_url", "/v1/chat/completions?stream=true", RoutingView{StreamingSet: true, Streaming: true}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodPost, c.url, nil)
+			r.RemoteAddr = "10.0.0.5:80"
+			reqEnv, _ := Build(r, AIQGHeadersView{}, c.view, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+			if reqEnv.Data.Streaming != c.want {
+				t.Errorf("Streaming=%v want=%v", reqEnv.Data.Streaming, c.want)
+			}
+		})
+	}
+}
+
+// Vendor and model are emitted verbatim from RoutingView — no
+// normalization, no inference. Empty values are emitted as omitted.
+func TestBuild_VendorModelPassthrough(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	r.RemoteAddr = "10.0.0.5:80"
+
+	// Populated case
+	reqEnv, _ := Build(r, AIQGHeadersView{}, RoutingView{Vendor: "anthropic", Model: "claude-3-7-sonnet"}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	if reqEnv.Data.Vendor != "anthropic" || reqEnv.Data.Model != "claude-3-7-sonnet" {
+		t.Errorf("vendor/model not passed through: %q / %q", reqEnv.Data.Vendor, reqEnv.Data.Model)
+	}
+
+	// Empty case
+	reqEnv2, _ := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	if reqEnv2.Data.Vendor != "" || reqEnv2.Data.Model != "" {
+		t.Errorf("vendor/model not empty: %q / %q", reqEnv2.Data.Vendor, reqEnv2.Data.Model)
 	}
 }
 


### PR DESCRIPTION
## Summary
Without this slice, every emitted AIQG event carried `vendor: ""` and `model: ""`. That neuters the entire downstream pipeline — Cost scoring needs vendor pricing tables, dashboards segment by model, and per-tenant attribution depends on knowing what was called.

This slice adds a context-scoped `Routing` sidecar (same mutable-pointer-in-ctx pattern as `instrumentation.TimingCollector`) so the chat-completion handlers stamp the routing decision as it becomes known:

| Stamp | When | Source |
|---|---|---|
| `StampModel` | After body decode | `req.Model` |
| `StampStreaming` | After body decode | `req.Stream` |
| `StampVendor` | After `router.Route` | `provider.GetProviderName()` |

## New API surface
```go
// internal/middleware
type Routing struct { /* mu, vendor, model, streaming, streamSet */ }
func NewRouting() *Routing
func WithRouting(ctx, *Routing) context.Context
func RoutingFromContext(ctx) *Routing
func StampVendor(ctx, string)    // no-op without Routing in ctx
func StampModel(ctx, string)
func StampStreaming(ctx, bool)
func (*Routing) Snapshot() RoutingSnapshot
```

Stamps are **first-write-wins** (idempotent) so a later fallback path can't overwrite the authoritative early stamp.

## events.Build signature change
```go
// Before
func Build(r, headers, snap, opts) (Req, Resp)
// After
func Build(r, headers, routing, snap, opts) (Req, Resp)
```

`RoutingView.StreamingSet` distinguishes "explicitly stamped false" from "never stamped" — when false, the URL-query heuristic remains the fallback (handy for tests + non-AIQG-wired calls).

## Path A middleware
- Attaches a fresh `Routing` alongside the `TimingCollector` on entry.
- Defer projects `Routing.Snapshot()` into `events.RoutingView` and passes it to `Build`.
- New `routingView()` projection lives in `internal/middleware` to avoid the same import cycle that drove `headersView()`.

## Test plan
- [x] `make test` clean across every package end-to-end
- [x] `internal/middleware/aiqg_routing_test.go` — nil-safe stampers without ctx Routing, ctx round-trip, idempotent first-write-wins, StreamingSet semantic, 300-goroutine concurrent stamp safety
- [x] `pkg/aiqg/events/event_test.go`:
  - `TestBuild_StreamingPrecedence` — 5-case table: URL heuristic vs. RoutingView override in both directions
  - `TestBuild_VendorModelPassthrough` — populated + empty cases
  - Existing `TestBuild_RoundTrip` extended with vendor/model assertions
- [x] `internal/middleware/aiqg_test.go` — `TestAIQG_VendorModelStampedReachEmittedEvent` — full middleware → handler-stamp → defer → emitter chain via MemoryEmitter

## Still pending (future slices)
- `tenant_id` / `aiqg_account_id` — needs token-resolver
- `clear.Cost` — now unblocked since Vendor/Model are stamped
- K3s manifest update to flip `aiqg.enabled: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)