### PR TITLE
feat: fill the clear.Assurance dimension from Gatekeeper findings

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -228,6 +228,9 @@ func routingView(r *Routing) events.RoutingView {
 		PromptTokens:     s.PromptTokens,
 		CompletionTokens: s.CompletionTokens,
 		UsageSet:         s.UsageSet,
+		InboundFindings:  s.InboundFindings,
+		OutboundFindings: s.OutboundFindings,
+		ScanRan:          s.ScanRan,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -29,6 +29,13 @@ type Routing struct {
 	promptTokens     int
 	completionTokens int
 	usageSet         bool
+
+	// Gatekeeper findings — counts per severity per direction. The
+	// scanRan flag distinguishes "scan ran, no findings" (Healthy
+	// Assurance) from "scan didn't run" (no Assurance score at all).
+	inboundFindings  map[string]int
+	outboundFindings map[string]int
+	scanRan          bool
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -56,9 +63,18 @@ type RoutingSnapshot struct {
 	PromptTokens     int
 	CompletionTokens int
 	UsageSet         bool
+
+	// Gatekeeper scan results, severity-count maps per direction.
+	// ScanRan distinguishes "scan ran, no findings" from "scan never
+	// ran" — the latter means Assurance scoring is skipped entirely.
+	InboundFindings  map[string]int
+	OutboundFindings map[string]int
+	ScanRan          bool
 }
 
 // Snapshot returns a read-only view of the current routing state.
+// Finding maps are copied so the caller can mutate without racing
+// future stamps.
 func (r *Routing) Snapshot() RoutingSnapshot {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -70,7 +86,21 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		PromptTokens:     r.promptTokens,
 		CompletionTokens: r.completionTokens,
 		UsageSet:         r.usageSet,
+		InboundFindings:  copyCounts(r.inboundFindings),
+		OutboundFindings: copyCounts(r.outboundFindings),
+		ScanRan:          r.scanRan,
 	}
+}
+
+func copyCounts(in map[string]int) map[string]int {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]int, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }
 
 type routingCtxKey struct{}
@@ -161,5 +191,43 @@ func StampTokenUsage(ctx context.Context, promptTokens, completionTokens int) {
 		r.promptTokens = promptTokens
 		r.completionTokens = completionTokens
 		r.usageSet = true
+	}
+}
+
+// Direction selects which side of the Gatekeeper scan a finding came
+// from. Both directions land on the same Routing sidecar and feed the
+// per-request Assurance score; dashboards can separate them via the
+// embedded AssuranceSummary.
+const (
+	GatekeeperDirectionInbound  = "inbound"
+	GatekeeperDirectionOutbound = "outbound"
+)
+
+// StampGatekeeperFindings records the per-severity count of findings
+// surfaced by a Gatekeeper scan. Direction selects inbound or outbound;
+// passing an empty severityCounts map is treated as "scan ran, no
+// findings" — ScanRan flips true so Assurance scores as Healthy=100
+// rather than nil-not-scored. Subsequent calls for the same direction
+// accumulate (max-per-severity) so multiple scan stages in the same
+// direction don't accidentally clobber each other.
+func StampGatekeeperFindings(ctx context.Context, direction string, severityCounts map[string]int) {
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.scanRan = true
+	target := &r.inboundFindings
+	if direction == GatekeeperDirectionOutbound {
+		target = &r.outboundFindings
+	}
+	if *target == nil {
+		*target = make(map[string]int, len(severityCounts))
+	}
+	for sev, count := range severityCounts {
+		if count > (*target)[sev] {
+			(*target)[sev] = count
+		}
 	}
 }

--- a/internal/middleware/aiqg_routing_test.go
+++ b/internal/middleware/aiqg_routing_test.go
@@ -128,6 +128,68 @@ func TestRouting_StampTokenUsageZeroIsValid(t *testing.T) {
 	}
 }
 
+// StampGatekeeperFindings: ScanRan flips true even on empty counts,
+// per-direction max-aggregates, and direction param selects target map.
+func TestRouting_StampGatekeeperFindings(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	if r.Snapshot().ScanRan {
+		t.Errorf("ScanRan=true before any stamp")
+	}
+
+	// Empty counts: scan ran, no findings — ScanRan flips true.
+	StampGatekeeperFindings(ctx, GatekeeperDirectionInbound, map[string]int{})
+	if !r.Snapshot().ScanRan {
+		t.Errorf("ScanRan should be true after empty inbound stamp")
+	}
+
+	// Stamp inbound findings.
+	StampGatekeeperFindings(ctx, GatekeeperDirectionInbound, map[string]int{"medium": 2, "high": 1})
+	s := r.Snapshot()
+	if s.InboundFindings["medium"] != 2 || s.InboundFindings["high"] != 1 {
+		t.Errorf("inbound stamps: %v", s.InboundFindings)
+	}
+	if len(s.OutboundFindings) != 0 {
+		t.Errorf("outbound should be empty: %v", s.OutboundFindings)
+	}
+
+	// Stamp outbound findings, separately.
+	StampGatekeeperFindings(ctx, GatekeeperDirectionOutbound, map[string]int{"critical": 1})
+	s2 := r.Snapshot()
+	if s2.OutboundFindings["critical"] != 1 {
+		t.Errorf("outbound stamp: %v", s2.OutboundFindings)
+	}
+
+	// Subsequent inbound stamp with HIGHER counts wins (max-aggregate).
+	StampGatekeeperFindings(ctx, GatekeeperDirectionInbound, map[string]int{"medium": 5})
+	if r.Snapshot().InboundFindings["medium"] != 5 {
+		t.Errorf("max-aggregate failed")
+	}
+	// LOWER counts ignored.
+	StampGatekeeperFindings(ctx, GatekeeperDirectionInbound, map[string]int{"medium": 1})
+	if r.Snapshot().InboundFindings["medium"] != 5 {
+		t.Errorf("lower count overwrote higher")
+	}
+}
+
+// Snapshot must return a copy — mutating it should not race future stamps.
+func TestRouting_SnapshotIsCopy(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+	StampGatekeeperFindings(ctx, GatekeeperDirectionInbound, map[string]int{"low": 1})
+	s := r.Snapshot()
+	s.InboundFindings["low"] = 999
+	if r.Snapshot().InboundFindings["low"] == 999 {
+		t.Errorf("Snapshot returned live map, not a copy")
+	}
+}
+
+func TestRouting_StampFindings_NilSafe(t *testing.T) {
+	// No collector in ctx — must not panic.
+	StampGatekeeperFindings(context.Background(), GatekeeperDirectionInbound, map[string]int{"high": 1})
+}
+
 func TestRouting_ConcurrentStamps(t *testing.T) {
 	r := NewRouting()
 	ctx := WithRouting(context.Background(), r)

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -601,6 +601,95 @@ func TestAIQG_TokenUsageStampedReachesEventAndCost(t *testing.T) {
 	}
 }
 
+// Gatekeeper findings stamped by the handler must produce both a
+// CLEAR.Assurance score and an AssuranceSummary on the response event.
+func TestAIQG_GatekeeperFindingsStampedReachEventAndAssurance(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionInbound, map[string]int{"medium": 2})
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionOutbound, map[string]int{})
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	if em.Len() != 1 {
+		t.Fatalf("emit count=%d want=1", em.Len())
+	}
+	rd := em.Responses()[0].Data
+
+	if rd.Assurance == nil {
+		t.Fatalf("Assurance summary nil")
+	}
+	if rd.Assurance.InboundFindings["medium"] != 2 {
+		t.Errorf("InboundFindings: %v", rd.Assurance.InboundFindings)
+	}
+	if rd.Assurance.WorstSeverity != "medium" {
+		t.Errorf("WorstSeverity=%q want=medium", rd.Assurance.WorstSeverity)
+	}
+	if rd.CLEAR.Assurance == nil || *rd.CLEAR.Assurance != 80 {
+		t.Errorf("CLEAR.Assurance=%v want=80 (medium bucket)", rd.CLEAR.Assurance)
+	}
+}
+
+// Clean scan (ScanRan=true, no findings) → Assurance = 100, summary
+// emitted with empty maps + no worst severity.
+func TestAIQG_CleanScanScoresAssurance100(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionInbound, map[string]int{})
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	rd := em.Responses()[0].Data
+	if rd.CLEAR.Assurance == nil || *rd.CLEAR.Assurance != 100 {
+		t.Errorf("clean scan Assurance=%v want=100", rd.CLEAR.Assurance)
+	}
+	if rd.Assurance == nil {
+		t.Fatalf("Assurance summary nil despite ScanRan=true")
+	}
+	if rd.Assurance.WorstSeverity != "" {
+		t.Errorf("WorstSeverity=%q want empty on clean scan", rd.Assurance.WorstSeverity)
+	}
+}
+
+// No-scan path (handler never stamps Gatekeeper findings) → Assurance
+// score nil + Assurance summary omitted. Distinct from clean scan.
+func TestAIQG_NoScanLeavesAssuranceNil(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	noStampHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(noStampHandler).ServeHTTP(rec, req)
+
+	rd := em.Responses()[0].Data
+	if rd.CLEAR.Assurance != nil {
+		t.Errorf("Assurance=%d want nil when no scan ran", *rd.CLEAR.Assurance)
+	}
+	if rd.Assurance != nil {
+		t.Errorf("AssuranceSummary should be omitted when no scan ran")
+	}
+}
+
 // Vendor/Model stamps made by the downstream handler must reach the
 // emitted event. Proves the Routing sidecar (attached by middleware) +
 // the deferred snapshot read both work end-to-end.
@@ -683,7 +772,7 @@ func TestAIQG_EmittedEventCarriesCLEARScores(t *testing.T) {
 		t.Errorf("CLEAR.Efficacy should be nil at MVP (response body not captured)")
 	}
 	if respEnv.Data.CLEAR.Assurance != nil {
-		t.Errorf("CLEAR.Assurance should be nil at MVP (Gatekeeper not integrated)")
+		t.Errorf("CLEAR.Assurance should be nil when no scan stamped, got %d", *respEnv.Data.CLEAR.Assurance)
 	}
 	if respEnv.Data.CLEAR.Reliability != nil {
 		t.Errorf("CLEAR.Reliability should be nil at MVP (retry detection not built)")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -364,6 +364,17 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 			} else {
 				w.Header().Set("X-TAS-Scan-Status", "violations")
 			}
+
+			// AIQG: project Gatekeeper findings into per-severity
+			// counts and stamp onto the routing sidecar. Drives the
+			// CLEAR.Assurance score and the AssuranceSummary on the
+			// emitted event. Empty counts still flip ScanRan true so
+			// Assurance scores as Healthy=100 rather than nil.
+			counts := map[string]int{}
+			for _, f := range result.ScanResult.Findings {
+				counts[string(f.Severity)]++
+			}
+			middleware.StampGatekeeperFindings(r.Context(), middleware.GatekeeperDirectionInbound, counts)
 		}
 	}
 

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -47,6 +47,14 @@ type RoutingView struct {
 	PromptTokens     int
 	CompletionTokens int
 	UsageSet         bool
+
+	// Gatekeeper scan results. Inbound/Outbound are per-severity
+	// counts ("low"/"medium"/"high"/"critical" → int). ScanRan
+	// distinguishes "scan ran, no findings" from "scan never ran"
+	// — events emit AssuranceSummary only when ScanRan is true.
+	InboundFindings  map[string]int
+	OutboundFindings map[string]int
+	ScanRan          bool
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -171,13 +179,16 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	// Build the clear.Input once; reuse for the embedded TokenAccounting
 	// dollar cost so Scores and the per-event accounting agree on prices.
 	clearInput := clear.Input{
-		EndToEndMs:        snap.EndToEndMs,
-		GatewayOverheadMs: snap.GatewayOverheadMs,
-		VendorTTFTMs:      snap.VendorTTFTMs,
-		Workflow:          headers.Workflow,
-		HTTPStatus:        opts.HTTPStatus,
-		Vendor:            routing.Vendor,
-		Model:             routing.Model,
+		EndToEndMs:                 snap.EndToEndMs,
+		GatewayOverheadMs:          snap.GatewayOverheadMs,
+		VendorTTFTMs:               snap.VendorTTFTMs,
+		Workflow:                   headers.Workflow,
+		HTTPStatus:                 opts.HTTPStatus,
+		Vendor:                     routing.Vendor,
+		Model:                      routing.Model,
+		AssuranceScanRan:           routing.ScanRan,
+		InboundFindingsBySeverity:  routing.InboundFindings,
+		OutboundFindingsBySeverity: routing.OutboundFindings,
 	}
 	var tokenAcct *TokenAccounting
 	if routing.UsageSet {
@@ -200,6 +211,15 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		tokenAcct = ta
 	}
 
+	var assuranceSummary *AssuranceSummary
+	if routing.ScanRan {
+		assuranceSummary = &AssuranceSummary{
+			InboundFindings:  routing.InboundFindings,
+			OutboundFindings: routing.OutboundFindings,
+			WorstSeverity:    worstSeverityIn(routing.InboundFindings, routing.OutboundFindings),
+		}
+	}
+
 	respEvent := ResponseEvent{
 		ResponseEventID:   respID,
 		RequestEventID:    reqID,
@@ -214,6 +234,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		ContentChunkCount: snap.ContentChunkCount,
 		EventTimestamps:   snap,
 		TokenAccounting:   tokenAcct,
+		Assurance:         assuranceSummary,
 		CLEAR:             clear.Compute(clearInput),
 		ScoringVersion:    ScoringVersion,
 		GatewayVersion:    GatewayVersion,
@@ -280,6 +301,20 @@ func clientIP(r *http.Request) string {
 		return r.RemoteAddr
 	}
 	return host
+}
+
+// worstSeverityIn returns the highest severity present across either
+// the inbound or outbound finding-count maps. Empty string means no
+// findings recorded. Mirrors the bucketing in pkg/clear's
+// scoreAssurance so the AssuranceSummary surfaces the same severity
+// the score was derived from.
+func worstSeverityIn(in, out map[string]int) string {
+	for _, sev := range []string{"critical", "high", "medium", "low"} {
+		if in[sev] > 0 || out[sev] > 0 {
+			return sev
+		}
+	}
+	return ""
 }
 
 // isStreaming inspects the request to decide whether it asked for a

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -142,6 +142,13 @@ type ResponseEvent struct {
 	// on the routing snapshot) — distinct from "0 tokens used".
 	TokenAccounting *TokenAccounting `json:"token_accounting,omitempty"`
 
+	// Compact Gatekeeper scan summary. Full tag_set integration is a
+	// later slice; for MVP this carries the per-severity counts +
+	// derived worst severity so dashboards can slice Assurance scoring
+	// by direction. Omitted when no scan ran (e.g. internal pass-
+	// through traffic or Gatekeeper-disabled deployments).
+	Assurance *AssuranceSummary `json:"assurance,omitempty"`
+
 	// CLEAR scores — populated by pkg/clear.Compute(). A nil *Scores
 	// (rather than a *Scores with all-nil dimension fields) means the
 	// scorer wasn't run at all, which today only happens on the noop
@@ -171,6 +178,18 @@ type TokenAccounting struct {
 	OutputCostUSD       float64 `json:"output_cost_usd"`
 	TotalCostUSD        float64 `json:"total_cost_usd"`
 	ModelPricingVersion string  `json:"model_pricing_version,omitempty"`
+}
+
+// AssuranceSummary is the lightweight per-event view of Gatekeeper
+// scan output. The full tag_set + per-NIST-characteristic breakdown
+// belongs on its own embedded sub-document (deferred slice — see
+// aether-shared/data-models/aiqg/tag-set.md). This summary keeps the
+// event payload small while still letting Spark/dashboards segment
+// by severity and direction.
+type AssuranceSummary struct {
+	InboundFindings  map[string]int `json:"inbound_findings,omitempty"`
+	OutboundFindings map[string]int `json:"outbound_findings,omitempty"`
+	WorstSeverity    string         `json:"worst_severity,omitempty"`
 }
 
 // Status enum values for ResponseEvent.Status.

--- a/pkg/clear/assurance.go
+++ b/pkg/clear/assurance.go
@@ -1,0 +1,71 @@
+package clear
+
+// Severity strings the Assurance scorer recognizes. Match the four
+// values Gatekeeper emits (pkg/scan.Severity in the Gatekeeper repo)
+// without importing Gatekeeper types here — keeps pkg/clear standalone.
+const (
+	SeverityLow      = "low"
+	SeverityMedium   = "medium"
+	SeverityHigh     = "high"
+	SeverityCritical = "critical"
+)
+
+// scoreAssurance buckets the request's worst Gatekeeper finding into
+// a 0-100 score per source-spec §2.2.3, which carries stricter tier
+// boundaries than the other dimensions because assurance failures have
+// asymmetric consequences (one unauthorized disclosure invalidates
+// otherwise perfect performance):
+//
+//	Healthy   ≥ 90  → no findings, or low-only
+//	Marginal  75-89 → any medium
+//	Failing   < 75  → any high or critical
+//
+// Concrete mapping:
+//
+//	no findings   → 100
+//	only "low"    → 95
+//	any "medium"  → 80
+//	any "high"    → 50
+//	any "critical"→ 0
+//
+// Bucketing on worst-severity (not count) matches the spec's
+// asymmetric-consequence framing — one critical finding shouldn't be
+// diluted by 99 clean checks. Counts still ride on the AssuranceSummary
+// for dashboards that want to slice by frequency.
+//
+// Returns nil when no scan ran at all (FindingsSet=false on the
+// routing snapshot). Distinct from "scan ran, found nothing" which
+// is the explicit Healthy=100 case.
+func scoreAssurance(in Input) *Score {
+	if !in.AssuranceScanRan {
+		return nil
+	}
+	worst := worstSeverity(in.InboundFindingsBySeverity, in.OutboundFindingsBySeverity)
+	var v Score
+	switch worst {
+	case SeverityCritical:
+		v = 0
+	case SeverityHigh:
+		v = 50
+	case SeverityMedium:
+		v = 80
+	case SeverityLow:
+		v = 95
+	default:
+		// No findings at any severity → Healthy.
+		v = 100
+	}
+	return &v
+}
+
+// worstSeverity returns the highest severity present across either
+// direction. Empty string means no findings.
+func worstSeverity(in, out map[string]int) string {
+	// Order matters — check critical first, then high, etc.
+	for _, sev := range []string{SeverityCritical, SeverityHigh, SeverityMedium, SeverityLow} {
+		if in[sev] > 0 || out[sev] > 0 {
+			return sev
+		}
+	}
+	return ""
+}

--- a/pkg/clear/assurance_test.go
+++ b/pkg/clear/assurance_test.go
@@ -1,0 +1,109 @@
+package clear
+
+import "testing"
+
+func TestScoreAssurance_NilWhenScanDidNotRun(t *testing.T) {
+	s := scoreAssurance(Input{HTTPStatus: 200, AssuranceScanRan: false})
+	if s != nil {
+		t.Errorf("expected nil when AssuranceScanRan=false, got %d", *s)
+	}
+}
+
+func TestScoreAssurance_HealthyOnCleanScan(t *testing.T) {
+	s := scoreAssurance(Input{
+		HTTPStatus:       200,
+		AssuranceScanRan: true,
+	})
+	if s == nil || *s != 100 {
+		t.Errorf("score=%v want=100 (clean scan)", s)
+	}
+}
+
+func TestScoreAssurance_Bucketing(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]int
+		out  map[string]int
+		want Score
+	}{
+		{"low_only", map[string]int{SeverityLow: 5}, nil, 95},
+		{"medium_inbound", map[string]int{SeverityMedium: 1}, nil, 80},
+		{"medium_outbound", nil, map[string]int{SeverityMedium: 2}, 80},
+		{"high_inbound_low_outbound_picks_high", map[string]int{SeverityHigh: 1}, map[string]int{SeverityLow: 5}, 50},
+		{"critical_inbound", map[string]int{SeverityCritical: 1}, nil, 0},
+		{"critical_outbound_only", nil, map[string]int{SeverityCritical: 1}, 0},
+		{"low_plus_medium_picks_medium", map[string]int{SeverityLow: 3, SeverityMedium: 1}, nil, 80},
+		{"high_plus_critical_picks_critical", map[string]int{SeverityHigh: 1, SeverityCritical: 1}, nil, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := scoreAssurance(Input{
+				HTTPStatus:                 200,
+				AssuranceScanRan:           true,
+				InboundFindingsBySeverity:  c.in,
+				OutboundFindingsBySeverity: c.out,
+			})
+			if s == nil {
+				t.Fatalf("score nil")
+			}
+			if *s != c.want {
+				t.Errorf("score=%d want=%d", *s, c.want)
+			}
+		})
+	}
+}
+
+// Per source-spec §2.2.3, Assurance uses stricter tier boundaries:
+// Healthy ≥90, Marginal 75-89, Failing <75. Verify the bucketed
+// scores land in the documented tiers.
+func TestScoreAssurance_TierBoundaries(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]int
+		tier string // "healthy" | "marginal" | "failing"
+	}{
+		{"clean → healthy", nil, "healthy"},                          // 100
+		{"low → healthy", map[string]int{SeverityLow: 1}, "healthy"}, // 95
+		{"medium → marginal", map[string]int{SeverityMedium: 1}, "marginal"}, // 80
+		{"high → failing", map[string]int{SeverityHigh: 1}, "failing"},       // 50
+		{"critical → failing", map[string]int{SeverityCritical: 1}, "failing"}, // 0
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := scoreAssurance(Input{HTTPStatus: 200, AssuranceScanRan: true, InboundFindingsBySeverity: c.in})
+			if s == nil {
+				t.Fatalf("nil")
+			}
+			actual := tierName(*s)
+			if actual != c.tier {
+				t.Errorf("score=%d → %s, want %s", *s, actual, c.tier)
+			}
+		})
+	}
+}
+
+func tierName(s Score) string {
+	switch {
+	case s >= 90:
+		return "healthy"
+	case s >= 75:
+		return "marginal"
+	default:
+		return "failing"
+	}
+}
+
+func TestCompute_PopulatesAssurance(t *testing.T) {
+	in := Input{
+		HTTPStatus:                200,
+		AssuranceScanRan:          true,
+		InboundFindingsBySeverity: map[string]int{SeverityMedium: 2},
+	}
+	s := Compute(in)
+	if s.Assurance == nil || *s.Assurance != 80 {
+		t.Errorf("Assurance=%v want=80", s.Assurance)
+	}
+	if s.Composite == nil {
+		t.Fatalf("Composite nil")
+	}
+}

--- a/pkg/clear/clear.go
+++ b/pkg/clear/clear.go
@@ -80,9 +80,17 @@ type Input struct {
 	PromptTokens     *int
 	CompletionTokens *int
 
+	// From the Gatekeeper scan. AssuranceScanRan distinguishes "scan
+	// ran, no findings" (the Healthy=100 case) from "scan didn't run"
+	// (the nil case — typically a non-AIQG path or a Gatekeeper-
+	// disabled deployment). The maps are keyed by severity strings:
+	// "low" / "medium" / "high" / "critical".
+	AssuranceScanRan           bool
+	InboundFindingsBySeverity  map[string]int
+	OutboundFindingsBySeverity map[string]int
+
 	// Future-slice inputs (left for forward compatibility):
 	//   ResponseBodyValid              *bool      // Efficacy structural
-	//   ComplianceFindingCount         *int       // Assurance
 	//   RetryObserved                  *bool      // Reliability
 }
 
@@ -98,9 +106,10 @@ type Input struct {
 // type alias.
 func Compute(in Input) *Scores {
 	s := &Scores{
-		Latency: scoreLatency(in),
-		Cost:    scoreCost(in),
-		// Efficacy/Assurance/Reliability remain nil — future slices.
+		Latency:   scoreLatency(in),
+		Cost:      scoreCost(in),
+		Assurance: scoreAssurance(in),
+		// Efficacy/Reliability remain nil — future slices.
 	}
 	s.Composite = composite(s)
 	if s.Composite != nil {


### PR DESCRIPTION
## Summary
Third CLEAR dimension wired end-to-end. Gatekeeper already scans every AIQG request; this slice captures its per-severity finding counts and turns them into a 0-100 score on every emitted event.

After this slice **three CLEAR dimensions** (Latency, Cost, Assurance) populate on every AIQG-mode request. Composite averages across all non-nil dimensions per the spec's equal-weight default.

## Bucketing (source-spec §2.2.3 stricter tier boundaries)
Assurance carries stricter boundaries than Latency/Cost because failures have asymmetric consequences (one unauthorized disclosure invalidates otherwise perfect performance).

| Worst severity present | Score | Tier |
|---|---|---|
| no findings | 100 | Healthy (≥90) |
| only `low` | 95 | Healthy |
| any `medium` | 80 | Marginal (75-89) |
| any `high` | 50 | Failing (<75) |
| any `critical` | 0 | Failing |

Worst-severity wins — one critical finding shouldn't be diluted by 99 clean checks. Finding **counts** still ride on the embedded `AssuranceSummary` for dashboards that want to slice by frequency.

## Two-state set-ness
- `ScanRan=false` (handler never stamped) → `CLEAR.Assurance: null` + `assurance: omitted` from event JSON. Non-AIQG paths or Gatekeeper-disabled deployments.
- `ScanRan=true` with empty maps → `CLEAR.Assurance: 100` + `assurance: {worst_severity: ""}`. Clean scan, Healthy.

Matches the same set-ness pattern from token-usage stamping.

## New AssuranceSummary on ResponseEvent
```json
"assurance": {
  "inbound_findings":  {"medium": 2, "low": 1},
  "outbound_findings": {},
  "worst_severity": "medium"
}
```
Compact. The full `tag_set` integration (per-NIST-characteristic breakdown, framework attribution, per-finding context) is deferred to its own slice.

## Plumbing
- **`internal/middleware/aiqg_routing.go`**: Routing sidecar gains `inboundFindings`/`outboundFindings`/`scanRan`. New `StampGatekeeperFindings(ctx, direction, severityCounts)` — empty map flips ScanRan true but leaves counts empty (Healthy case); subsequent same-direction stamps **max-aggregate** so multi-stage scans on the same direction don't clobber each other. Snapshot returns **copies** of the count maps to prevent caller mutation racing future stamps.
- **`internal/server/server.go`**: after the inbound Gatekeeper scan returns in `handleChatCompletion`, project `ScanResult.Findings` into a `map[string]int` via `string(f.Severity)` and call `StampGatekeeperFindings`.

## Test plan
- [x] `make test` end-to-end clean (13 packages)
- [x] `pkg/clear/assurance_test.go`: nil-when-not-scanned, healthy-on-clean, 8-case bucketing including cross-direction worst-pick, tier-boundary mapping
- [x] `pkg/clear/clear_test.go`: TestCompute_PopulatesAssurance — wires through Compute
- [x] `internal/middleware/aiqg_routing_test.go`: StampGatekeeperFindings (empty=ScanRan, direction selection, max-aggregate, Snapshot returns copy, nil-safe)
- [x] `internal/middleware/aiqg_test.go`: TestAIQG_GatekeeperFindingsStampedReachEventAndAssurance, TestAIQG_CleanScanScoresAssurance100, TestAIQG_NoScanLeavesAssuranceNil

🤖 Generated with [Claude Code](https://claude.com/claude-code)