### PR TITLE
fix: kustomization image mapping points at the wrong repo

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -18,6 +18,11 @@ commonLabels:
   app.kubernetes.io/part-of: tas
 
 images:
+# Ops pushes to registry-api.tas.scharber.com/tas-llm-router — the
+# `tas-` prefix differs from this kustomization's local name
+# (`llm-router`, matching the deployment.yaml container image). Without
+# the prefix, `kubectl apply -k` rewrites the Deployment to pull a
+# stale unrelated repo and the live image silently changes on apply.
 - name: llm-router
-  newName: registry-api.tas.scharber.com/llm-router
+  newName: registry-api.tas.scharber.com/tas-llm-router
   newTag: latest


### PR DESCRIPTION
## Summary
The kustomization's \`images:\` block rewrote \`llm-router\` → \`registry-api.tas.scharber.com/llm-router\` (no \`tas-\` prefix), but ops actually pushes to \`registry-api.tas.scharber.com/tas-llm-router\`. Without this fix, every \`kubectl apply -k k8s/\` silently switches the live Deployment image to the wrong (stale, unrelated) repo.

## How it surfaced
Caught during the PR #26 rollout. My freshly-built \`tas-llm-router:aiqg-v2\` was pushed correctly, but \`kubectl apply -k k8s/\` rewrote the live image to \`registry-api.tas.scharber.com/llm-router:latest\`, which resolved to \`fix-health-8a8272f\` — someone else's WIP build in a different repo. Took a manual \`kubectl set image\` to recover.

## Verification
\`\`\`
$ kustomize build k8s/ | grep 'image:'
        image: registry-api.tas.scharber.com/tas-llm-router:latest
        image: busybox:1.36
        image: busybox:1.36
\`\`\`
Matches what ops pushes.

## Test plan
- [x] \`kustomize build k8s/\` renders the right image name
- [ ] Next \`kubectl apply -k k8s/\` keeps the live image on tas-llm-router

🤖 Generated with [Claude Code](https://claude.com/claude-code)