### PR TITLE
feat: also stamp outbound Gatekeeper findings onto the routing sidecar

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -570,6 +570,19 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 				s.writeErrorResponse(w, http.StatusForbidden, "response blocked by content policy")
 				return
 			}
+
+			// AIQG: project outbound findings to per-severity counts
+			// and stamp on the routing sidecar. Same pattern as the
+			// inbound stamp in handleChatCompletion. Empty counts
+			// still stamp so the outbound side participates in the
+			// AssuranceSummary even on a clean scan.
+			if result != nil && result.ScanResult != nil {
+				counts := map[string]int{}
+				for _, f := range result.ScanResult.Findings {
+					counts[string(f.Severity)]++
+				}
+				middleware.StampGatekeeperFindings(r.Context(), middleware.GatekeeperDirectionOutbound, counts)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
The Assurance slice (PR #29) only wired the **inbound** Gatekeeper scan. Outbound scan (response content) was already running in \`handleNonStreamingCompletionWithRetry\` but its findings never reached the AIQG event — production events were emitting \`\"assurance\": {}\` with empty inbound/outbound maps because the inbound case was always clean and outbound was never stamped at all.

One-line projection mirroring the inbound stamp:
\`\`\`go
result.ScanResult.Findings → map[severity]int → StampGatekeeperFindings(ctx, GatekeeperDirectionOutbound, counts)
\`\`\`

## What changes in production after rollout
- \`AssuranceSummary.OutboundFindings\` populates when the outbound scan runs (which it does for every successful non-streaming completion when \`gatekeeper.outbound.enabled: true\`).
- \`AssuranceSummary.WorstSeverity\` becomes meaningful when either direction surfaces findings.
- \`clear.Assurance\` score now reflects the worst of both directions, not just inbound.

## Test plan
- [x] \`make test\` clean (existing tests already cover the outbound direction in \`StampGatekeeperFindings\` / \`scoreAssurance\` — only the call site changed)
- [ ] Roll to K3s, smoke a request, confirm Loki event carries \`outbound_findings\` (possibly empty) under \`assurance\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)