### PR TITLE
feat: fill the clear.Reliability dimension from routing retry signals

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -232,6 +232,9 @@ func routingView(r *Routing) events.RoutingView {
 		OutboundFindings: s.OutboundFindings,
 		ScanRan:          s.ScanRan,
 		FinishReason:     s.FinishReason,
+		AttemptCount:     s.AttemptCount,
+		FallbackUsed:     s.FallbackUsed,
+		RetrySet:         s.RetrySet,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -41,6 +41,12 @@ type Routing struct {
 	// "tool_calls" / "function_call". Empty string means unset (no
 	// vendor response). First-write-wins like the other stampers.
 	finishReason string
+
+	// Routing-layer retry metadata for the MVP Reliability proxy.
+	// attemptCount=0 means unset; 1 = clean first try.
+	attemptCount int
+	fallbackUsed bool
+	retrySet     bool
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -80,6 +86,13 @@ type RoutingSnapshot struct {
 	// the vendor never returned one (gateway-blocked, streaming
 	// truncation).
 	FinishReason string
+
+	// Routing-layer retry signals (from types.RouterMetadata).
+	// RetrySet distinguishes "router didn't surface metadata" (no
+	// score) from "1 attempt, no fallback" (Healthy score).
+	AttemptCount int
+	FallbackUsed bool
+	RetrySet     bool
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -100,6 +113,9 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		OutboundFindings: copyCounts(r.outboundFindings),
 		ScanRan:          r.scanRan,
 		FinishReason:     r.finishReason,
+		AttemptCount:     r.attemptCount,
+		FallbackUsed:     r.fallbackUsed,
+		RetrySet:         r.retrySet,
 	}
 }
 
@@ -222,6 +238,33 @@ func StampFinishReason(ctx context.Context, reason string) {
 	defer r.mu.Unlock()
 	if r.finishReason == "" {
 		r.finishReason = reason
+	}
+}
+
+// StampRetryMetadata records the routing layer's per-request retry
+// outcome — attempt count and whether a cross-provider fallback fired.
+// Drives the MVP Reliability score. First-write-wins; subsequent calls
+// are ignored so the authoritative end-of-request value sticks.
+//
+// Calling with attemptCount=0 is treated as a no-op (the routing layer
+// didn't surface metadata for this request) so RetrySet stays false
+// and Reliability stays nil. Pass attemptCount>=1 once the router
+// returns metadata, even if no retries fired (1 = clean first try,
+// which scores 100).
+func StampRetryMetadata(ctx context.Context, attemptCount int, fallbackUsed bool) {
+	if attemptCount <= 0 {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if !r.retrySet {
+		r.attemptCount = attemptCount
+		r.fallbackUsed = fallbackUsed
+		r.retrySet = true
 	}
 }
 

--- a/internal/middleware/aiqg_routing_test.go
+++ b/internal/middleware/aiqg_routing_test.go
@@ -228,6 +228,42 @@ func TestRouting_StampFinishReason_NilSafe(t *testing.T) {
 	StampFinishReason(context.Background(), "stop") // no panic
 }
 
+func TestRouting_StampRetryMetadata(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	if r.Snapshot().RetrySet {
+		t.Errorf("RetrySet true before stamp")
+	}
+
+	StampRetryMetadata(ctx, 2, true)
+	s := r.Snapshot()
+	if !s.RetrySet || s.AttemptCount != 2 || !s.FallbackUsed {
+		t.Errorf("after stamp: %#v", s)
+	}
+
+	// First-write-wins.
+	StampRetryMetadata(ctx, 99, false)
+	if r.Snapshot().AttemptCount != 2 {
+		t.Errorf("not idempotent")
+	}
+}
+
+// attemptCount=0 is a sentinel for "router didn't surface metadata" —
+// stamp must no-op so RetrySet stays false and Reliability stays nil.
+func TestRouting_StampRetryMetadata_ZeroIsNoop(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+	StampRetryMetadata(ctx, 0, false)
+	if r.Snapshot().RetrySet {
+		t.Errorf("RetrySet=true after attemptCount=0 stamp")
+	}
+}
+
+func TestRouting_StampRetryMetadata_NilSafe(t *testing.T) {
+	StampRetryMetadata(context.Background(), 1, false) // no panic
+}
+
 func TestRouting_ConcurrentStamps(t *testing.T) {
 	r := NewRouting()
 	ctx := WithRouting(context.Background(), r)

--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -737,6 +737,50 @@ func TestAIQG_ContentFilterScoresEfficacy0(t *testing.T) {
 	}
 }
 
+// Retry metadata stamped by the handler reaches CLEAR.Reliability.
+// Clean first try → 100. Validates the four-stamp wire-up of the
+// final CLEAR dimension.
+func TestAIQG_RetryMetadataStampedReachesReliability(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampRetryMetadata(r.Context(), 1, false) // clean first try
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	rd := em.Responses()[0].Data
+	if rd.CLEAR.Reliability == nil || *rd.CLEAR.Reliability != 100 {
+		t.Errorf("Reliability=%v want=100", rd.CLEAR.Reliability)
+	}
+}
+
+// Retry + fallback degrades Reliability.
+func TestAIQG_RetryWithFallbackDegradesReliability(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampRetryMetadata(r.Context(), 2, true) // 1 retry + fallback = 50
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	rd := em.Responses()[0].Data
+	if rd.CLEAR.Reliability == nil || *rd.CLEAR.Reliability != 50 {
+		t.Errorf("Reliability=%v want=50", rd.CLEAR.Reliability)
+	}
+}
+
 // Vendor/Model stamps made by the downstream handler must reach the
 // emitted event. Proves the Routing sidecar (attached by middleware) +
 // the deferred snapshot read both work end-to-end.
@@ -822,7 +866,7 @@ func TestAIQG_EmittedEventCarriesCLEARScores(t *testing.T) {
 		t.Errorf("CLEAR.Assurance should be nil when no scan stamped, got %d", *respEnv.Data.CLEAR.Assurance)
 	}
 	if respEnv.Data.CLEAR.Reliability != nil {
-		t.Errorf("CLEAR.Reliability should be nil at MVP (retry detection not built)")
+		t.Errorf("CLEAR.Reliability should be nil when no retry metadata stamped, got %d", *respEnv.Data.CLEAR.Reliability)
 	}
 	if respEnv.Data.ScoringVersion == "" {
 		t.Errorf("ScoringVersion must be present even with partial scoring")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -449,6 +449,9 @@ func (s *Server) handleNonStreamingCompletion(w http.ResponseWriter, r *http.Req
 	if len(resp.Choices) > 0 {
 		middleware.StampFinishReason(r.Context(), resp.Choices[0].FinishReason)
 	}
+	if metadata != nil {
+		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
+	}
 
 	// Add routing metadata to response
 	if resp.RouterMetadata == nil {
@@ -475,6 +478,14 @@ func (s *Server) handleStreamingCompletion(w http.ResponseWriter, r *http.Reques
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
+
+	// AIQG: stamp the routing-layer retry metadata (drives the MVP
+	// Reliability score). For streaming the metadata is fixed at this
+	// point — the retry chain ran fully before StreamCompletion was
+	// invoked, so the AttemptCount + FallbackUsed are final.
+	if metadata != nil {
+		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
+	}
 
 	// Send routing metadata as first chunk
 	metadataChunk := &types.ChatChunk{
@@ -571,6 +582,9 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 	if len(resp.Choices) > 0 {
 		middleware.StampFinishReason(r.Context(), resp.Choices[0].FinishReason)
 	}
+	if metadata != nil {
+		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
+	}
 
 	// Add routing metadata to response
 	resp.RouterMetadata = metadata
@@ -615,6 +629,14 @@ func (s *Server) handleStreamingCompletionWithRetry(w http.ResponseWriter, r *ht
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
+
+	// AIQG: stamp the routing-layer retry metadata (drives the MVP
+	// Reliability score). For streaming the metadata is fixed at this
+	// point — the retry chain ran fully before StreamCompletion was
+	// invoked, so the AttemptCount + FallbackUsed are final.
+	if metadata != nil {
+		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
+	}
 
 	// Send routing metadata as first chunk
 	metadataChunk := &types.ChatChunk{

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -60,6 +60,14 @@ type RoutingView struct {
 	// to populate ResponseEvent.FinishReason (taking precedence
 	// over the BuildOptions value) and to drive clear.Efficacy.
 	FinishReason string
+
+	// Routing-layer retry signals from types.RouterMetadata. Drive
+	// the MVP Reliability score (a gateway-fulfillment proxy for
+	// the spec's pass@k). RetrySet=false means the routing layer
+	// didn't surface metadata and Reliability stays nil.
+	AttemptCount int
+	FallbackUsed bool
+	RetrySet     bool
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -204,6 +212,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		InboundFindingsBySeverity:  routing.InboundFindings,
 		OutboundFindingsBySeverity: routing.OutboundFindings,
 		FinishReason:               finishReason,
+		AttemptCount:               routing.AttemptCount,
+		FallbackUsed:               routing.FallbackUsed,
 	}
 	var tokenAcct *TokenAccounting
 	if routing.UsageSet {

--- a/pkg/clear/clear.go
+++ b/pkg/clear/clear.go
@@ -94,9 +94,15 @@ type Input struct {
 	// truncation, vendor outage) — Efficacy stays nil in that case.
 	FinishReason string
 
+	// Routing-layer retry signals for the MVP Reliability proxy
+	// (see pkg/clear/reliability.go). AttemptCount of 0 means the
+	// signal wasn't captured; 1 means clean first try.
+	AttemptCount int
+	FallbackUsed bool
+
 	// Future-slice inputs (left for forward compatibility):
 	//   ResponseBodyValid *bool // Efficacy structural-validity sub-metric
-	//   RetryObserved     *bool // Reliability
+	//   ConversationTurnRetry *bool // Reliability cross-request signal
 }
 
 // Compute runs every dimension scorer against in and returns the
@@ -111,11 +117,11 @@ type Input struct {
 // type alias.
 func Compute(in Input) *Scores {
 	s := &Scores{
-		Latency:   scoreLatency(in),
-		Cost:      scoreCost(in),
-		Assurance: scoreAssurance(in),
-		Efficacy:  scoreEfficacy(in),
-		// Reliability remains nil — future slice.
+		Latency:     scoreLatency(in),
+		Cost:        scoreCost(in),
+		Assurance:   scoreAssurance(in),
+		Efficacy:    scoreEfficacy(in),
+		Reliability: scoreReliability(in),
 	}
 	s.Composite = composite(s)
 	if s.Composite != nil {

--- a/pkg/clear/reliability.go
+++ b/pkg/clear/reliability.go
@@ -1,0 +1,59 @@
+package clear
+
+// scoreReliability is the MVP — gateway-fulfillment-proxy —
+// implementation of source-spec §2.2.4's Reliability dimension. The
+// spec's canonical Reliability metric is pass@k (probability of k
+// consecutive identical-input successes), which requires cross-request
+// session state the gateway doesn't yet track. Without that, we use
+// the routing layer's per-request retry/fallback signals as a
+// gateway-side proxy for "how reliably did the gateway fulfill this
+// request":
+//
+//	attempt_count | fallback_used | score | tier
+//	1             | false         | 100   | Healthy   (clean first try)
+//	1             | true          |  75   | Marginal  (shouldn't happen but defensive)
+//	2             | false         |  75   | Marginal  (one in-provider retry)
+//	2             | true          |  50   | Failing   (had to switch providers)
+//	3             | false         |  50   | Failing   (multiple in-provider retries)
+//	3             | true          |  25   | Failing
+//	≥4            | any           |   0   | Failing   (chronic instability)
+//
+// Honest framing for dashboards: this measures the gateway's ability
+// to deliver a vendor response on first attempt, NOT the spec's
+// "model behavior consistency across runs". Once the retry-detection
+// slice lands (60s session windows, similarity matching), this scorer
+// will absorb those signals too.
+//
+// Returns nil when:
+//   - HTTPStatus is 0 (gateway-blocked before forwarding — no attempt
+//     was made, so the dimension has no signal)
+//   - AttemptCount is unset (zero — handler never stamped, the routing
+//     layer didn't surface metadata)
+func scoreReliability(in Input) *Score {
+	if in.HTTPStatus == 0 {
+		return nil
+	}
+	if in.AttemptCount <= 0 {
+		return nil
+	}
+
+	var base Score
+	switch in.AttemptCount {
+	case 1:
+		base = 100
+	case 2:
+		base = 75
+	case 3:
+		base = 50
+	default:
+		base = 0
+	}
+	// Fallback costs an extra tier on top of attempt-count scoring.
+	if in.FallbackUsed && base > 0 {
+		base -= 25
+		if base < 0 {
+			base = 0
+		}
+	}
+	return &base
+}

--- a/pkg/clear/reliability_test.go
+++ b/pkg/clear/reliability_test.go
@@ -1,0 +1,70 @@
+package clear
+
+import "testing"
+
+func TestScoreReliability_Table(t *testing.T) {
+	cases := []struct {
+		name     string
+		attempts int
+		fallback bool
+		want     Score
+	}{
+		{"clean_first_try", 1, false, 100},
+		{"fallback_after_one_attempt_unusual", 1, true, 75},
+		{"one_in_provider_retry", 2, false, 75},
+		{"retry_plus_fallback", 2, true, 50},
+		{"two_retries", 3, false, 50},
+		{"two_retries_plus_fallback", 3, true, 25},
+		{"chronic_4", 4, false, 0},
+		{"chronic_4_plus_fallback_clamped", 4, true, 0}, // base 0 stays 0
+		{"chronic_10", 10, true, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := scoreReliability(Input{HTTPStatus: 200, AttemptCount: c.attempts, FallbackUsed: c.fallback})
+			if s == nil {
+				t.Fatalf("nil score")
+			}
+			if *s != c.want {
+				t.Errorf("attempts=%d fallback=%v → %d, want %d", c.attempts, c.fallback, *s, c.want)
+			}
+		})
+	}
+}
+
+func TestScoreReliability_NilCases(t *testing.T) {
+	// HTTPStatus=0 → no attempt was made
+	if s := scoreReliability(Input{HTTPStatus: 0, AttemptCount: 1}); s != nil {
+		t.Errorf("HTTPStatus=0 should nil out, got %d", *s)
+	}
+	// AttemptCount=0 → routing metadata not surfaced
+	if s := scoreReliability(Input{HTTPStatus: 200, AttemptCount: 0}); s != nil {
+		t.Errorf("AttemptCount=0 should nil out, got %d", *s)
+	}
+}
+
+func TestCompute_PopulatesReliability(t *testing.T) {
+	s := Compute(Input{HTTPStatus: 200, AttemptCount: 1})
+	if s.Reliability == nil || *s.Reliability != 100 {
+		t.Errorf("Reliability=%v want=100", s.Reliability)
+	}
+	// Verify all five dimensions can co-populate (with the right inputs).
+	full := Compute(Input{
+		EndToEndMs:                ptr64(2500), Workflow: "rag",
+		HTTPStatus:                200,
+		Vendor:                    "openai", Model: "gpt-4o-mini",
+		PromptTokens:              intP(100), CompletionTokens: intP(50),
+		AssuranceScanRan:          true,
+		InboundFindingsBySeverity: map[string]int{},
+		FinishReason:              "stop",
+		AttemptCount:              1,
+	})
+	for name, p := range map[string]*Score{
+		"Latency": full.Latency, "Cost": full.Cost, "Efficacy": full.Efficacy,
+		"Assurance": full.Assurance, "Reliability": full.Reliability, "Composite": full.Composite,
+	} {
+		if p == nil {
+			t.Errorf("%s nil — should populate with full inputs", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
**Fifth and final CLEAR dimension wired end-to-end.** All five (Latency, Cost, Assurance, Efficacy, Reliability) now populate on every AIQG-mode request with a vendor response.

MVP scope is a **gateway-fulfillment proxy** — the spec's canonical pass@k metric requires cross-request session state we don't yet track. Honest framing for dashboards: this measures *how reliably the gateway fulfilled this request* using router-layer signals (`attempt_count`, `fallback_used`), NOT the spec's *model behavior consistency across runs*. Once a retry-detection slice lands (60s session windows + similarity matching), this scorer will absorb those signals too.

## Scoring table
| attempt_count | fallback_used | score | tier |
|---|---|---|---|
| 1 | false | 100 | Healthy |
| 1 | true | 75 | Marginal (defensive — shouldn't happen) |
| 2 | false | 75 | Marginal |
| 2 | true | 50 | Failing |
| 3 | false | 50 | Failing |
| 3 | true | 25 | Failing |
| ≥4 | any | 0 | Failing |

Returns nil when HTTPStatus=0 (gateway-blocked, no attempt made) or AttemptCount=0 (router didn't surface metadata).

## Plumbing
- **`internal/middleware/aiqg_routing.go`**: Routing sidecar gains `attemptCount` + `fallbackUsed` + `retrySet`. `StampRetryMetadata(ctx, attempts, fallback)` no-ops when `attempts=0` so an absent metadata pointer can't accidentally lock in a Healthy=100 score.
- **`internal/server/server.go`**: stamps in all 4 handler sites (non-streaming direct + retry; streaming direct + retry) right after the routing metadata is available. For streaming, the metadata is final by the time SSE headers are sent (retry chain ran in `router.Route` before `StreamCompletion` was invoked).

## Test plan
- [x] `make test` end-to-end clean (13 packages)
- [x] `pkg/clear/reliability_test.go`: 9-case scoring table + nil cases (HTTPStatus=0, AttemptCount=0)
- [x] `pkg/clear/clear_test.go`: TestCompute_PopulatesReliability + a full-input case that verifies all five dimensions can co-populate
- [x] `internal/middleware/aiqg_routing_test.go`: StampRetryMetadata (idempotent first-write-wins, attemptCount=0 no-op, nil-safe)
- [x] `internal/middleware/aiqg_test.go`: TestAIQG_RetryMetadataStampedReachesReliability, TestAIQG_RetryWithFallbackDegradesReliability

## What this closes
After this PR + a rollout, every AIQG-mode request emits a CloudEvent with **all five CLEAR scores populated** (plus Composite). The original spec §2.2 CLEAR framework is now end-to-end live in production for the MVP-scoped sub-metrics. Deeper sub-metrics (structural validity, conversation-threading reliability, groundedness NLI) remain on the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)