### PR TITLE
feat: enable AIQG ingress on K3s internal Deployment

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -138,3 +138,34 @@ security:
     max_request_size: 10485760  # 10MB
     max_message_length: 100000
     max_messages: 50
+
+# AIQG (AI Quality Gateway) ingress
+#
+# When enabled, mounts the AIQG middleware on the three completion routes
+# (/v1/chat/completions, /v1/completions, /v1/messages). Permissive mode
+# (strict: false) is the default: internal callers without TAS-Auth pass
+# through untouched; customer-facing requests with TAS-Auth + Authorization
+# enter Path A and emit paired CloudEvents via the LogEmitter → Loki path.
+#
+# Strict mode (strict: true) returns 401 on any request missing TAS-Auth or
+# Authorization — use only on a customer-facing ingress (gateway.aiqg.tas.io).
+#
+# Tokens: the in-memory MVP store. Omit the list (or omit the whole aiqg
+# block) and the middleware accepts any TAS-Auth as opaque — events emit
+# with empty tenant fields. Populate to enable tenant attribution before
+# the dashboard-backed Resolver ships.
+#
+# Env-var overrides: AIQG_ENABLED, AIQG_STRICT, AIQG_REGION.
+aiqg:
+  enabled: false
+  strict: false
+  region: ""
+  tokens: []
+  # Example token entry:
+  # tokens:
+  #   - token_id: "7c8d5e2a-1a4b-4d2c-9e3f-1234567890ab"   # UUID FK to aiqg_token table
+  #     token: "tas_qg_live_abc123"                          # the actual bearer
+  #     tenant_id: "tenant-a"
+  #     aiqg_account_id: "account-a"
+  #     source_app: "billing-api-prod"
+  #     suspended: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/security"
 	"github.com/tributary-ai/llm-router-waf/internal/server"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
 
 // Config represents the complete application configuration
@@ -23,6 +24,38 @@ type Config struct {
 	Logging    LoggingConfig    `yaml:"logging"`
 	Security   SecurityConfig   `yaml:"security"`
 	Gatekeeper GatekeeperConfig `yaml:"gatekeeper"`
+	AIQG       AIQGConfig       `yaml:"aiqg"`
+}
+
+// AIQGConfig configures the AIQG ingress feature. Empty/zero means
+// AIQG is disabled — the middleware doesn't mount and existing traffic
+// is completely unaffected. Flipping Enabled=true wires the timing
+// collector + header parser + Path A entry middleware onto the three
+// completion routes; the LogEmitter ships paired CloudEvents to logrus
+// (→ Loki via the existing Alloy pipeline).
+//
+// MVP Tokens is a small in-process list; production deployments swap
+// to a backend-client Resolver against aiqg-dashboard-be once that
+// service ships.
+type AIQGConfig struct {
+	Enabled bool                  `yaml:"enabled"`
+	Strict  bool                  `yaml:"strict"`
+	Region  string                `yaml:"region"`
+	Tokens  []AIQGTokenConfig     `yaml:"tokens"`
+}
+
+// AIQGTokenConfig is the in-memory MVP token entry. Mirrors
+// pkg/aiqg/tokens.ConfigToken so the conversion in ToServerConfig is
+// a straight field copy; defined here to keep the config package's
+// YAML schema self-describing without pulling pkg/aiqg/tokens into
+// callers that only need to parse config.
+type AIQGTokenConfig struct {
+	TokenID       string `yaml:"token_id"`
+	Token         string `yaml:"token"`
+	TenantID      string `yaml:"tenant_id"`
+	AIQGAccountID string `yaml:"aiqg_account_id"`
+	SourceApp     string `yaml:"source_app"`
+	Suspended     bool   `yaml:"suspended"`
 }
 
 // GatekeeperConfig holds content scanning configuration
@@ -357,6 +390,21 @@ func (c *Config) loadFromEnv() {
 			c.Gatekeeper.ScanTimeout = d
 		}
 	}
+
+	// AIQG ingress — env overrides for the simple scalars. Tokens are
+	// only loadable via the YAML config file (env vars are a poor
+	// shape for a list of structs); deployments that want a token
+	// store either ship a baked config.yaml or wait for the
+	// dashboard-backed Resolver slice.
+	if enabled := os.Getenv("AIQG_ENABLED"); enabled != "" {
+		c.AIQG.Enabled = enabled == "true" || enabled == "1"
+	}
+	if strict := os.Getenv("AIQG_STRICT"); strict != "" {
+		c.AIQG.Strict = strict == "true" || strict == "1"
+	}
+	if region := os.Getenv("AIQG_REGION"); region != "" {
+		c.AIQG.Region = region
+	}
 }
 
 // validate validates the configuration
@@ -429,7 +477,36 @@ func (c *Config) ToServerConfig() *server.ServerConfig {
 		WriteTimeout:   c.Server.WriteTimeout,
 		MaxHeaderBytes: c.Server.MaxHeaderBytes,
 		Security:       c.ToSecurityMiddlewareConfig(),
+		AIQG:           c.ToAIQGServerConfig(),
 	}
+}
+
+// ToAIQGServerConfig converts to server.AIQGServerConfig. Returns nil
+// when AIQG isn't enabled — server.NewServer treats that as "skip the
+// middleware entirely". Token list is copied through verbatim.
+func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
+	if !c.AIQG.Enabled {
+		return nil
+	}
+	out := &server.AIQGServerConfig{
+		Enabled: c.AIQG.Enabled,
+		Strict:  c.AIQG.Strict,
+		Region:  c.AIQG.Region,
+	}
+	if len(c.AIQG.Tokens) > 0 {
+		out.Tokens = make([]tokens.ConfigToken, len(c.AIQG.Tokens))
+		for i, t := range c.AIQG.Tokens {
+			out.Tokens[i] = tokens.ConfigToken{
+				TokenID:       t.TokenID,
+				Token:         t.Token,
+				TenantID:      t.TenantID,
+				AIQGAccountID: t.AIQGAccountID,
+				SourceApp:     t.SourceApp,
+				Suspended:     t.Suspended,
+			}
+		}
+	}
+	return out
 }
 
 // ToSecurityMiddlewareConfig converts to middleware.SecurityMiddlewareConfig

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -312,6 +312,87 @@ func TestConfig_ToServerConfig(t *testing.T) {
 	}
 }
 
+// AIQG disabled (the safe default) maps to a nil server.AIQGServerConfig
+// so the middleware doesn't mount.
+func TestConfig_ToAIQGServerConfig_Disabled(t *testing.T) {
+	cfg := &Config{}
+	cfg.setDefaults()
+	// AIQG.Enabled is false by default.
+
+	if got := cfg.ToAIQGServerConfig(); got != nil {
+		t.Errorf("expected nil AIQG config when disabled, got %#v", got)
+	}
+	if got := cfg.ToServerConfig().AIQG; got != nil {
+		t.Errorf("ToServerConfig should also yield nil AIQG when disabled, got %#v", got)
+	}
+}
+
+// When enabled, AIQG values + tokens copy through to the server config.
+func TestConfig_ToAIQGServerConfig_EnabledWithTokens(t *testing.T) {
+	cfg := &Config{}
+	cfg.setDefaults()
+	cfg.AIQG.Enabled = true
+	cfg.AIQG.Strict = true
+	cfg.AIQG.Region = "us-west"
+	cfg.AIQG.Tokens = []AIQGTokenConfig{
+		{
+			TokenID:       "tok_1",
+			Token:         "tas_qg_live_abc",
+			TenantID:      "tenant-a",
+			AIQGAccountID: "account-a",
+			SourceApp:     "billing",
+			Suspended:     false,
+		},
+		{
+			TokenID:   "tok_2",
+			Token:     "tas_qg_live_def",
+			Suspended: true,
+		},
+	}
+
+	got := cfg.ToAIQGServerConfig()
+	if got == nil {
+		t.Fatalf("expected non-nil AIQG config when enabled")
+	}
+	if !got.Enabled || !got.Strict {
+		t.Errorf("flags not propagated: enabled=%v strict=%v", got.Enabled, got.Strict)
+	}
+	if got.Region != "us-west" {
+		t.Errorf("Region=%q", got.Region)
+	}
+	if len(got.Tokens) != 2 {
+		t.Fatalf("token count=%d want=2", len(got.Tokens))
+	}
+	if got.Tokens[0].Token != "tas_qg_live_abc" || got.Tokens[0].TenantID != "tenant-a" {
+		t.Errorf("token[0] mismatch: %#v", got.Tokens[0])
+	}
+	if !got.Tokens[1].Suspended {
+		t.Errorf("token[1].Suspended not propagated")
+	}
+}
+
+// Env-var overrides flip the YAML defaults.
+func TestLoadConfig_AIQGEnvOverrides(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key") // satisfy provider validation
+	t.Setenv("AIQG_ENABLED", "true")
+	t.Setenv("AIQG_STRICT", "1")
+	t.Setenv("AIQG_REGION", "eu")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.AIQG.Enabled {
+		t.Errorf("AIQG_ENABLED=true did not flip Enabled")
+	}
+	if !cfg.AIQG.Strict {
+		t.Errorf("AIQG_STRICT=1 did not flip Strict")
+	}
+	if cfg.AIQG.Region != "eu" {
+		t.Errorf("Region=%q", cfg.AIQG.Region)
+	}
+}
+
 func TestConfig_SaveToFile(t *testing.T) {
 	// Create a config
 	cfg := &Config{}

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -71,3 +71,15 @@ data:
   FEATURE_REQUEST_DEDUPLICATION: "true"
   FEATURE_OPENAI_ASSISTANTS: "true"
   FEATURE_MULTIMODAL_OPTIMIZATION: "true"
+
+  # AIQG (AI Quality Gateway) ingress.
+  # Permissive mode on the internal K3s ingress — internal callers without
+  # a TAS-Auth header pass through unchanged. Customer-facing requests
+  # (with TAS-Auth + Authorization) enter Path A: timing collector +
+  # parsed TAS-* headers attached to ctx, paired CloudEvents emitted on
+  # response completion via LogEmitter → logrus → Loki.
+  # Set AIQG_STRICT=true and route a separate Ingress to this Deployment
+  # to host the customer-facing gateway.aiqg.tas.io endpoint.
+  AIQG_ENABLED: "true"
+  AIQG_STRICT: "false"
+  AIQG_REGION: "us-east"


### PR DESCRIPTION
## Summary
This slice does **two things** that together flip AIQG on in production:

1. **Closes the config-loader gap.** `Config.AIQG` was missing from `internal/config` — `ToServerConfig` was dropping `server.AIQG` on the floor. Without this, the `AIQGServerConfig` field added in PR #19 was orphaned and unreachable from production startup.
2. **Sets `AIQG_ENABLED=true`** on the K3s configmap. Internal traffic flows through the Path A middleware in permissive mode immediately on next rollout.

## Config changes

### `internal/config/config.go`
- New `Config.AIQG` struct mirroring `server.AIQGServerConfig` (Enabled / Strict / Region / Tokens).
- New `ToAIQGServerConfig()` — returns nil when disabled (safe default), copies Tokens through verbatim when enabled.
- `ToServerConfig()` now populates `server.AIQG` via the new projection.
- Env-var overrides: `AIQG_ENABLED`, `AIQG_STRICT`, `AIQG_REGION` (Tokens are YAML-only — env vars are a poor shape for a list of structs).

### `configs/config.yaml`
Documented `aiqg:` block with the four scalars and a commented example token entry (so a YAML-driven deployment doesn't accidentally hardcode customer tokens).

### `k8s/configmap.yaml`
```yaml
AIQG_ENABLED: "true"
AIQG_STRICT: "false"
AIQG_REGION: "us-east"
```

Strict=false on the internal ingress means internal callers without `TAS-Auth` pass through untouched — **zero behavior change** for today's traffic.

## What this lights up in production

| Behavior | Before this PR | After |
|---|---|---|
| Internal completion request | unchanged | `TimingCollector` + paired CloudEvents → LogEmitter → Loki |
| Customer request (TAS-Auth + Authorization) | unchanged | full TAS-* header parsing, AIQG event emission |
| `clear.Latency` scoring on real traffic | never | every AIQG-mode request |
| Tenant attribution | n/a | empty fields (no token store yet — see "deliberately out of scope") |

## Deliberately out of scope
- **Token list** is not in the K8s configmap. Customer tokens belong in a Secret, not a ConfigMap. Without a Resolver the middleware accepts any TAS-Auth as opaque and emits events with empty tenant fields — the documented incremental-rollout path from PR #22. A follow-up slice will add a `Secret`-backed token list or the dashboard-backed Resolver.
- **Strict-mode ingress** for `gateway.aiqg.tas.io` — needs a separate Ingress resource + DNS. Follow-up when the customer-facing endpoint goes live.

## Test plan
- [x] `make test` end-to-end clean (16 packages, every one ok or `[no test files]`)
- [x] `TestConfig_ToAIQGServerConfig_Disabled` — disabled (default) maps to nil server.AIQG
- [x] `TestConfig_ToAIQGServerConfig_EnabledWithTokens` — enabled values + 2-token list copy through verbatim, including Suspended flag
- [x] `TestLoadConfig_AIQGEnvOverrides` — AIQG_ENABLED=true / AIQG_STRICT=1 / AIQG_REGION=eu all flip the loaded config
- [ ] Smoke-test on the actual K3s cluster — deferred to the deploy. After rollout, query Loki: `{namespace="tas-llm-router", container="llm-router"} | json | ce_type="com.tas.aiqg.response.v1"` should start returning events on the next /v1/chat/completions hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)