### PR TITLE
fix: copy aether-shared/go-events into Docker build context

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,12 @@ FROM golang:1.24-alpine AS builder
 
 WORKDIR /build
 
-# Copy Gatekeeper dependency (local replace directive)
+# Copy local-replace dependencies.
+# Gatekeeper transitively pulls aether-shared/go-events; both are
+# replaced to local paths in tas-llm-router's go.mod, so both must
+# exist under the build context.
 COPY Gatekeeper/ /build/Gatekeeper/
+COPY aether-shared/go-events/ /build/aether-shared/go-events/
 
 WORKDIR /build/app
 


### PR DESCRIPTION
## Summary
The go-events module is a transitive dep of `Gatekeeper/pkg/stream` and since PR #20 it's pinned via a local replace in tas-llm-router's `go.mod`. Without copying its source into the build context, the post-#20 Docker build fails with `missing go.sum entry` on the replaced module.

Two-line `COPY` adds it next to `Gatekeeper/` so the build context contains everything `go build` needs.

## Why this surfaced now
Caught while attempting the K3s rollout for the AIQG MVP — the live cluster runs a 22-day-old image (pre-AIQG, pre-replace) so the Docker build hadn't been re-run since PR #20 landed. Without this fix the rollout would fail at build time.

## Test plan
- [x] `docker build -f docker/Dockerfile ..` (from the tas-llm-router dir) succeeds against the current main
- [ ] Rolled out to K3s — pending the rollout sequence this PR unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)