### PR TITLE
feat: resolve TAS-Auth to tenant_id / aiqg_account_id

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
 
 // AIQGConfig configures the AIQG entry middleware.
@@ -62,6 +63,14 @@ type AIQGConfig struct {
 	// "us-west", "eu"). Set from deployment config. Empty is allowed
 	// during local dev and is omitted from the event JSON.
 	Region string
+
+	// Resolver turns the TAS-Auth bearer into a tenant_id / account_id
+	// for event attribution. Nil is allowed during incremental rollout:
+	// the middleware skips resolution, every request is treated as
+	// opaque-token-known, and emitted events carry empty tenant fields.
+	// Once a Resolver is configured, unknown tokens become 401 and
+	// suspended accounts become 403.
+	Resolver tokens.Resolver
 }
 
 // NewAIQG returns the middleware constructor. The returned handler is a
@@ -123,16 +132,43 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 		return
 	}
 
-	// Enter AIQG mode: attach collector + headers + routing sidecar,
-	// stamp Received, arrange for StampComplete + event emission on
-	// response end. The routing sidecar is empty here; the completion
-	// handlers populate it via StampVendor / StampModel / StampStreaming
-	// as those decisions are made.
+	// Resolve TAS-Auth to a tenant/account when a resolver is wired.
+	// Unknown tokens become 401 (path_a_auth_rejected with reason=
+	// token_unknown); suspended accounts become 403. When no resolver
+	// is configured, tokens stay opaque and emitted events carry empty
+	// tenant fields — this is the incremental-rollout path.
+	var resolvedToken *tokens.Token
+	if cfg.Resolver != nil {
+		tok, err := cfg.Resolver.Resolve(r.Context(), parsed.Auth)
+		switch {
+		case errors.Is(err, tokens.ErrTokenNotFound):
+			rejectTokenUnknown(cfg.Logger, w, r)
+			return
+		case errors.Is(err, tokens.ErrTokenSuspended):
+			rejectAccountSuspended(cfg.Logger, w, r, tok)
+			return
+		case err != nil:
+			cfg.Logger.WithError(err).WithField("event", "aiqg.token_resolve_error").
+				Error("AIQG token resolver returned unexpected error")
+			writeResolverError(w)
+			return
+		}
+		resolvedToken = tok
+	}
+
+	// Enter AIQG mode: attach collector + headers + routing sidecar +
+	// resolved token, stamp Received, arrange for StampComplete + event
+	// emission on response end. The routing sidecar is empty here; the
+	// completion handlers populate it via StampVendor / StampModel /
+	// StampStreaming as those decisions are made.
 	collector := instrumentation.NewCollector()
 	routing := NewRouting()
 	ctx := instrumentation.WithCollector(r.Context(), collector)
 	ctx = WithHeaders(ctx, parsed)
 	ctx = WithRouting(ctx, routing)
+	if resolvedToken != nil {
+		ctx = tokens.WithToken(ctx, resolvedToken)
+	}
 	instrumentation.StampReceived(ctx)
 
 	sw := &statusCapturingResponseWriter{ResponseWriter: w}
@@ -147,7 +183,7 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// routing sidecar is read at the same moment, so any vendor/model
 	// stamps made by the handler reach the event.
 	defer func() {
-		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), collector.Snapshot(), events.BuildOptions{
+		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
 			HTTPStatus: sw.status(),
 			Region:     cfg.Region,
 		})
@@ -190,6 +226,73 @@ func routingView(r *Routing) events.RoutingView {
 		Streaming:    s.Streaming,
 		StreamingSet: s.StreamingSet,
 	}
+}
+
+// tokenView projects a resolved tokens.Token into the read-only shape
+// events.Build expects. Nil token (no resolver configured) returns the
+// zero view; events then carry empty tenant_id / aiqg_account_id /
+// tas_auth_token_id fields, which downstream consumers can detect and
+// filter out as non-attributed traffic.
+func tokenView(t *tokens.Token) events.TokenView {
+	if t == nil {
+		return events.TokenView{}
+	}
+	return events.TokenView{
+		TenantID:       t.TenantID,
+		AIQGAccountID:  t.AIQGAccountID,
+		TASAuthTokenID: t.TokenID,
+		SourceApp:      t.SourceApp,
+	}
+}
+
+// rejectTokenUnknown emits 401 for a TAS-Auth bearer that the resolver
+// didn't recognize. Distinct response code (`token_unknown`) so
+// dashboards can break out genuine misconfigurations from "auth header
+// missing" failures.
+func rejectTokenUnknown(log *logrus.Logger, w http.ResponseWriter, r *http.Request) {
+	log.WithFields(logrus.Fields{
+		"event":  "aiqg.path_a_auth_rejected",
+		"reason": "token_unknown",
+		"path":   r.URL.Path,
+		"method": r.Method,
+	}).Warn("Path A auth rejected — token unknown")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("WWW-Authenticate", `TAS realm="aiqg"`)
+	w.WriteHeader(http.StatusUnauthorized)
+	_, _ = w.Write([]byte(`{"error":{"code":"path_a_auth_required","message":"AIQG ingress requires a recognized TAS-Auth token","reason":"token_unknown","docs":"https://docs.tas.scharber.com/aiqg/auth"}}`))
+}
+
+// rejectAccountSuspended emits 403 for a TAS-Auth bearer that resolves
+// to a suspended account. Per spec request-event.md §564 we still
+// recognize the token; we reject the request before forwarding. The
+// resolved token info is logged for support to triage.
+func rejectAccountSuspended(log *logrus.Logger, w http.ResponseWriter, r *http.Request, tok *tokens.Token) {
+	fields := logrus.Fields{
+		"event":  "aiqg.account_suspended",
+		"path":   r.URL.Path,
+		"method": r.Method,
+	}
+	if tok != nil {
+		fields["aiqg_account_id"] = tok.AIQGAccountID
+		fields["tenant_id"] = tok.TenantID
+	}
+	log.WithFields(fields).Warn("AIQG request rejected — account suspended")
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write([]byte(`{"error":{"code":"account_suspended","message":"AIQG account is currently suspended; contact support"}}`))
+}
+
+// writeResolverError emits 503 for resolver-side failures (e.g. the
+// production backend resolver can't reach the token store). 503 instead
+// of 500 because the failure is upstream-dependency unavailability, and
+// callers should retry rather than treat the request as permanently
+// broken.
+func writeResolverError(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	_, _ = w.Write([]byte(`{"error":{"code":"token_resolver_unavailable","message":"AIQG token resolver is temporarily unavailable; retry"}}`))
 }
 
 // statusCapturingResponseWriter records the HTTP status code written

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -1,7 +1,9 @@
 package middleware
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -11,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
 
 // silentLogger returns a logger that discards output — keeps test
@@ -355,6 +358,201 @@ func TestAIQG_EmitsPairedEvents(t *testing.T) {
 	}
 	if respEnv.Data.Status != events.StatusSuccess {
 		t.Errorf("status=%q", respEnv.Data.Status)
+	}
+}
+
+// A configured Resolver enriches the event with tenant_id /
+// aiqg_account_id / tas_auth_token_id when the bearer resolves.
+func TestAIQG_ResolverEnrichesEvent(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	resolver := tokens.NewMapResolver([]tokens.ConfigToken{
+		{
+			TokenID:       "tok_uuid_1",
+			Token:         "tas_qg_live_abc",
+			TenantID:      "tenant-a",
+			AIQGAccountID: "account-a",
+			SourceApp:     "billing-api-prod",
+		},
+	})
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{
+		Strict:   true,
+		Logger:   silentLogger(),
+		Emitter:  em,
+		Resolver: resolver,
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk-customer")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if em.Len() != 1 {
+		t.Fatalf("emit count=%d want=1", em.Len())
+	}
+	d := em.Requests()[0].Data
+	if d.TenantID != "tenant-a" {
+		t.Errorf("TenantID=%q", d.TenantID)
+	}
+	if d.AIQGAccountID != "account-a" {
+		t.Errorf("AIQGAccountID=%q", d.AIQGAccountID)
+	}
+	if d.TASAuthTokenID != "tok_uuid_1" {
+		t.Errorf("TASAuthTokenID=%q", d.TASAuthTokenID)
+	}
+	// SourceApp falls back to the token claim when no header was sent.
+	if d.SourceApp != "billing-api-prod" {
+		t.Errorf("SourceApp=%q want=billing-api-prod (token claim fallback)", d.SourceApp)
+	}
+
+	// Response event also carries the denormalized IDs.
+	rd := em.Responses()[0].Data
+	if rd.TenantID != "tenant-a" || rd.AIQGAccountID != "account-a" {
+		t.Errorf("response denorm IDs not populated: tenant=%q account=%q", rd.TenantID, rd.AIQGAccountID)
+	}
+}
+
+// TAS-Source-App header wins over the token's source_app claim per spec §80.
+func TestAIQG_SourceAppHeaderOverridesTokenClaim(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	resolver := tokens.NewMapResolver([]tokens.ConfigToken{
+		{Token: "tas_qg_live_abc", TenantID: "t1", AIQGAccountID: "a1", SourceApp: "token-claim-app"},
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em, Resolver: resolver})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	req.Header.Set("TAS-Source-App", "header-override-app")
+	rec := httptest.NewRecorder()
+	mw(&echoHandler{}).ServeHTTP(rec, req)
+
+	d := em.Requests()[0].Data
+	if d.SourceApp != "header-override-app" {
+		t.Errorf("SourceApp=%q; header should win over token claim", d.SourceApp)
+	}
+}
+
+// Unknown token → 401 with reason=token_unknown; no event emitted.
+func TestAIQG_UnknownTokenReturns401AndEmitsNothing(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	resolver := tokens.NewMapResolver([]tokens.ConfigToken{
+		{Token: "tas_qg_live_known", TenantID: "t1", AIQGAccountID: "a1"},
+	})
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em, Resolver: resolver})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_unknown")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("code=%d want=401", rec.Code)
+	}
+	if next.called {
+		t.Errorf("downstream called on unknown token")
+	}
+	if em.Len() != 0 {
+		t.Errorf("emit count=%d want=0 (pre-validation auth failure per spec §273)", em.Len())
+	}
+
+	var body struct {
+		Error struct {
+			Code   string `json:"code"`
+			Reason string `json:"reason"`
+		} `json:"error"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &body)
+	if body.Error.Reason != "token_unknown" {
+		t.Errorf("error.reason=%q want=token_unknown", body.Error.Reason)
+	}
+}
+
+// Suspended account → 403 with code=account_suspended; no event emitted.
+func TestAIQG_SuspendedAccountReturns403(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	resolver := tokens.NewMapResolver([]tokens.ConfigToken{
+		{Token: "tas_qg_live_suspended", TenantID: "t1", AIQGAccountID: "a1", Suspended: true},
+	})
+	next := &echoHandler{}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em, Resolver: resolver})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_suspended")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(next).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("code=%d want=403", rec.Code)
+	}
+	if next.called {
+		t.Errorf("downstream called on suspended account")
+	}
+	if em.Len() != 0 {
+		t.Errorf("emit count=%d want=0", em.Len())
+	}
+	if !strings.Contains(rec.Body.String(), "account_suspended") {
+		t.Errorf("body missing code: %s", rec.Body.String())
+	}
+}
+
+// Resolver errors (e.g. backend store unavailable) → 503, no emit.
+type errResolver struct{ err error }
+
+func (e errResolver) Resolve(_ context.Context, _ string) (*tokens.Token, error) {
+	return nil, e.err
+}
+
+func TestAIQG_ResolverErrorReturns503(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	resolver := errResolver{err: errors.New("backend down")}
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em, Resolver: resolver})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_anything")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(&echoHandler{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("code=%d want=503", rec.Code)
+	}
+	if em.Len() != 0 {
+		t.Errorf("emit on resolver error")
+	}
+}
+
+// No-resolver config (incremental rollout) accepts any TAS-Auth as
+// opaque; events emit with empty tenant fields.
+func TestAIQG_NoResolverAcceptsAnyToken(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	mw := NewAIQG(AIQGConfig{
+		Strict:   true,
+		Logger:   silentLogger(),
+		Emitter:  em,
+		Resolver: nil, // no resolver configured
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_anything")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(&echoHandler{}).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("code=%d want=200 (no-resolver path should accept)", rec.Code)
+	}
+	if em.Len() != 1 {
+		t.Fatalf("emit count=%d want=1", em.Len())
+	}
+	d := em.Requests()[0].Data
+	if d.TenantID != "" || d.AIQGAccountID != "" || d.TASAuthTokenID != "" {
+		t.Errorf("expected empty tenant fields without resolver, got tenant=%q account=%q tokenID=%q",
+			d.TenantID, d.AIQGAccountID, d.TASAuthTokenID)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/security"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
 
 // Server represents the HTTP server
@@ -66,6 +67,13 @@ type AIQGServerConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	Strict  bool   `yaml:"strict"`
 	Region  string `yaml:"region"`
+
+	// Tokens is the MVP in-memory token store. Production deployments
+	// swap to a dashboard-backend resolver via a separate config knob
+	// (TBD when aiqg-dashboard-be ships). Empty/omitted means no
+	// resolver is wired — tokens stay opaque and events carry empty
+	// tenant fields. Suitable for incremental rollout.
+	Tokens []tokens.ConfigToken `yaml:"tokens"`
 }
 
 // NewServer creates a new server instance
@@ -102,15 +110,29 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 	// emitted on response completion via LogEmitter → logrus → Loki.
 	if config.AIQG != nil && config.AIQG.Enabled {
 		server.aiqgEmitter = &events.LogEmitter{Logger: logger}
+
+		// Build the token resolver when tokens are configured. Without
+		// a resolver the middleware accepts any TAS-Auth bearer but
+		// emits events with empty tenant fields — useful for an early
+		// rollout where the token store hasn't shipped yet.
+		var resolver tokens.Resolver
+		if len(config.AIQG.Tokens) > 0 {
+			mr := tokens.NewMapResolver(config.AIQG.Tokens)
+			resolver = mr
+			logger.WithField("token_count", mr.Len()).Info("AIQG token resolver loaded (in-memory)")
+		}
+
 		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{
-			Strict:  config.AIQG.Strict,
-			Logger:  logger,
-			Emitter: server.aiqgEmitter,
-			Region:  config.AIQG.Region,
+			Strict:   config.AIQG.Strict,
+			Logger:   logger,
+			Emitter:  server.aiqgEmitter,
+			Region:   config.AIQG.Region,
+			Resolver: resolver,
 		})
 		logger.WithFields(logrus.Fields{
-			"strict": config.AIQG.Strict,
-			"region": config.AIQG.Region,
+			"strict":           config.AIQG.Strict,
+			"region":           config.AIQG.Region,
+			"resolver_enabled": resolver != nil,
 		}).Info("AIQG ingress enabled on completion routes")
 	}
 

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -40,6 +40,19 @@ type RoutingView struct {
 	StreamingSet bool
 }
 
+// TokenView is the subset of resolved-token state the event builder
+// needs. The Path A middleware constructs it from pkg/aiqg/tokens.Token
+// after a successful Resolve. Pre-validation auth failures never
+// reach Build (the middleware short-circuits with 401/403 before
+// emitting), so TokenView is either fully populated or fully empty —
+// never partial.
+type TokenView struct {
+	TenantID       string
+	AIQGAccountID  string
+	TASAuthTokenID string
+	SourceApp      string // token-claim source_app; header overrides per spec §80
+}
+
 // GatewayVersion is the build version stamped on every event. Override
 // at build time via -ldflags "-X .../events.GatewayVersion=v1.4.2".
 var GatewayVersion = "dev"
@@ -80,7 +93,12 @@ type BuildOptions struct {
 // streaming flag. When routing.StreamingSet is false, the builder
 // falls back to the URL-query heuristic — handy for tests but the
 // completion handlers in production always stamp it explicitly.
-func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
+//
+// token carries the resolved tenant/account identifiers. Pre-validation
+// auth failures don't reach Build (per spec §273), so token is either
+// fully populated from a successful resolve or fully empty (resolver
+// not configured / non-AIQG path).
+func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token TokenView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
 	reqID := newUUID()
 	respID := newUUID()
 	now := time.Now().UTC()
@@ -104,13 +122,24 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, snap i
 		streaming = routing.Streaming
 	}
 
+	// SourceApp precedence per request-event.md §80: customer-supplied
+	// TAS-Source-App header wins; falls back to the token's source_app
+	// claim. Empty if neither side provides it.
+	sourceApp := headers.SourceApp
+	if sourceApp == "" {
+		sourceApp = token.SourceApp
+	}
+
 	reqEvent := RequestEvent{
 		RequestEventID:            reqID,
+		TenantID:                  token.TenantID,
+		AIQGAccountID:             token.AIQGAccountID,
+		TASAuthTokenID:            token.TASAuthTokenID,
 		ReceivedAt:                receivedAt,
 		Endpoint:                  r.URL.Path,
 		Method:                    r.Method,
 		SourceIP:                  clientIP(r),
-		SourceApp:                 headers.SourceApp,
+		SourceApp:                 sourceApp,
 		ClientRequestID:           r.Header.Get("X-Request-ID"),
 		Region:                    opts.Region,
 		Vendor:                    routing.Vendor,
@@ -133,6 +162,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, snap i
 	respEvent := ResponseEvent{
 		ResponseEventID:   respID,
 		RequestEventID:    reqID,
+		TenantID:          token.TenantID,        // denormalized per response-event.md §"Denormalization rationale"
+		AIQGAccountID:     token.AIQGAccountID,   // ditto
 		CompleteAt:        completeAt,
 		Status:            status,
 		HTTPStatus:        opts.HTTPStatus,

--- a/pkg/aiqg/events/event_test.go
+++ b/pkg/aiqg/events/event_test.go
@@ -79,7 +79,7 @@ func TestBuild_RoundTrip(t *testing.T) {
 		Model:        "gpt-4o-mini",
 		Streaming:    true,
 		StreamingSet: true,
-	}, c.Snapshot(), BuildOptions{
+	}, TokenView{}, c.Snapshot(), BuildOptions{
 		HTTPStatus: 200,
 		Region:     "us-east",
 	})
@@ -190,7 +190,7 @@ func TestBuild_EmptySnapshot(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "/anthropic/v1/messages", nil)
 	r.RemoteAddr = "10.0.0.5:1234"
 
-	reqEnv, respEnv := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 0})
+	reqEnv, respEnv := Build(r, AIQGHeadersView{}, RoutingView{}, TokenView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 0})
 
 	if reqEnv.Data.LifecycleState != LifecyclePairedWithResponse {
 		t.Errorf("lifecycle_state default missing")
@@ -210,7 +210,7 @@ func TestBuild_XForwardedFor(t *testing.T) {
 	r.RemoteAddr = "10.0.0.5:1234"
 	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
 
-	reqEnv, _ := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	reqEnv, _ := Build(r, AIQGHeadersView{}, RoutingView{}, TokenView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 	if reqEnv.Data.SourceIP != "203.0.113.7" {
 		t.Errorf("source_ip=%q (XFF first-entry not picked)", reqEnv.Data.SourceIP)
 	}
@@ -221,7 +221,7 @@ func TestBuild_XForwardedFor(t *testing.T) {
 func TestEnvelopeMarshalsToCloudEventsShape(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
 	r.RemoteAddr = "10.0.0.5:80"
-	reqEnv, respEnv := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	reqEnv, respEnv := Build(r, AIQGHeadersView{}, RoutingView{}, TokenView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 
 	for _, env := range []any{reqEnv, respEnv} {
 		b, err := json.Marshal(env)
@@ -259,7 +259,7 @@ func TestBuild_StreamingPrecedence(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			r := httptest.NewRequest(http.MethodPost, c.url, nil)
 			r.RemoteAddr = "10.0.0.5:80"
-			reqEnv, _ := Build(r, AIQGHeadersView{}, c.view, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+			reqEnv, _ := Build(r, AIQGHeadersView{}, c.view, TokenView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 			if reqEnv.Data.Streaming != c.want {
 				t.Errorf("Streaming=%v want=%v", reqEnv.Data.Streaming, c.want)
 			}
@@ -274,13 +274,13 @@ func TestBuild_VendorModelPassthrough(t *testing.T) {
 	r.RemoteAddr = "10.0.0.5:80"
 
 	// Populated case
-	reqEnv, _ := Build(r, AIQGHeadersView{}, RoutingView{Vendor: "anthropic", Model: "claude-3-7-sonnet"}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	reqEnv, _ := Build(r, AIQGHeadersView{}, RoutingView{Vendor: "anthropic", Model: "claude-3-7-sonnet"}, TokenView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 	if reqEnv.Data.Vendor != "anthropic" || reqEnv.Data.Model != "claude-3-7-sonnet" {
 		t.Errorf("vendor/model not passed through: %q / %q", reqEnv.Data.Vendor, reqEnv.Data.Model)
 	}
 
 	// Empty case
-	reqEnv2, _ := Build(r, AIQGHeadersView{}, RoutingView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
+	reqEnv2, _ := Build(r, AIQGHeadersView{}, RoutingView{}, TokenView{}, instrumentation.Snapshot{}, BuildOptions{HTTPStatus: 200})
 	if reqEnv2.Data.Vendor != "" || reqEnv2.Data.Model != "" {
 		t.Errorf("vendor/model not empty: %q / %q", reqEnv2.Data.Vendor, reqEnv2.Data.Model)
 	}

--- a/pkg/aiqg/tokens/tokens.go
+++ b/pkg/aiqg/tokens/tokens.go
@@ -1,0 +1,150 @@
+// Package tokens resolves AIQG bearer tokens (`tas_qg_live_*`) to
+// tenant + account identifiers. Per build-vs-reuse §1.2 the production
+// resolver will query aiqg-dashboard-be's token store; for MVP this
+// package ships an in-memory MapResolver constructed from server config
+// so deployments can start emitting tenant-scoped events without
+// blocking on the dashboard-backend rollout.
+//
+// The Resolver interface keeps the production swap a one-line change:
+//
+//	type DashboardResolver struct { client *dashboard.Client }
+//	func (r *DashboardResolver) Resolve(ctx, token) (*Token, error) { ... }
+//
+// Errors:
+//   - ErrTokenNotFound  → middleware emits 401 (spec request-event.md §564)
+//   - ErrTokenSuspended → middleware emits 403 (account suspended)
+//
+// Both errors bypass event emission per spec §273 — pre-validation auth
+// failures are counted in Prometheus auth-failure metrics only because
+// there is no resolved tenant to attribute an event to.
+package tokens
+
+import (
+	"context"
+	"errors"
+)
+
+// Token is the resolved view of a `tas_qg_live_*` bearer. Field names
+// mirror aether-shared/data-models/aiqg/account.md so plumbing the
+// dashboard-backend resolver later is a copy of the same struct.
+type Token struct {
+	// TokenID is the UUID FK to the aiqg_token table managed by
+	// aiqg-dashboard-be. Stamped on request_event.tas_auth_token_id
+	// (request-event.md §"Field reference").
+	TokenID string
+
+	// TenantID is the customer-scoped isolation boundary. Hot index
+	// for tenant-scoped dashboard queries.
+	TenantID string
+
+	// AIQGAccountID is 1:1 with TenantID but stored explicitly for
+	// join convenience (per spec field reference).
+	AIQGAccountID string
+
+	// SourceApp is the token's claimed source-app identifier. Per
+	// request-event.md §80 the customer-supplied TAS-Source-App
+	// header overrides this when both are present.
+	SourceApp string
+
+	// Suspended marks accounts that should receive 403, not 401.
+	// Token presence + recognition is fine; the account itself is
+	// suspended.
+	Suspended bool
+}
+
+// ErrTokenNotFound means the bearer wasn't recognized by the resolver.
+// Distinct from ErrTokenSuspended (which means recognized but blocked).
+var ErrTokenNotFound = errors.New("aiqg/tokens: token not found")
+
+// ErrTokenSuspended means the token resolved to an account that is
+// currently suspended. Maps to HTTP 403 per spec.
+var ErrTokenSuspended = errors.New("aiqg/tokens: token's account is suspended")
+
+// Resolver turns a `tas_qg_live_*` bearer into a Token. The MVP
+// MapResolver is in-process; production swaps to a backend-client
+// implementation against aiqg-dashboard-be.
+type Resolver interface {
+	Resolve(ctx context.Context, bearer string) (*Token, error)
+}
+
+// MapResolver looks tokens up in an in-memory map. Constructed from
+// server config; safe for concurrent reads (no writes after
+// construction).
+type MapResolver struct {
+	byBearer map[string]*Token
+}
+
+// NewMapResolver builds a resolver from a slice of token definitions.
+// Duplicate bearer entries take the LAST occurrence — config-loader
+// validation should reject duplicates before reaching here, but the
+// behavior is documented so the silent collision is not surprising.
+func NewMapResolver(tokens []ConfigToken) *MapResolver {
+	m := &MapResolver{byBearer: make(map[string]*Token, len(tokens))}
+	for _, t := range tokens {
+		m.byBearer[t.Token] = &Token{
+			TokenID:       t.TokenID,
+			TenantID:      t.TenantID,
+			AIQGAccountID: t.AIQGAccountID,
+			SourceApp:     t.SourceApp,
+			Suspended:     t.Suspended,
+		}
+	}
+	return m
+}
+
+// Resolve returns the Token for bearer, or ErrTokenNotFound. Suspended
+// accounts return their populated Token AND ErrTokenSuspended — the
+// middleware needs both: the Token to log the resolved account, the
+// error to gate the response.
+func (m *MapResolver) Resolve(_ context.Context, bearer string) (*Token, error) {
+	tok, ok := m.byBearer[bearer]
+	if !ok {
+		return nil, ErrTokenNotFound
+	}
+	if tok.Suspended {
+		return tok, ErrTokenSuspended
+	}
+	return tok, nil
+}
+
+// Len returns the number of tokens in the resolver. Useful for startup
+// log lines confirming the config loaded correctly.
+func (m *MapResolver) Len() int {
+	return len(m.byBearer)
+}
+
+// ConfigToken is the YAML-mappable shape consumed by NewMapResolver.
+// Lives in this package so the server-config struct can reference it
+// without pulling middleware/events deps into config parsing.
+type ConfigToken struct {
+	TokenID       string `yaml:"token_id"`
+	Token         string `yaml:"token"`
+	TenantID      string `yaml:"tenant_id"`
+	AIQGAccountID string `yaml:"aiqg_account_id"`
+	SourceApp     string `yaml:"source_app"`
+	Suspended     bool   `yaml:"suspended"`
+}
+
+// Context plumbing — same shape as middleware.WithHeaders. Lets
+// downstream consumers (audit logger, policy resolver) read the
+// resolved token without re-running the resolver.
+
+type ctxKey struct{}
+
+var tokenKey = ctxKey{}
+
+// WithToken attaches a resolved Token to ctx.
+func WithToken(ctx context.Context, t *Token) context.Context {
+	return context.WithValue(ctx, tokenKey, t)
+}
+
+// FromContext returns the Token attached to ctx, or nil. Callers that
+// don't need the token (non-AIQG paths) get nil and can skip
+// tenant-scoped work entirely.
+func FromContext(ctx context.Context) *Token {
+	if ctx == nil {
+		return nil
+	}
+	t, _ := ctx.Value(tokenKey).(*Token)
+	return t
+}

--- a/pkg/aiqg/tokens/tokens_test.go
+++ b/pkg/aiqg/tokens/tokens_test.go
@@ -1,0 +1,127 @@
+package tokens
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func newResolverWithFixtures() *MapResolver {
+	return NewMapResolver([]ConfigToken{
+		{
+			TokenID:       "tok_uuid_1",
+			Token:         "tas_qg_live_abc",
+			TenantID:      "tenant-a",
+			AIQGAccountID: "account-a",
+			SourceApp:     "billing-api-prod",
+		},
+		{
+			TokenID:       "tok_uuid_2",
+			Token:         "tas_qg_live_def",
+			TenantID:      "tenant-b",
+			AIQGAccountID: "account-b",
+			SourceApp:     "claims-api-prod",
+			Suspended:     true,
+		},
+	})
+}
+
+func TestMapResolver_Hit(t *testing.T) {
+	r := newResolverWithFixtures()
+	tok, err := r.Resolve(context.Background(), "tas_qg_live_abc")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if tok.TenantID != "tenant-a" {
+		t.Errorf("TenantID=%q", tok.TenantID)
+	}
+	if tok.AIQGAccountID != "account-a" {
+		t.Errorf("AIQGAccountID=%q", tok.AIQGAccountID)
+	}
+	if tok.TokenID != "tok_uuid_1" {
+		t.Errorf("TokenID=%q", tok.TokenID)
+	}
+	if tok.SourceApp != "billing-api-prod" {
+		t.Errorf("SourceApp=%q", tok.SourceApp)
+	}
+	if tok.Suspended {
+		t.Errorf("Suspended=true for active token")
+	}
+}
+
+func TestMapResolver_NotFound(t *testing.T) {
+	r := newResolverWithFixtures()
+	tok, err := r.Resolve(context.Background(), "tas_qg_live_not_in_config")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound, got %v", err)
+	}
+	if tok != nil {
+		t.Errorf("Token should be nil on not-found: %#v", tok)
+	}
+}
+
+// Suspended accounts return BOTH the populated token AND ErrTokenSuspended
+// so the middleware can log the resolved tenant for triage even as it
+// rejects the request.
+func TestMapResolver_Suspended(t *testing.T) {
+	r := newResolverWithFixtures()
+	tok, err := r.Resolve(context.Background(), "tas_qg_live_def")
+	if !errors.Is(err, ErrTokenSuspended) {
+		t.Fatalf("expected ErrTokenSuspended, got %v", err)
+	}
+	if tok == nil {
+		t.Fatalf("Token should be populated even on suspended account (for logging)")
+	}
+	if tok.TenantID != "tenant-b" {
+		t.Errorf("TenantID=%q", tok.TenantID)
+	}
+}
+
+func TestMapResolver_EmptyTokenString(t *testing.T) {
+	r := newResolverWithFixtures()
+	_, err := r.Resolve(context.Background(), "")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("empty string should be ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestMapResolver_Len(t *testing.T) {
+	if got := newResolverWithFixtures().Len(); got != 2 {
+		t.Errorf("Len()=%d want=2", got)
+	}
+	if got := NewMapResolver(nil).Len(); got != 0 {
+		t.Errorf("Len()=%d want=0 for nil config", got)
+	}
+}
+
+func TestContextRoundTrip(t *testing.T) {
+	src := &Token{TenantID: "t1", AIQGAccountID: "a1", TokenID: "tok-1"}
+	ctx := WithToken(context.Background(), src)
+	got := FromContext(ctx)
+	if got != src {
+		t.Errorf("FromContext did not round-trip the token")
+	}
+
+	if FromContext(context.Background()) != nil {
+		t.Errorf("FromContext on bare ctx should return nil")
+	}
+	var nilCtx context.Context
+	if FromContext(nilCtx) != nil {
+		t.Errorf("FromContext(nil ctx) should return nil")
+	}
+}
+
+// Duplicate token entries — the LAST wins, documented behavior.
+func TestMapResolver_DuplicateLastWins(t *testing.T) {
+	r := NewMapResolver([]ConfigToken{
+		{Token: "tas_qg_live_dup", TenantID: "first-tenant", TokenID: "first"},
+		{Token: "tas_qg_live_dup", TenantID: "second-tenant", TokenID: "second"},
+	})
+	tok, err := r.Resolve(context.Background(), "tas_qg_live_dup")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if tok.TenantID != "second-tenant" {
+		t.Errorf("expected last to win, got TenantID=%q", tok.TenantID)
+	}
+}


### PR DESCRIPTION
## Summary
Adds `pkg/aiqg/tokens` with a `Resolver` interface + MVP `MapResolver` constructed from server config. Wires the resolver into the Path A middleware so AIQG events finally carry tenant attribution — without it every emitted event was unscoped, blocking tenant-scoped dashboards, per-account weighting, and Cost segmentation.

## Resolver semantics

| Resolve outcome | HTTP response | Event emitted? | Notes |
|---|---|---|---|
| Recognized token | passes through to handler | ✅ paired req/resp event with full tenant attribution | `source_app` from token claim; TAS-Source-App header overrides per spec §80 |
| Unknown token | 401 with `reason: token_unknown` | ❌ (spec §273: pre-validation auth failures emit no events) | Distinct from missing TAS-Auth so dashboards can break out genuine misconfigurations |
| Suspended account | 403 with `code: account_suspended` | ❌ | Token info logged for triage |
| Resolver error | 503 with `code: token_resolver_unavailable` | ❌ | Upstream-dependency failure; clients should retry |
| No Resolver configured | passes through, empty tenant fields | ✅ but unattributed | Incremental-rollout path |

## Architecture

```
pkg/aiqg/tokens/
├── Token       — resolved view: TokenID / TenantID / AIQGAccountID / SourceApp / Suspended
├── Resolver    — interface; production swap is one line (dashboard-backed)
├── MapResolver — in-memory MVP, built from config
├── ConfigToken — YAML-mappable shape (aiqg.tokens in server config)
└── WithToken / FromContext — ctx sidecar
```

`events.Build` gains a `TokenView` arg (matching the `AIQGHeadersView` / `RoutingView` anti-cycle pattern). The middleware projects `*tokens.Token` into `TokenView` before calling `Build`. SourceApp precedence (header wins over claim) is encoded inside `Build`.

Response events also carry denormalized `tenant_id` / `aiqg_account_id` per response-event.md's "denormalization rationale" — avoids a join on every dashboard query.

## Server config
```yaml
aiqg:
  enabled: true
  strict: false
  region: us-east
  tokens:
    - token_id: 7c8d5e2a-...   # FK to aiqg_token table (UUID)
      token: tas_qg_live_abc   # the actual bearer
      tenant_id: tenant-a
      aiqg_account_id: account-a
      source_app: billing-api-prod
      suspended: false
```

## Test plan
- [x] `make test` end-to-end clean
- [x] `pkg/aiqg/tokens`: hit / not-found / suspended / empty-string / Len / context round-trip / duplicate-last-wins
- [x] `pkg/aiqg/events`: TokenView fields populate request + response envelopes; SourceApp header-over-claim precedence
- [x] `internal/middleware`: Resolver-enriches-event happy path, source-app header override, 401 unknown token (with no emit), 403 suspended (with no emit), 503 resolver error, no-resolver permissive path

## Pending (future slices)
- Real backend `Resolver` against `aiqg-dashboard-be` (one-line swap)
- `clear.Cost` — unblocked once vendor/model + tenant are stamped (this PR closes the last input gap)
- K3s manifest update to flip `aiqg.enabled: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)