### PR TITLE
feat: stamp git SHA into AIQG events.GatewayVersion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,8 +128,10 @@ fmt: ## Format code
 ##@ Docker & Containerization
 
 .PHONY: docker-build
-docker-build: ## Build Docker image
-	docker build -f docker/Dockerfile -t ${DOCKER_IMAGE}:${VERSION} .
+docker-build: ## Build Docker image (stamps AIQG events.GatewayVersion with git SHA)
+	docker build -f docker/Dockerfile \
+		--build-arg GATEWAY_VERSION=${GIT_COMMIT} \
+		-t ${DOCKER_IMAGE}:${VERSION} .
 	docker tag ${DOCKER_IMAGE}:${VERSION} ${DOCKER_IMAGE}:latest
 
 .PHONY: docker-run

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,8 +19,18 @@ RUN go mod download
 # Copy source code
 COPY tas-llm-router/ .
 
-# Build with nohs tag (regexp engine, no CGO/Hyperscan needed)
-RUN CGO_ENABLED=0 GOOS=linux go build -tags nohs -a -installsuffix cgo -o llm-router ./cmd/llm-router/main.go
+# Build-time version stamp for AIQG events. The events package reads
+# this via -ldflags "-X .../events.GatewayVersion=<value>" so emitted
+# events carry a stable identifier (git short-SHA) instead of the
+# baked-in "dev" default. Default kept as "dev" so unset builds still
+# produce a meaningful value.
+ARG GATEWAY_VERSION=dev
+
+# Build with nohs tag (regexp engine, no CGO/Hyperscan needed).
+# -ldflags overrides pkg/aiqg/events.GatewayVersion at link time.
+RUN CGO_ENABLED=0 GOOS=linux go build -tags nohs -a -installsuffix cgo \
+    -ldflags "-X github.com/tributary-ai/llm-router-waf/pkg/aiqg/events.GatewayVersion=${GATEWAY_VERSION}" \
+    -o llm-router ./cmd/llm-router/main.go
 
 # Runtime stage
 FROM alpine:latest


### PR DESCRIPTION
## Summary
Live AIQG events have been emitting \`gateway_version: \"dev\"\` since the AIQG work shipped — fine for local dev but unhelpful in production where you want to attribute an event to a specific deploy. This wires a build-arg through the Dockerfile to override the linker default.

## Changes
- **\`docker/Dockerfile\`**: \`ARG GATEWAY_VERSION=dev\` (kept as fallback so raw \`docker build\` still produces a meaningful value); the build RUN line passes \`-ldflags \"-X .../events.GatewayVersion=...\"\` so the linker overrides the package-level var.
- **\`Makefile\`**: \`docker-build\` target now passes \`--build-arg GATEWAY_VERSION=\${GIT_COMMIT}\`, re-using the existing short-SHA variable. Manual \`docker build\` invocations should pass the same arg if they want the SHA stamp; otherwise they get \"dev\".

## Verification
Built locally with \`--build-arg GATEWAY_VERSION=aiqg-v5.1+8928e2b\`. Confirmed the linker replaces the default. The next rollout will emit events with the actual SHA in production.

## Test plan
- [x] Local docker build succeeds with the arg
- [ ] Roll to K3s, smoke a request, confirm \`gateway_version\` in Loki carries the SHA instead of \"dev\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)