### PR TITLE
fix: also stamp finish_reason in the non-streaming retry path

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -562,10 +562,14 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 		}
 	}
 
-	// AIQG: stamp the vendor-reported token usage (same as the non-retry
-	// path) so the response event carries TokenAccounting + Cost score.
+	// AIQG: stamp the vendor-reported token usage + finish_reason
+	// (same as the non-retry path) so the response event carries
+	// TokenAccounting + Cost + Efficacy scores.
 	if resp.Usage != nil {
 		middleware.StampTokenUsage(r.Context(), resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+	}
+	if len(resp.Choices) > 0 {
+		middleware.StampFinishReason(r.Context(), resp.Choices[0].FinishReason)
 	}
 
 	// Add routing metadata to response


### PR DESCRIPTION
## Summary
PR #30 added `StampFinishReason` in three of the four handler stamp sites but missed the non-streaming retry variant (the path production traffic actually hits — every request flows through it whether or not a fallback fires).

Smoke request on \`aiqg-v4\` after rolling PR #30 returned events with \`finish_reason: null\` and no \`CLEAR.Efficacy\` score. One-line fix to match the existing TokenUsage pattern in the same block.

## Test plan
- [x] \`make test\` clean
- [ ] Rolled to K3s — verify next smoke shows \`finish_reason\` populated + \`CLEAR.Efficacy\` non-nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)