### PR TITLE
feat: secret-backed AIQG token list

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -392,10 +392,8 @@ func (c *Config) loadFromEnv() {
 	}
 
 	// AIQG ingress — env overrides for the simple scalars. Tokens are
-	// only loadable via the YAML config file (env vars are a poor
-	// shape for a list of structs); deployments that want a token
-	// store either ship a baked config.yaml or wait for the
-	// dashboard-backed Resolver slice.
+	// only loadable via YAML (env vars are a poor shape for a list of
+	// structs).
 	if enabled := os.Getenv("AIQG_ENABLED"); enabled != "" {
 		c.AIQG.Enabled = enabled == "true" || enabled == "1"
 	}
@@ -405,6 +403,51 @@ func (c *Config) loadFromEnv() {
 	if region := os.Getenv("AIQG_REGION"); region != "" {
 		c.AIQG.Region = region
 	}
+	// AIQG_TOKENS_FILE points to a separate YAML file containing the
+	// token list (typically mounted from a Kubernetes Secret so the
+	// list never sits in a ConfigMap). When set + readable, the file's
+	// tokens REPLACE any tokens already loaded from config.yaml —
+	// this matches the operator's mental model of "the Secret is the
+	// source of truth for live tokens." A missing or unreadable file
+	// is logged but does not fail startup; the AIQG middleware
+	// gracefully degrades to the no-resolver permissive path
+	// documented in pkg/aiqg/middleware.
+	if path := os.Getenv("AIQG_TOKENS_FILE"); path != "" {
+		if err := c.loadAIQGTokensFromFile(path); err != nil {
+			// Use stdlib log here; structured logger isn't initialized
+			// at this point in startup.
+			fmt.Fprintf(os.Stderr, "warning: AIQG_TOKENS_FILE=%q could not be loaded: %v\n", path, err)
+		}
+	}
+}
+
+// loadAIQGTokensFromFile reads a tokens file and replaces c.AIQG.Tokens
+// with its contents. The file shape is:
+//
+//	tokens:
+//	  - token_id: "uuid"
+//	    token: "tas_qg_live_..."
+//	    tenant_id: "..."
+//	    aiqg_account_id: "..."
+//	    source_app: "..."
+//	    suspended: false
+//
+// This is intentionally a sub-schema of the main Config so the same
+// YAML structure works whether tokens come from config.yaml or a
+// separately-mounted Secret.
+func (c *Config) loadAIQGTokensFromFile(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read tokens file: %w", err)
+	}
+	var wrapper struct {
+		Tokens []AIQGTokenConfig `yaml:"tokens"`
+	}
+	if err := yaml.Unmarshal(data, &wrapper); err != nil {
+		return fmt.Errorf("parse tokens file: %w", err)
+	}
+	c.AIQG.Tokens = wrapper.Tokens
+	return nil
 }
 
 // validate validates the configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -371,6 +371,103 @@ func TestConfig_ToAIQGServerConfig_EnabledWithTokens(t *testing.T) {
 	}
 }
 
+// AIQG_TOKENS_FILE pointing at a valid YAML replaces any config.yaml tokens.
+func TestLoadConfig_AIQGTokensFile(t *testing.T) {
+	dir := t.TempDir()
+	tokensFile := dir + "/tokens.yaml"
+	yaml := `tokens:
+  - token_id: "tok-1"
+    token: "tas_qg_live_abc"
+    tenant_id: "tenant-a"
+    aiqg_account_id: "account-a"
+    source_app: "billing"
+    suspended: false
+  - token_id: "tok-2"
+    token: "tas_qg_live_def"
+    tenant_id: "tenant-b"
+    aiqg_account_id: "account-b"
+    suspended: true
+`
+	if err := os.WriteFile(tokensFile, []byte(yaml), 0o600); err != nil {
+		t.Fatalf("write tokens file: %v", err)
+	}
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("AIQG_ENABLED", "true")
+	t.Setenv("AIQG_TOKENS_FILE", tokensFile)
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if len(cfg.AIQG.Tokens) != 2 {
+		t.Fatalf("token count=%d want=2", len(cfg.AIQG.Tokens))
+	}
+	if cfg.AIQG.Tokens[0].TenantID != "tenant-a" || cfg.AIQG.Tokens[0].Token != "tas_qg_live_abc" {
+		t.Errorf("token[0] mismatch: %#v", cfg.AIQG.Tokens[0])
+	}
+	if !cfg.AIQG.Tokens[1].Suspended {
+		t.Errorf("token[1].Suspended not propagated")
+	}
+}
+
+// File takes precedence over config.yaml tokens (replace, not merge).
+func TestLoadConfig_AIQGTokensFileReplacesYAML(t *testing.T) {
+	dir := t.TempDir()
+	tokensFile := dir + "/tokens.yaml"
+	if err := os.WriteFile(tokensFile, []byte("tokens:\n  - token: \"tas_qg_live_from_file\"\n    tenant_id: \"tenant-from-file\"\n"), 0o600); err != nil {
+		t.Fatalf("write tokens file: %v", err)
+	}
+
+	c := &Config{}
+	c.setDefaults()
+	c.AIQG.Tokens = []AIQGTokenConfig{{Token: "tas_qg_live_from_yaml", TenantID: "tenant-from-yaml"}}
+
+	if err := c.loadAIQGTokensFromFile(tokensFile); err != nil {
+		t.Fatalf("loadAIQGTokensFromFile: %v", err)
+	}
+	if len(c.AIQG.Tokens) != 1 {
+		t.Fatalf("len=%d want=1", len(c.AIQG.Tokens))
+	}
+	if c.AIQG.Tokens[0].Token != "tas_qg_live_from_file" {
+		t.Errorf("file did not override YAML: %#v", c.AIQG.Tokens[0])
+	}
+}
+
+// Missing AIQG_TOKENS_FILE is logged but does NOT fail LoadConfig.
+// The middleware just runs in the no-resolver permissive path.
+func TestLoadConfig_AIQGTokensFileMissingDoesNotFail(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("AIQG_TOKENS_FILE", "/this/path/does/not/exist.yaml")
+
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig should not fail on missing tokens file: %v", err)
+	}
+	if len(cfg.AIQG.Tokens) != 0 {
+		t.Errorf("expected empty tokens, got %d", len(cfg.AIQG.Tokens))
+	}
+}
+
+// Malformed YAML in the tokens file is logged but doesn't fail startup.
+func TestLoadConfig_AIQGTokensFileMalformedDoesNotFail(t *testing.T) {
+	dir := t.TempDir()
+	tokensFile := dir + "/tokens.yaml"
+	if err := os.WriteFile(tokensFile, []byte("this is not\n valid: : yaml: :"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	t.Setenv("OPENAI_API_KEY", "test-key")
+	t.Setenv("AIQG_TOKENS_FILE", tokensFile)
+	cfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatalf("LoadConfig should not fail on malformed tokens file: %v", err)
+	}
+	if len(cfg.AIQG.Tokens) != 0 {
+		t.Errorf("malformed yaml should leave tokens empty, got %d", len(cfg.AIQG.Tokens))
+	}
+}
+
 // Env-var overrides flip the YAML defaults.
 func TestLoadConfig_AIQGEnvOverrides(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "test-key") // satisfy provider validation

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -55,6 +55,11 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.podIP
+        # Points the AIQG token-resolver at the Secret-mounted file.
+        # When the Secret isn't present (volume is optional), the binary
+        # logs a warning and runs in the no-resolver permissive path.
+        - name: AIQG_TOKENS_FILE
+          value: /app/secrets/aiqg/aiqg-tokens.yaml
 
         resources:
           requests:
@@ -94,6 +99,12 @@ spec:
           mountPath: /tmp
         - name: cache
           mountPath: /app/cache
+        # AIQG token list — mounted from a Secret rather than a ConfigMap
+        # because token bearers are sensitive. The binary reads this via
+        # AIQG_TOKENS_FILE (set on the env block).
+        - name: aiqg-tokens
+          mountPath: /app/secrets/aiqg
+          readOnly: true
 
       volumes:
       - name: tmp
@@ -101,6 +112,13 @@ spec:
       - name: cache
         emptyDir:
           sizeLimit: 1Gi
+      - name: aiqg-tokens
+        secret:
+          secretName: llm-router-aiqg-tokens
+          # Optional so the Deployment still starts when the Secret
+          # hasn't been applied yet — the AIQG middleware just runs in
+          # the no-resolver permissive path until it lands.
+          optional: true
 
       affinity:
         podAntiAffinity:

--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - namespace.yaml
 - configmap.yaml
 - secret.yaml
+- secret-aiqg-tokens.yaml
 - deployment.yaml
 - service.yaml
 - ingress.yaml

--- a/k8s/secret-aiqg-tokens.yaml
+++ b/k8s/secret-aiqg-tokens.yaml
@@ -1,0 +1,39 @@
+# AIQG token list — sensitive material, lives in a Secret rather than the
+# ConfigMap. The binary reads this file via AIQG_TOKENS_FILE.
+#
+# This file ships with NO real tokens. Ops applies the populated version
+# out-of-band (kubectl apply -f from a Secret stored in a vault, or via
+# sealed-secrets / external-secrets / SOPS — pick your tooling).
+#
+# Format mirrors config.yaml's aiqg.tokens block:
+#
+#   tokens:
+#     - token_id: "<uuid>"               # FK to aiqg_token table
+#       token: "tas_qg_live_<random>"    # the actual bearer
+#       tenant_id: "<uuid>"
+#       aiqg_account_id: "<uuid>"
+#       source_app: "<free-form>"        # max 128 chars
+#       suspended: false
+#
+# Until populated, the AIQG middleware runs in the no-resolver permissive
+# path: any TAS-Auth bearer is accepted but emitted events carry empty
+# tenant fields. Populating this file flips on tenant attribution
+# without any code change or rollout.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: llm-router-aiqg-tokens
+  namespace: tas-llm-router
+  labels:
+    app: llm-router
+type: Opaque
+stringData:
+  aiqg-tokens.yaml: |
+    tokens: []
+    # Example entry — copy and fill in real values:
+    #   - token_id: "00000000-0000-0000-0000-000000000000"
+    #     token: "tas_qg_live_REPLACE_ME"
+    #     tenant_id: "00000000-0000-0000-0000-000000000000"
+    #     aiqg_account_id: "00000000-0000-0000-0000-000000000000"
+    #     source_app: "your-app-name"
+    #     suspended: false


### PR DESCRIPTION
## Summary
Closes the gap exposed by the live rollout: emitted events were unattributed (empty `tenant_id` / `aiqg_account_id`) because no token store was wired. The previous slice put tokens in the YAML config schema; this slice adds the path that keeps them **out of ConfigMaps and in Secrets** where bearer tokens belong.

## Wire-up
- **`internal/config`**: `AIQG_TOKENS_FILE` env var points the loader at a standalone YAML file. When set + readable, its tokens **REPLACE** any tokens already loaded from `config.yaml` (matches operator mental model: "the Secret is the source of truth"). Missing/malformed file is logged but does **NOT** fail startup — the AIQG middleware gracefully degrades to the no-resolver permissive path documented in PR #22.
- **`k8s/secret-aiqg-tokens.yaml`**: stub Secret with an empty tokens list + documented example entry. Ops populates out-of-band (sealed-secrets / external-secrets / SOPS — pick your tooling) so real bearers never sit in git.
- **`k8s/deployment.yaml`**: mounts the Secret at `/app/secrets/aiqg/` (volume marked **optional** so the Deployment starts when the Secret isn't applied yet), sets `AIQG_TOKENS_FILE` to point at it.
- **`k8s/kustomization.yaml`**: registers the new Secret.

## Ops workflow
1. Stub Secret deploys with this PR — Deployment starts cleanly, token list empty, middleware in no-resolver path.
2. Ops creates the real Secret out-of-band:
   ```bash
   kubectl create secret generic llm-router-aiqg-tokens \
     -n tas-llm-router \
     --from-file=aiqg-tokens.yaml=./real-tokens.yaml \
     --dry-run=client -o yaml | kubectl apply -f -
   ```
3. Restart the Deployment (`kubectl rollout restart deploy/llm-router -n tas-llm-router`). Next pod picks up the populated Secret.
4. Verify in Loki: next AIQG request emits an event with `tenant_id` and `aiqg_account_id` populated.

No image rebuild required for steps 2-4 — the Secret update is purely a runtime config change.

## Test plan
- [x] `make test` end-to-end clean
- [x] `TestLoadConfig_AIQGTokensFile` — valid YAML with two entries loads + populates suspended flag
- [x] `TestLoadConfig_AIQGTokensFileReplacesYAML` — file takes precedence over config.yaml tokens
- [x] `TestLoadConfig_AIQGTokensFileMissingDoesNotFail` — `/nonexistent/path` is logged + tolerated
- [x] `TestLoadConfig_AIQGTokensFileMalformedDoesNotFail` — broken YAML is logged + tolerated
- [ ] Smoke on K3s after rollout — empty Secret should produce the same behavior as today (events with empty tenant fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)