### PR TITLE
feat: fill the clear.Cost dimension from vendor token usage

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -221,10 +221,13 @@ func routingView(r *Routing) events.RoutingView {
 	}
 	s := r.Snapshot()
 	return events.RoutingView{
-		Vendor:       s.Vendor,
-		Model:        s.Model,
-		Streaming:    s.Streaming,
-		StreamingSet: s.StreamingSet,
+		Vendor:           s.Vendor,
+		Model:            s.Model,
+		Streaming:        s.Streaming,
+		StreamingSet:     s.StreamingSet,
+		PromptTokens:     s.PromptTokens,
+		CompletionTokens: s.CompletionTokens,
+		UsageSet:         s.UsageSet,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -21,11 +21,14 @@ import (
 // can't accidentally overwrite an earlier decision with a fallback
 // guess.
 type Routing struct {
-	mu        sync.Mutex
-	vendor    string
-	model     string
-	streaming bool
-	streamSet bool
+	mu               sync.Mutex
+	vendor           string
+	model            string
+	streaming        bool
+	streamSet        bool
+	promptTokens     int
+	completionTokens int
+	usageSet         bool
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -44,6 +47,15 @@ type RoutingSnapshot struct {
 	// from "never stamped" — the events package uses this to decide
 	// whether to fall back to its URL-query heuristic.
 	StreamingSet bool
+
+	// Token usage from the vendor response. UsageSet distinguishes
+	// "vendor returned 0 tokens" (which is legitimate for some
+	// finish_reason=content_filter responses) from "vendor never
+	// returned a usage block" (the events package emits the former
+	// as `prompt_tokens: 0`, the latter omits the field).
+	PromptTokens     int
+	CompletionTokens int
+	UsageSet         bool
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -51,10 +63,13 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return RoutingSnapshot{
-		Vendor:       r.vendor,
-		Model:        r.model,
-		Streaming:    r.streaming,
-		StreamingSet: r.streamSet,
+		Vendor:           r.vendor,
+		Model:            r.model,
+		Streaming:        r.streaming,
+		StreamingSet:     r.streamSet,
+		PromptTokens:     r.promptTokens,
+		CompletionTokens: r.completionTokens,
+		UsageSet:         r.usageSet,
 	}
 }
 
@@ -125,5 +140,26 @@ func StampStreaming(ctx context.Context, streaming bool) {
 	if !r.streamSet {
 		r.streaming = streaming
 		r.streamSet = true
+	}
+}
+
+// StampTokenUsage records the vendor-reported token counts. Same
+// first-write-wins semantic as the other stampers — for streaming
+// responses, the final chunk's usage is the authoritative value,
+// and subsequent fallback paths must not overwrite it. Calling with
+// both counts zero is still treated as a valid stamp (UsageSet flips
+// true) so the event distinguishes "vendor returned 0 tokens" from
+// "vendor never returned a usage block".
+func StampTokenUsage(ctx context.Context, promptTokens, completionTokens int) {
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.usageSet {
+		r.promptTokens = promptTokens
+		r.completionTokens = completionTokens
+		r.usageSet = true
 	}
 }

--- a/internal/middleware/aiqg_routing_test.go
+++ b/internal/middleware/aiqg_routing_test.go
@@ -90,6 +90,44 @@ func TestRouting_StreamingSetSemantic(t *testing.T) {
 	}
 }
 
+func TestRouting_StampTokenUsage(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	// Before stamping: UsageSet=false, counts=0 (distinguishable from "vendor returned 0").
+	if s := r.Snapshot(); s.UsageSet {
+		t.Errorf("UsageSet=true before stamping")
+	}
+
+	StampTokenUsage(ctx, 1000, 500)
+	s := r.Snapshot()
+	if !s.UsageSet {
+		t.Errorf("UsageSet=false after stamping")
+	}
+	if s.PromptTokens != 1000 || s.CompletionTokens != 500 {
+		t.Errorf("counts: prompt=%d completion=%d", s.PromptTokens, s.CompletionTokens)
+	}
+
+	// First-write-wins: a later fallback path must not overwrite.
+	StampTokenUsage(ctx, 9999, 9999)
+	s2 := r.Snapshot()
+	if s2.PromptTokens != 1000 || s2.CompletionTokens != 500 {
+		t.Errorf("StampTokenUsage not idempotent: %#v", s2)
+	}
+}
+
+// Stamping (0, 0) is a valid stamp — represents the legitimate case of
+// a content_filter response with no completion. UsageSet must flip true.
+func TestRouting_StampTokenUsageZeroIsValid(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+	StampTokenUsage(ctx, 0, 0)
+	s := r.Snapshot()
+	if !s.UsageSet {
+		t.Errorf("UsageSet should be true after explicit (0,0) stamp")
+	}
+}
+
 func TestRouting_ConcurrentStamps(t *testing.T) {
 	r := NewRouting()
 	ctx := WithRouting(context.Background(), r)

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -556,6 +556,51 @@ func TestAIQG_NoResolverAcceptsAnyToken(t *testing.T) {
 	}
 }
 
+// Stamping vendor + model + token usage from the handler must produce
+// a populated TokenAccounting on the response event and a non-nil
+// CLEAR.Cost score. End-to-end test of the second CLEAR dimension.
+func TestAIQG_TokenUsageStampedReachesEventAndCost(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampVendor(r.Context(), "openai")
+		StampModel(r.Context(), "gpt-4o-mini")
+		StampTokenUsage(r.Context(), 1000, 500)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	if em.Len() != 1 {
+		t.Fatalf("emit count=%d want=1", em.Len())
+	}
+	rd := em.Responses()[0].Data
+
+	if rd.TokenAccounting == nil {
+		t.Fatalf("TokenAccounting nil despite StampTokenUsage")
+	}
+	if rd.TokenAccounting.PromptTokens != 1000 || rd.TokenAccounting.CompletionTokens != 500 {
+		t.Errorf("token counts: prompt=%d completion=%d", rd.TokenAccounting.PromptTokens, rd.TokenAccounting.CompletionTokens)
+	}
+	if rd.TokenAccounting.TotalTokens != 1500 {
+		t.Errorf("total_tokens=%d want=1500", rd.TokenAccounting.TotalTokens)
+	}
+	if rd.TokenAccounting.TotalCostUSD <= 0 {
+		t.Errorf("TotalCostUSD=%v want>0 for priced model", rd.TokenAccounting.TotalCostUSD)
+	}
+	if rd.TokenAccounting.ModelPricingVersion == "" {
+		t.Errorf("ModelPricingVersion empty")
+	}
+	if rd.CLEAR.Cost == nil {
+		t.Fatalf("CLEAR.Cost nil despite priced model + usage stamp")
+	}
+}
+
 // Vendor/Model stamps made by the downstream handler must reach the
 // emitted event. Proves the Routing sidecar (attached by middleware) +
 // the deferred snapshot read both work end-to-end.
@@ -628,9 +673,11 @@ func TestAIQG_EmittedEventCarriesCLEARScores(t *testing.T) {
 	if respEnv.Data.CLEAR.Composite == nil {
 		t.Errorf("CLEAR.Composite nil — should equal Latency when only Latency is scored")
 	}
-	// MVP: other dimensions remain nil until their respective slices land.
+	// This handler doesn't stamp vendor/model/usage, so the Cost path
+	// stays nil here even though it's wired. See
+	// TestAIQG_TokenUsageStampedReachesEventAndCost for the populated case.
 	if respEnv.Data.CLEAR.Cost != nil {
-		t.Errorf("CLEAR.Cost should be nil at MVP (token-accounting not plumbed)")
+		t.Errorf("CLEAR.Cost should be nil when no usage stamped, got %d", *respEnv.Data.CLEAR.Cost)
 	}
 	if respEnv.Data.CLEAR.Efficacy != nil {
 		t.Errorf("CLEAR.Efficacy should be nil at MVP (response body not captured)")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -428,6 +428,13 @@ func (s *Server) handleNonStreamingCompletion(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// AIQG: stamp the vendor-reported token usage onto the routing
+	// sidecar so the response event carries TokenAccounting + the
+	// clear.Cost dimension scores. No-op outside AIQG mode.
+	if resp.Usage != nil {
+		middleware.StampTokenUsage(r.Context(), resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+	}
+
 	// Add routing metadata to response
 	if resp.RouterMetadata == nil {
 		resp.RouterMetadata = metadata
@@ -469,6 +476,14 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 
 	// Stream chunks
 	for chunk := range chunks {
+		// AIQG: stamp vendor token usage from the final chunk. OpenAI
+		// emits this on the last chunk when stream_options.include_usage
+		// is set; Anthropic carries it in message_delta. StampTokenUsage
+		// is first-write-wins so safe to call on every chunk.
+		if chunk.Usage != nil {
+			middleware.StampTokenUsage(r.Context(), chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
+		}
+
 		data, err := json.Marshal(chunk)
 		if err != nil {
 			s.logger.WithError(err).Error("Failed to marshal chunk")
@@ -522,6 +537,12 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 				return
 			}
 		}
+	}
+
+	// AIQG: stamp the vendor-reported token usage (same as the non-retry
+	// path) so the response event carries TokenAccounting + Cost score.
+	if resp.Usage != nil {
+		middleware.StampTokenUsage(r.Context(), resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
 	}
 
 	// Add routing metadata to response
@@ -583,6 +604,14 @@ func (s *Server) handleStreamingCompletionWithRetry(w http.ResponseWriter, r *ht
 
 	// Stream chunks
 	for chunk := range chunks {
+		// AIQG: stamp vendor token usage from the final chunk. OpenAI
+		// emits this on the last chunk when stream_options.include_usage
+		// is set; Anthropic carries it in message_delta. StampTokenUsage
+		// is first-write-wins so safe to call on every chunk.
+		if chunk.Usage != nil {
+			middleware.StampTokenUsage(r.Context(), chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
+		}
+
 		data, err := json.Marshal(chunk)
 		if err != nil {
 			s.logger.WithError(err).Error("Failed to marshal chunk")

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -38,6 +38,15 @@ type RoutingView struct {
 	Model        string
 	Streaming    bool
 	StreamingSet bool
+
+	// Token usage from the vendor response (stamped by handlers via
+	// middleware.StampTokenUsage). UsageSet distinguishes "vendor
+	// returned 0 tokens" (a legitimate value for content_filter
+	// finish-reason) from "vendor never returned a usage block"
+	// (events omit TokenAccounting entirely in the latter case).
+	PromptTokens     int
+	CompletionTokens int
+	UsageSet         bool
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -159,6 +168,38 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		LifecycleState:            LifecyclePairedWithResponse,
 	}
 
+	// Build the clear.Input once; reuse for the embedded TokenAccounting
+	// dollar cost so Scores and the per-event accounting agree on prices.
+	clearInput := clear.Input{
+		EndToEndMs:        snap.EndToEndMs,
+		GatewayOverheadMs: snap.GatewayOverheadMs,
+		VendorTTFTMs:      snap.VendorTTFTMs,
+		Workflow:          headers.Workflow,
+		HTTPStatus:        opts.HTTPStatus,
+		Vendor:            routing.Vendor,
+		Model:             routing.Model,
+	}
+	var tokenAcct *TokenAccounting
+	if routing.UsageSet {
+		prompt := routing.PromptTokens
+		completion := routing.CompletionTokens
+		clearInput.PromptTokens = &prompt
+		clearInput.CompletionTokens = &completion
+		inputRate, outputRate, priced := clear.LookupPricing(routing.Vendor, routing.Model)
+		ta := &TokenAccounting{
+			PromptTokens:     prompt,
+			CompletionTokens: completion,
+			TotalTokens:      prompt + completion,
+		}
+		if priced {
+			ta.InputCostUSD = (float64(prompt) / 1000.0) * inputRate
+			ta.OutputCostUSD = (float64(completion) / 1000.0) * outputRate
+			ta.TotalCostUSD = ta.InputCostUSD + ta.OutputCostUSD
+			ta.ModelPricingVersion = clear.PricingVersion
+		}
+		tokenAcct = ta
+	}
+
 	respEvent := ResponseEvent{
 		ResponseEventID:   respID,
 		RequestEventID:    reqID,
@@ -172,15 +213,10 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		ChunkCount:        snap.ChunkCount,
 		ContentChunkCount: snap.ContentChunkCount,
 		EventTimestamps:   snap,
-		CLEAR: clear.Compute(clear.Input{
-			EndToEndMs:        snap.EndToEndMs,
-			GatewayOverheadMs: snap.GatewayOverheadMs,
-			VendorTTFTMs:      snap.VendorTTFTMs,
-			Workflow:          headers.Workflow,
-			HTTPStatus:        opts.HTTPStatus,
-		}),
-		ScoringVersion: ScoringVersion,
-		GatewayVersion: GatewayVersion,
+		TokenAccounting:   tokenAcct,
+		CLEAR:             clear.Compute(clearInput),
+		ScoringVersion:    ScoringVersion,
+		GatewayVersion:    GatewayVersion,
 	}
 
 	reqEnv := RequestEnvelope{

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -137,6 +137,11 @@ type ResponseEvent struct {
 	// Embedded timing block — see event-timestamps.md
 	EventTimestamps instrumentation.Snapshot `json:"event_timestamps"`
 
+	// Embedded token-accounting block — see token-accounting.md.
+	// Omitted when the vendor returned no usage data (UsageSet=false
+	// on the routing snapshot) — distinct from "0 tokens used".
+	TokenAccounting *TokenAccounting `json:"token_accounting,omitempty"`
+
 	// CLEAR scores — populated by pkg/clear.Compute(). A nil *Scores
 	// (rather than a *Scores with all-nil dimension fields) means the
 	// scorer wasn't run at all, which today only happens on the noop
@@ -147,6 +152,25 @@ type ResponseEvent struct {
 	// Versioning
 	ScoringVersion string `json:"scoring_version"`
 	GatewayVersion string `json:"gateway_version"`
+}
+
+// TokenAccounting carries the vendor-reported token counts and the
+// gateway-computed dollar costs. Mirrors aether-shared/data-models/aiqg/
+// token-accounting.md.
+//
+// Dollar costs are zero when the vendor:model pair isn't in the
+// pkg/clear pricing table — distinct from "request used zero tokens"
+// (in which case the *Tokens fields are zero too). The
+// ModelPricingVersion stamps the pricing-table revision used so a
+// Spark re-score job can identify rows scored under stale rates.
+type TokenAccounting struct {
+	PromptTokens        int     `json:"prompt_tokens"`
+	CompletionTokens    int     `json:"completion_tokens"`
+	TotalTokens         int     `json:"total_tokens"`
+	InputCostUSD        float64 `json:"input_cost_usd"`
+	OutputCostUSD       float64 `json:"output_cost_usd"`
+	TotalCostUSD        float64 `json:"total_cost_usd"`
+	ModelPricingVersion string  `json:"model_pricing_version,omitempty"`
 }
 
 // Status enum values for ResponseEvent.Status.

--- a/pkg/clear/clear.go
+++ b/pkg/clear/clear.go
@@ -71,8 +71,16 @@ type Input struct {
 	Workflow   string // CLEAR workflow type (rag, agentic, code_generation, ...)
 	HTTPStatus int    // 0 means gateway never wrote a response
 
+	// From the routing decision + vendor response. Vendor/Model drive
+	// pricing lookup; the *int token counts distinguish "not captured"
+	// (nil — vendor didn't return usage) from "captured as zero"
+	// (e.g. policy_blocked emitted no completion).
+	Vendor           string
+	Model            string
+	PromptTokens     *int
+	CompletionTokens *int
+
 	// Future-slice inputs (left for forward compatibility):
-	//   PromptTokens, CompletionTokens *int       // Cost
 	//   ResponseBodyValid              *bool      // Efficacy structural
 	//   ComplianceFindingCount         *int       // Assurance
 	//   RetryObserved                  *bool      // Reliability
@@ -91,7 +99,8 @@ type Input struct {
 func Compute(in Input) *Scores {
 	s := &Scores{
 		Latency: scoreLatency(in),
-		// Cost/Efficacy/Assurance/Reliability remain nil for MVP.
+		Cost:    scoreCost(in),
+		// Efficacy/Assurance/Reliability remain nil — future slices.
 	}
 	s.Composite = composite(s)
 	if s.Composite != nil {

--- a/pkg/clear/clear_test.go
+++ b/pkg/clear/clear_test.go
@@ -127,7 +127,7 @@ func TestComputeMVPHappyPath(t *testing.T) {
 		t.Errorf("Latency=%v want=100", s.Latency)
 	}
 	if s.Cost != nil {
-		t.Errorf("Cost should be nil in MVP (not yet plumbed), got %d", *s.Cost)
+		t.Errorf("Cost should be nil when no vendor/model/tokens supplied, got %d", *s.Cost)
 	}
 	if s.Efficacy != nil {
 		t.Errorf("Efficacy should be nil in MVP")

--- a/pkg/clear/cost.go
+++ b/pkg/clear/cost.go
@@ -1,0 +1,129 @@
+package clear
+
+import "math"
+
+// PricingVersion is the identifier of the per-model pricing table baked
+// into this binary. Bump when any rate changes so Spark re-score jobs
+// can identify rows scored under stale pricing and recompute.
+//
+// Format: `pricing-vYYYY-MM-DD` reflecting the publication date of the
+// rates encoded in modelPricing.
+const PricingVersion = "pricing-v2026-06-01"
+
+// modelPricingEntry is the input/output rate pair for one vendor:model.
+// Rates are USD per 1,000 tokens (matches source-spec §2.1.3's CNA/CPS
+// arithmetic). Vendor APIs typically publish rates per million; we
+// divide by 1,000 here so the per-1k math is straight multiplication.
+type modelPricingEntry struct {
+	InputCostPer1K  float64
+	OutputCostPer1K float64
+}
+
+// modelPricing is a sparse table of vendor:model → rate. Unknown
+// combinations skip Cost scoring (the dimension stays nil rather than
+// scoring a guess). The table is intentionally short — adding a model
+// requires a deliberate edit + PricingVersion bump.
+//
+// Rates are mid-2026 public list prices. Customer-negotiated rates are
+// out of scope for the in-binary table; the dashboard-backed Resolver
+// slice will eventually pull per-account overrides.
+var modelPricing = map[string]modelPricingEntry{
+	// OpenAI
+	"openai:gpt-4o-mini":           {InputCostPer1K: 0.00015, OutputCostPer1K: 0.00060},
+	"openai:gpt-4o":                {InputCostPer1K: 0.00250, OutputCostPer1K: 0.01000},
+	"openai:gpt-4-turbo":           {InputCostPer1K: 0.01000, OutputCostPer1K: 0.03000},
+	"openai:gpt-3.5-turbo":         {InputCostPer1K: 0.00050, OutputCostPer1K: 0.00150},
+
+	// Anthropic
+	"anthropic:claude-3-7-sonnet-20250219": {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
+	"anthropic:claude-3-5-sonnet-20241022": {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
+	"anthropic:claude-3-5-haiku-20241022":  {InputCostPer1K: 0.00080, OutputCostPer1K: 0.00400},
+	"anthropic:claude-3-opus-20240229":     {InputCostPer1K: 0.01500, OutputCostPer1K: 0.07500},
+	"anthropic:claude-3-haiku-20240307":    {InputCostPer1K: 0.00025, OutputCostPer1K: 0.00125},
+}
+
+// LookupPricing returns the rates for a vendor:model pair, or false if
+// the combination isn't in the table. Exported so events.Build can
+// populate the per-event token-accounting block (which carries the
+// dollar costs separately from the Cost score).
+func LookupPricing(vendor, model string) (inputPer1K, outputPer1K float64, ok bool) {
+	if vendor == "" || model == "" {
+		return 0, 0, false
+	}
+	p, ok := modelPricing[vendor+":"+model]
+	if !ok {
+		return 0, 0, false
+	}
+	return p.InputCostPer1K, p.OutputCostPer1K, true
+}
+
+// DollarCost computes the total USD cost of a request given token
+// counts and the model's rates. Returns 0 (and ok=false) when pricing
+// isn't known for the vendor:model pair — callers should treat that
+// as "cost unknown, do not score".
+func DollarCost(vendor, model string, promptTokens, completionTokens int) (cost float64, ok bool) {
+	inputRate, outputRate, found := LookupPricing(vendor, model)
+	if !found {
+		return 0, false
+	}
+	cost = (float64(promptTokens)/1000.0)*inputRate + (float64(completionTokens)/1000.0)*outputRate
+	return cost, true
+}
+
+// scoreCost converts the request's USD cost into a 0-100 score with a
+// logarithmic curve. The boundary points are chosen so the score maps
+// to source-spec §2.1.3's Healthy / Marginal / Failing tiers at round
+// cost values:
+//
+//	$0.001 / request → 100 (Healthy)
+//	$0.01  / request → 75  (Healthy / Marginal boundary)
+//	$0.10  / request → 50  (Marginal / Failing boundary)
+//	$1.00  / request → 25
+//	$10+   / request → 0
+//
+// Formula: score = 100 − 25 × log10(cost_usd × 1000), clamped to [0,100].
+// The 25-per-decade slope spans 4 orders of magnitude — wide enough to
+// distinguish a $0.001 classifier call from a $1 long-context summary
+// without collapsing every score into the same band.
+//
+// Returns nil when:
+//   - HTTPStatus is 0 (gateway-blocked; cost is meaningless)
+//   - Prompt+completion token counts are both zero (no usage to score)
+//   - Pricing for the vendor:model isn't in the table
+func scoreCost(in Input) *Score {
+	if in.HTTPStatus == 0 {
+		return nil
+	}
+	if in.PromptTokens == nil && in.CompletionTokens == nil {
+		return nil
+	}
+	prompt, completion := 0, 0
+	if in.PromptTokens != nil {
+		prompt = *in.PromptTokens
+	}
+	if in.CompletionTokens != nil {
+		completion = *in.CompletionTokens
+	}
+	if prompt == 0 && completion == 0 {
+		return nil
+	}
+	cost, ok := DollarCost(in.Vendor, in.Model, prompt, completion)
+	if !ok {
+		return nil
+	}
+	// log10(0) is -Inf; guard against pricing-table entries with both
+	// rates at zero (which shouldn't exist but defensive code is cheap).
+	if cost <= 0 {
+		s := Score(100)
+		return &s
+	}
+	score := 100.0 - 25.0*math.Log10(cost*1000.0)
+	switch {
+	case score > 100:
+		score = 100
+	case score < 0:
+		score = 0
+	}
+	s := Score(score)
+	return &s
+}

--- a/pkg/clear/cost_test.go
+++ b/pkg/clear/cost_test.go
@@ -1,0 +1,144 @@
+package clear
+
+import "testing"
+
+func intP(v int) *int { return &v }
+
+func TestLookupPricing_Known(t *testing.T) {
+	in, out, ok := LookupPricing("openai", "gpt-4o-mini")
+	if !ok {
+		t.Fatalf("expected gpt-4o-mini to be priced")
+	}
+	if in != 0.00015 || out != 0.00060 {
+		t.Errorf("gpt-4o-mini rates: in=%v out=%v", in, out)
+	}
+}
+
+func TestLookupPricing_UnknownReturnsFalse(t *testing.T) {
+	for _, c := range []struct{ vendor, model string }{
+		{"openai", "gpt-99-imaginary"},
+		{"unknown-vendor", "gpt-4o-mini"},
+		{"", "gpt-4o-mini"},
+		{"openai", ""},
+		{"", ""},
+	} {
+		_, _, ok := LookupPricing(c.vendor, c.model)
+		if ok {
+			t.Errorf("expected !ok for %q:%q", c.vendor, c.model)
+		}
+	}
+}
+
+func TestDollarCost(t *testing.T) {
+	// gpt-4o-mini: input $0.00015/1k, output $0.00060/1k
+	// 1000 prompt + 500 completion = $0.00015 + $0.00030 = $0.00045
+	cost, ok := DollarCost("openai", "gpt-4o-mini", 1000, 500)
+	if !ok {
+		t.Fatalf("expected priced")
+	}
+	want := 0.00045
+	if cost < want*0.999 || cost > want*1.001 {
+		t.Errorf("DollarCost=%v want=%v", cost, want)
+	}
+
+	if _, ok := DollarCost("unknown", "model", 100, 100); ok {
+		t.Errorf("unknown model should not price")
+	}
+}
+
+func TestScoreCost_Curve(t *testing.T) {
+	// Boundary checks for the documented curve points using gpt-4o-mini
+	// rates. We feed prompt-only tokens (output rate 4× input) so the
+	// math stays predictable: cost = prompt_tokens × 0.00015/1000.
+	//
+	//   cost $0.001   → 100  → need promptTokens ≈ 6,667
+	//   cost $0.01    → 75   → ≈ 66,667
+	//   cost $0.10    → 50   → ≈ 666,667
+	//   cost $1.00    → 25   → ≈ 6,666,667
+	//   cost $10+     → 0    → ≥ 66,666,667
+	cases := []struct {
+		name   string
+		prompt int
+		wantLo Score
+		wantHi Score
+	}{
+		{"sub_001_dollar_clamps_to_100", 100, 100, 100},
+		{"around_001_dollar", 6667, 99, 100},
+		{"around_01_dollar", 66_667, 74, 76},
+		{"around_10_cents", 666_667, 49, 51},
+		{"around_1_dollar", 6_666_667, 24, 26},
+		{"around_10_dollars_clamps_to_0", 66_666_667, 0, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := scoreCost(Input{
+				Vendor:       "openai",
+				Model:        "gpt-4o-mini",
+				PromptTokens: intP(c.prompt),
+				HTTPStatus:   200,
+			})
+			if s == nil {
+				t.Fatalf("score was nil")
+			}
+			if *s < c.wantLo || *s > c.wantHi {
+				t.Errorf("score=%d want in [%d,%d]", *s, c.wantLo, c.wantHi)
+			}
+		})
+	}
+}
+
+func TestScoreCost_NilCases(t *testing.T) {
+	// HTTPStatus=0 (gateway-blocked) — must skip.
+	if s := scoreCost(Input{Vendor: "openai", Model: "gpt-4o-mini", PromptTokens: intP(100), HTTPStatus: 0}); s != nil {
+		t.Errorf("HTTPStatus=0 should nil out cost score, got %d", *s)
+	}
+	// Both token counts nil — must skip.
+	if s := scoreCost(Input{Vendor: "openai", Model: "gpt-4o-mini", HTTPStatus: 200}); s != nil {
+		t.Errorf("nil token counts should nil out, got %d", *s)
+	}
+	// Both counts zero — also skip (no usage to score).
+	zero := 0
+	if s := scoreCost(Input{Vendor: "openai", Model: "gpt-4o-mini", PromptTokens: &zero, CompletionTokens: &zero, HTTPStatus: 200}); s != nil {
+		t.Errorf("0+0 tokens should nil out, got %d", *s)
+	}
+	// Unknown vendor:model — must skip (don't guess).
+	if s := scoreCost(Input{Vendor: "openai", Model: "made-up-2026", PromptTokens: intP(1000), HTTPStatus: 200}); s != nil {
+		t.Errorf("unknown model should nil out, got %d", *s)
+	}
+}
+
+func TestPricingVersionPresent(t *testing.T) {
+	if PricingVersion == "" {
+		t.Fatalf("PricingVersion must not be empty — re-score jobs filter on it")
+	}
+}
+
+// Compute end-to-end now populates Cost when inputs are present.
+func TestCompute_PopulatesCostAndComposite(t *testing.T) {
+	s := Compute(Input{
+		EndToEndMs:       ptr64(2500), // under rag SLA → Latency=100
+		Workflow:         "rag",
+		HTTPStatus:       200,
+		Vendor:           "openai",
+		Model:            "gpt-4o-mini",
+		PromptTokens:     intP(1000),
+		CompletionTokens: intP(500),
+	})
+	if s.Latency == nil || *s.Latency != 100 {
+		t.Errorf("Latency=%v want=100", s.Latency)
+	}
+	if s.Cost == nil {
+		t.Fatalf("Cost nil despite vendor/model/tokens")
+	}
+	// 1k+0.5k for gpt-4o-mini = $0.00045 → ~$0.0005, well in Healthy.
+	if *s.Cost < 90 {
+		t.Errorf("Cost=%d, expected >=90 for cheap request", *s.Cost)
+	}
+	if s.Composite == nil {
+		t.Fatalf("Composite nil")
+	}
+	// (Latency + Cost) / 2 ≈ (100 + ~108-clamped-to-100) / 2 = 100
+	if *s.Composite != 100 {
+		t.Errorf("Composite=%d want=100", *s.Composite)
+	}
+}


### PR DESCRIPTION
## Summary
Wires the second CLEAR dimension end-to-end. Now that vendor / model / tenant inputs all land on AIQG events, Cost scoring can finally compute.

After this slice, every AIQG-mode completion request with a known vendor:model emits **both** Latency and Cost scores plus a TokenAccounting block carrying the dollar cost. Composite averages across both dimensions.

## New pricing table
`pkg/clear/cost.go` ships a sparse `vendor:model → (input_rate, output_rate)` map covering the 9 OpenAI / Anthropic models in active use at mid-2026 list prices. Unknown combinations skip Cost (stays nil rather than guess). Every emitted event carries `PricingVersion` so a future Spark re-score job can identify rows priced under stale rates.

| Model | Input $/1k | Output $/1k |
|---|---|---|
| openai:gpt-4o-mini | 0.00015 | 0.00060 |
| openai:gpt-4o | 0.00250 | 0.01000 |
| openai:gpt-4-turbo | 0.01000 | 0.03000 |
| openai:gpt-3.5-turbo | 0.00050 | 0.00150 |
| anthropic:claude-3-7-sonnet-20250219 | 0.00300 | 0.01500 |
| anthropic:claude-3-5-sonnet-20241022 | 0.00300 | 0.01500 |
| anthropic:claude-3-5-haiku-20241022 | 0.00080 | 0.00400 |
| anthropic:claude-3-opus-20240229 | 0.01500 | 0.07500 |
| anthropic:claude-3-haiku-20240307 | 0.00025 | 0.00125 |

## Cost scoring curve
Logarithmic decay mapping per-request USD cost to a 0-100 score. Boundary points line up with source-spec §2.1.3's Healthy / Marginal / Failing tiers at round cost values:

| Per-request cost | Score | Tier |
|---|---|---|
| ≤ $0.001 | 100 | Healthy |
| $0.01 | 75 | Healthy / Marginal boundary |
| $0.10 | 50 | Marginal / Failing boundary |
| $1.00 | 25 | |
| ≥ $10 | 0 | Failing |

Formula: `score = 100 − 25 × log10(cost_usd × 1000)`, clamped. Returns nil when HTTPStatus=0 (gateway-blocked, cost meaningless), token counts are missing, or pricing isn't known for the vendor:model.

## TokenAccounting on ResponseEvent
```json
"token_accounting": {
  "prompt_tokens": 1000,
  "completion_tokens": 500,
  "total_tokens": 1500,
  "input_cost_usd": 0.00015,
  "output_cost_usd": 0.00030,
  "total_cost_usd": 0.00045,
  "model_pricing_version": "pricing-v2026-06-01"
}
```
Mirrors token-accounting.md. Omitted entirely when the vendor returned no usage block.

## Plumbing
- **Routing sidecar** (internal/middleware/aiqg_routing.go) gains `promptTokens`/`completionTokens`/`usageSet`. New `StampTokenUsage(ctx, prompt, completion)` — first-write-wins, treats 0+0 as a valid stamp (content_filter responses with zero completion still get a TokenAccounting block).
- **events.RoutingView** extended with the same three fields; events.Build computes TokenAccounting + passes counts into clear.Compute.
- **server.go handlers** stamp in three places: non-streaming after ChatCompletion (direct + retry variants), inside both streaming chunk loops. OpenAI emits usage on the final chunk when `stream_options.include_usage` is set; Anthropic carries it in `message_delta` — first-write-wins makes per-chunk stamping safe.

## Out of scope
- **Customer-specific pricing overrides** — the dashboard-backed Resolver slice will eventually pull per-account rates; the in-binary table is public list prices only.
- **Cost-recovery attribution** (direct payload waste vs. induced vs. genuine post-model) — source-spec §2.1.3's three-category decomposition needs the active payload-reduction feature, Phase 2.

## Test plan
- [x] `make test` end-to-end clean
- [x] `pkg/clear/cost_test.go`: pricing lookup (known/unknown/empty); DollarCost arithmetic; scoreCost curve at 6 boundary points (`$0.001 / $0.01 / $0.10 / $1 / $10`); nil cases (HTTPStatus=0, missing tokens, 0+0 tokens, unknown model)
- [x] `pkg/clear/clear_test.go`: TestCompute_PopulatesCostAndComposite — Latency + Cost both score, Composite averages
- [x] `internal/middleware/aiqg_routing_test.go`: StampTokenUsage first-write-wins + (0,0) treated as valid stamp
- [x] `internal/middleware/aiqg_test.go`: TestAIQG_TokenUsageStampedReachesEventAndCost — handler stamp → defer → emitter → TokenAccounting populated + CLEAR.Cost non-nil
- [ ] Smoke-test on K3s after rollout — query Loki for `{...} | json | response_event | has(token_accounting)` after a real request

🤖 Generated with [Claude Code](https://claude.com/claude-code)