### PR TITLE
feat: fill the clear.Efficacy dimension from vendor finish_reason

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -231,6 +231,7 @@ func routingView(r *Routing) events.RoutingView {
 		InboundFindings:  s.InboundFindings,
 		OutboundFindings: s.OutboundFindings,
 		ScanRan:          s.ScanRan,
+		FinishReason:     s.FinishReason,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -36,6 +36,11 @@ type Routing struct {
 	inboundFindings  map[string]int
 	outboundFindings map[string]int
 	scanRan          bool
+
+	// Vendor finish_reason — "stop" / "length" / "content_filter" /
+	// "tool_calls" / "function_call". Empty string means unset (no
+	// vendor response). First-write-wins like the other stampers.
+	finishReason string
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -70,6 +75,11 @@ type RoutingSnapshot struct {
 	InboundFindings  map[string]int
 	OutboundFindings map[string]int
 	ScanRan          bool
+
+	// Vendor finish_reason captured from the response. Empty when
+	// the vendor never returned one (gateway-blocked, streaming
+	// truncation).
+	FinishReason string
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -89,6 +99,7 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		InboundFindings:  copyCounts(r.inboundFindings),
 		OutboundFindings: copyCounts(r.outboundFindings),
 		ScanRan:          r.scanRan,
+		FinishReason:     r.finishReason,
 	}
 }
 
@@ -191,6 +202,26 @@ func StampTokenUsage(ctx context.Context, promptTokens, completionTokens int) {
 		r.promptTokens = promptTokens
 		r.completionTokens = completionTokens
 		r.usageSet = true
+	}
+}
+
+// StampFinishReason records the vendor-reported finish_reason on the
+// routing sidecar. First-write-wins: the streaming path may stamp
+// from each chunk's choice.FinishReason (only the last chunk
+// typically populates it), but if a later fallback path tries to
+// stamp again the first authoritative value wins.
+func StampFinishReason(ctx context.Context, reason string) {
+	if reason == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.finishReason == "" {
+		r.finishReason = reason
 	}
 }
 

--- a/internal/middleware/aiqg_routing_test.go
+++ b/internal/middleware/aiqg_routing_test.go
@@ -190,6 +190,44 @@ func TestRouting_StampFindings_NilSafe(t *testing.T) {
 	StampGatekeeperFindings(context.Background(), GatekeeperDirectionInbound, map[string]int{"high": 1})
 }
 
+func TestRouting_StampFinishReason(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	if r.Snapshot().FinishReason != "" {
+		t.Errorf("FinishReason not empty before stamping")
+	}
+
+	StampFinishReason(ctx, "stop")
+	if got := r.Snapshot().FinishReason; got != "stop" {
+		t.Errorf("FinishReason=%q want=stop", got)
+	}
+
+	// First-write-wins.
+	StampFinishReason(ctx, "length")
+	if got := r.Snapshot().FinishReason; got != "stop" {
+		t.Errorf("FinishReason=%q want=stop (idempotent)", got)
+	}
+}
+
+// Empty-string stamps are no-ops (so an early loop iteration that hasn't
+// seen the final chunk's finish_reason doesn't accidentally lock in "").
+func TestRouting_StampFinishReasonEmptyIsNoop(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	StampFinishReason(ctx, "")
+	StampFinishReason(ctx, "")
+	StampFinishReason(ctx, "stop") // first real value wins
+	if got := r.Snapshot().FinishReason; got != "stop" {
+		t.Errorf("FinishReason=%q want=stop", got)
+	}
+}
+
+func TestRouting_StampFinishReason_NilSafe(t *testing.T) {
+	StampFinishReason(context.Background(), "stop") // no panic
+}
+
 func TestRouting_ConcurrentStamps(t *testing.T) {
 	r := NewRouting()
 	ctx := WithRouting(context.Background(), r)

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -690,6 +690,53 @@ func TestAIQG_NoScanLeavesAssuranceNil(t *testing.T) {
 	}
 }
 
+// finish_reason stamped by the handler reaches both ResponseEvent.
+// FinishReason and CLEAR.Efficacy.
+func TestAIQG_FinishReasonStampedReachesEventAndEfficacy(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampFinishReason(r.Context(), "stop")
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	rd := em.Responses()[0].Data
+	if rd.FinishReason != "stop" {
+		t.Errorf("FinishReason=%q want=stop", rd.FinishReason)
+	}
+	if rd.CLEAR.Efficacy == nil || *rd.CLEAR.Efficacy != 100 {
+		t.Errorf("CLEAR.Efficacy=%v want=100", rd.CLEAR.Efficacy)
+	}
+}
+
+// content_filter → Efficacy 0; the request still emits an event with
+// status=success (HTTP 200) but Efficacy registers the policy block.
+func TestAIQG_ContentFilterScoresEfficacy0(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampFinishReason(r.Context(), "content_filter")
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	rd := em.Responses()[0].Data
+	if rd.CLEAR.Efficacy == nil || *rd.CLEAR.Efficacy != 0 {
+		t.Errorf("CLEAR.Efficacy=%v want=0", rd.CLEAR.Efficacy)
+	}
+}
+
 // Vendor/Model stamps made by the downstream handler must reach the
 // emitted event. Proves the Routing sidecar (attached by middleware) +
 // the deferred snapshot read both work end-to-end.
@@ -769,7 +816,7 @@ func TestAIQG_EmittedEventCarriesCLEARScores(t *testing.T) {
 		t.Errorf("CLEAR.Cost should be nil when no usage stamped, got %d", *respEnv.Data.CLEAR.Cost)
 	}
 	if respEnv.Data.CLEAR.Efficacy != nil {
-		t.Errorf("CLEAR.Efficacy should be nil at MVP (response body not captured)")
+		t.Errorf("CLEAR.Efficacy should be nil when no finish_reason stamped, got %d", *respEnv.Data.CLEAR.Efficacy)
 	}
 	if respEnv.Data.CLEAR.Assurance != nil {
 		t.Errorf("CLEAR.Assurance should be nil when no scan stamped, got %d", *respEnv.Data.CLEAR.Assurance)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -439,11 +439,15 @@ func (s *Server) handleNonStreamingCompletion(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// AIQG: stamp the vendor-reported token usage onto the routing
-	// sidecar so the response event carries TokenAccounting + the
-	// clear.Cost dimension scores. No-op outside AIQG mode.
+	// AIQG: stamp the vendor-reported token usage + finish_reason
+	// onto the routing sidecar so the response event carries
+	// TokenAccounting + the clear.Cost / clear.Efficacy dimension
+	// scores. No-ops outside AIQG mode.
 	if resp.Usage != nil {
 		middleware.StampTokenUsage(r.Context(), resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+	}
+	if len(resp.Choices) > 0 {
+		middleware.StampFinishReason(r.Context(), resp.Choices[0].FinishReason)
 	}
 
 	// Add routing metadata to response
@@ -487,12 +491,20 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 
 	// Stream chunks
 	for chunk := range chunks {
-		// AIQG: stamp vendor token usage from the final chunk. OpenAI
-		// emits this on the last chunk when stream_options.include_usage
-		// is set; Anthropic carries it in message_delta. StampTokenUsage
-		// is first-write-wins so safe to call on every chunk.
+		// AIQG: stamp vendor token usage + finish_reason from the
+		// final chunk. OpenAI emits Usage on the last chunk when
+		// stream_options.include_usage is set; Anthropic carries it
+		// in message_delta. FinishReason lives on the per-choice
+		// delta typically on the second-to-last chunk. Both stampers
+		// are first-write-wins so safe to call on every chunk.
 		if chunk.Usage != nil {
 			middleware.StampTokenUsage(r.Context(), chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
+		}
+		for _, c := range chunk.Choices {
+			if c.FinishReason != "" {
+				middleware.StampFinishReason(r.Context(), c.FinishReason)
+				break
+			}
 		}
 
 		data, err := json.Marshal(chunk)
@@ -615,12 +627,20 @@ func (s *Server) handleStreamingCompletionWithRetry(w http.ResponseWriter, r *ht
 
 	// Stream chunks
 	for chunk := range chunks {
-		// AIQG: stamp vendor token usage from the final chunk. OpenAI
-		// emits this on the last chunk when stream_options.include_usage
-		// is set; Anthropic carries it in message_delta. StampTokenUsage
-		// is first-write-wins so safe to call on every chunk.
+		// AIQG: stamp vendor token usage + finish_reason from the
+		// final chunk. OpenAI emits Usage on the last chunk when
+		// stream_options.include_usage is set; Anthropic carries it
+		// in message_delta. FinishReason lives on the per-choice
+		// delta typically on the second-to-last chunk. Both stampers
+		// are first-write-wins so safe to call on every chunk.
 		if chunk.Usage != nil {
 			middleware.StampTokenUsage(r.Context(), chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens)
+		}
+		for _, c := range chunk.Choices {
+			if c.FinishReason != "" {
+				middleware.StampFinishReason(r.Context(), c.FinishReason)
+				break
+			}
 		}
 
 		data, err := json.Marshal(chunk)

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -55,6 +55,11 @@ type RoutingView struct {
 	InboundFindings  map[string]int
 	OutboundFindings map[string]int
 	ScanRan          bool
+
+	// Vendor finish_reason captured from the response. Used both
+	// to populate ResponseEvent.FinishReason (taking precedence
+	// over the BuildOptions value) and to drive clear.Efficacy.
+	FinishReason string
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -176,6 +181,15 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		LifecycleState:            LifecyclePairedWithResponse,
 	}
 
+	// Routing's FinishReason wins over BuildOptions.FinishReason when
+	// both are set — the routing sidecar is the authoritative path
+	// (handler-stamped); BuildOptions.FinishReason exists for tests
+	// and synthetic events.
+	finishReason := opts.FinishReason
+	if routing.FinishReason != "" {
+		finishReason = routing.FinishReason
+	}
+
 	// Build the clear.Input once; reuse for the embedded TokenAccounting
 	// dollar cost so Scores and the per-event accounting agree on prices.
 	clearInput := clear.Input{
@@ -189,6 +203,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		AssuranceScanRan:           routing.ScanRan,
 		InboundFindingsBySeverity:  routing.InboundFindings,
 		OutboundFindingsBySeverity: routing.OutboundFindings,
+		FinishReason:               finishReason,
 	}
 	var tokenAcct *TokenAccounting
 	if routing.UsageSet {
@@ -228,7 +243,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		CompleteAt:        completeAt,
 		Status:            status,
 		HTTPStatus:        opts.HTTPStatus,
-		FinishReason:      opts.FinishReason,
+		FinishReason:      finishReason,
 		Streamed:          snap.ChunkCount > 0,
 		ChunkCount:        snap.ChunkCount,
 		ContentChunkCount: snap.ContentChunkCount,

--- a/pkg/clear/clear.go
+++ b/pkg/clear/clear.go
@@ -89,9 +89,14 @@ type Input struct {
 	InboundFindingsBySeverity  map[string]int
 	OutboundFindingsBySeverity map[string]int
 
+	// Vendor finish_reason for Efficacy scoring. Empty string means
+	// the vendor never returned one (gateway-blocked, streaming
+	// truncation, vendor outage) — Efficacy stays nil in that case.
+	FinishReason string
+
 	// Future-slice inputs (left for forward compatibility):
-	//   ResponseBodyValid              *bool      // Efficacy structural
-	//   RetryObserved                  *bool      // Reliability
+	//   ResponseBodyValid *bool // Efficacy structural-validity sub-metric
+	//   RetryObserved     *bool // Reliability
 }
 
 // Compute runs every dimension scorer against in and returns the
@@ -109,7 +114,8 @@ func Compute(in Input) *Scores {
 		Latency:   scoreLatency(in),
 		Cost:      scoreCost(in),
 		Assurance: scoreAssurance(in),
-		// Efficacy/Reliability remain nil — future slices.
+		Efficacy:  scoreEfficacy(in),
+		// Reliability remains nil — future slice.
 	}
 	s.Composite = composite(s)
 	if s.Composite != nil {

--- a/pkg/clear/efficacy.go
+++ b/pkg/clear/efficacy.go
@@ -1,0 +1,48 @@
+package clear
+
+// scoreEfficacy converts the vendor's finish_reason into a 0-100
+// Efficacy score. This is the MVP — finish-reason-only — implementation
+// of source-spec §2.2.2's Efficacy dimension. Full structural-validity
+// + implicit-acceptance + groundedness sub-metrics need response-body
+// capture (deferred slice).
+//
+// Mapping:
+//
+//	finish_reason   | score | rationale
+//	"stop"          | 100   | clean completion — vendor signaled the model finished naturally
+//	"tool_calls"    | 100   | function-calling success path
+//	"function_call" | 100   | legacy OpenAI function-call path
+//	"length"        |  60   | truncated at max_tokens — output is partial; usable but degraded
+//	"content_filter"|   0   | vendor blocked output — content policy violation
+//	""              |  nil  | finish_reason not captured (streaming truncation, gateway block, vendor outage)
+//
+// 60 for "length" sits in the Marginal band (50-74 per spec §2.2 default)
+// — partial output isn't a hard failure but it's not Healthy either.
+// 0 for "content_filter" mirrors how Assurance handles critical
+// findings: hard policy outcomes shouldn't be diluted.
+//
+// HTTPStatus=0 (gateway-blocked) returns nil — no vendor response means
+// no finish_reason means no Efficacy signal.
+func scoreEfficacy(in Input) *Score {
+	if in.HTTPStatus == 0 {
+		return nil
+	}
+	if in.FinishReason == "" {
+		return nil
+	}
+	var v Score
+	switch in.FinishReason {
+	case "stop", "tool_calls", "function_call":
+		v = 100
+	case "length":
+		v = 60
+	case "content_filter":
+		v = 0
+	default:
+		// Unknown finish_reason — emerging values like "max_tokens" or
+		// "end_turn" we haven't seen yet. Return nil rather than guess
+		// so dashboards can flag the request and prompt a code update.
+		return nil
+	}
+	return &v
+}

--- a/pkg/clear/efficacy_test.go
+++ b/pkg/clear/efficacy_test.go
@@ -1,0 +1,63 @@
+package clear
+
+import "testing"
+
+func TestScoreEfficacy_FinishReasonMap(t *testing.T) {
+	cases := []struct {
+		reason string
+		want   Score
+		hasVal bool
+	}{
+		{"stop", 100, true},
+		{"tool_calls", 100, true},
+		{"function_call", 100, true},
+		{"length", 60, true},
+		{"content_filter", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.reason, func(t *testing.T) {
+			s := scoreEfficacy(Input{HTTPStatus: 200, FinishReason: c.reason})
+			if s == nil {
+				t.Fatalf("nil for %q", c.reason)
+			}
+			if *s != c.want {
+				t.Errorf("%q → %d, want %d", c.reason, *s, c.want)
+			}
+		})
+	}
+}
+
+// Empty finish_reason → nil (vendor didn't return one). Distinct from
+// any of the documented values.
+func TestScoreEfficacy_EmptyIsNil(t *testing.T) {
+	if s := scoreEfficacy(Input{HTTPStatus: 200, FinishReason: ""}); s != nil {
+		t.Errorf("empty FinishReason should produce nil, got %d", *s)
+	}
+}
+
+// Unknown finish_reason (emerging vendor value we haven't mapped yet)
+// → nil rather than a guess. Lets dashboards surface the unmapped
+// value and prompt a code update.
+func TestScoreEfficacy_UnknownIsNil(t *testing.T) {
+	for _, r := range []string{"end_turn", "max_tokens", "unknown_value", "STOP"} { // STOP — case matters
+		if s := scoreEfficacy(Input{HTTPStatus: 200, FinishReason: r}); s != nil {
+			t.Errorf("unknown %q should produce nil, got %d", r, *s)
+		}
+	}
+}
+
+// HTTPStatus=0 (gateway-blocked) — no vendor response, no finish_reason
+// signal, nil score.
+func TestScoreEfficacy_GatewayBlocked(t *testing.T) {
+	if s := scoreEfficacy(Input{HTTPStatus: 0, FinishReason: "stop"}); s != nil {
+		t.Errorf("HTTPStatus=0 should nil out, got %d", *s)
+	}
+}
+
+// Compute end-to-end: FinishReason wires through.
+func TestCompute_PopulatesEfficacy(t *testing.T) {
+	s := Compute(Input{HTTPStatus: 200, FinishReason: "length"})
+	if s.Efficacy == nil || *s.Efficacy != 60 {
+		t.Errorf("Efficacy=%v want=60", s.Efficacy)
+	}
+}


### PR DESCRIPTION
## Summary
Fourth CLEAR dimension wired end-to-end. MVP scope is **finish-reason only** — the spec's structural-validity / implicit-acceptance / groundedness sub-metrics need response-body parsing (deferred slice).

After this slice **four of five** CLEAR dimensions populate on every AIQG-mode request with a vendor response (Latency, Cost, Assurance, Efficacy). Only Reliability remains nil-stubbed (needs conversation threading + retry detection).

## Mapping (source-spec §2.2.2)
| `finish_reason` | Score | Tier | Rationale |
|---|---|---|---|
| `stop` | 100 | Healthy | clean completion |
| `tool_calls` | 100 | Healthy | function-calling success |
| `function_call` | 100 | Healthy | legacy OpenAI function-call path |
| `length` | 60 | Marginal | truncated at max_tokens — usable but degraded |
| `content_filter` | 0 | Failing | vendor policy block |
| `""` | nil | — | not captured (gateway-blocked, streaming truncation) |
| unknown | nil | — | emerging vendor value — surface for code update |

**60 for `length`** sits in the Marginal band — partial output isn't a hard failure but it's not Healthy either.
**0 for `content_filter`** mirrors how Assurance handles critical findings: hard policy outcomes shouldn't be diluted.
**nil for unknown** lets dashboards flag the request and prompt a code update (better than guessing).

## Plumbing
- **`internal/middleware/aiqg_routing.go`**: Routing sidecar gains `finishReason`. New `StampFinishReason(ctx, reason)`. Empty-string stamps are **no-ops** — important for the streaming loop, where the first chunks have `FinishReason: ""` and the actual reason only lands on (typically) the second-to-last chunk. First non-empty stamp wins.
- **`pkg/aiqg/events`**: RoutingView gains FinishReason; Build prefers `routing.FinishReason` over `opts.FinishReason` when both are set (routing is the authoritative handler-stamped path; opts is reserved for tests + synthetic events).
- **`internal/server/server.go`**: handlers stamp from `resp.Choices[0].FinishReason` (non-streaming, both direct and retry paths) and from each `chunk.Choices[].FinishReason` inside both streaming loops.

## Test plan
- [x] `make test` end-to-end clean (13 packages)
- [x] `pkg/clear/efficacy_test.go`: full finish_reason → score mapping table, empty=nil, unknown=nil (case-sensitive), HTTPStatus=0=nil, end-to-end via Compute
- [x] `pkg/aiqg/events`: routing.FinishReason takes precedence over opts.FinishReason (existing tests cover; new behavior verified via middleware integration)
- [x] `internal/middleware/aiqg_routing_test.go`: StampFinishReason (first-write-wins, empty-string no-op, nil-safe)
- [x] `internal/middleware/aiqg_test.go`: TestAIQG_FinishReasonStampedReachesEventAndEfficacy, TestAIQG_ContentFilterScoresEfficacy0

## Deferred follow-ups (Efficacy depth)
- Response-body structural validity (JSON parseable, code parses, tool-call args valid) — needs streaming-body buffering
- Implicit acceptance rate (no retry within 60s) — needs cross-request session state
- Groundedness rate (RAG claim-level NLI) — Phase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)