### PR TITLE
feat: emit explicit count fields on AssuranceSummary

### DIFF
--- a/internal/middleware/aiqg_test.go
+++ b/internal/middleware/aiqg_test.go
@@ -638,6 +638,62 @@ func TestAIQG_GatekeeperFindingsStampedReachEventAndAssurance(t *testing.T) {
 	}
 }
 
+// Clean scan emits AssuranceSummary with concrete count=0 (not just
+// the omitempty-stripped {}). Dashboards need a slice-able number.
+func TestAIQG_CleanScanEmitsExplicitCounts(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionInbound, map[string]int{})
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionOutbound, map[string]int{})
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	a := em.Responses()[0].Data.Assurance
+	if a == nil {
+		t.Fatalf("AssuranceSummary nil")
+	}
+	if a.InboundCount != 0 || a.OutboundCount != 0 {
+		t.Errorf("clean scan counts: in=%d out=%d (want 0/0)", a.InboundCount, a.OutboundCount)
+	}
+	// JSON marshalling must produce the int fields, even with value 0
+	// (omitempty would strip the maps but NOT named int fields per
+	// Go's encoding/json semantics for typed int).
+	js, _ := json.Marshal(a)
+	if !strings.Contains(string(js), `"inbound_count":0`) {
+		t.Errorf("inbound_count should always emit, got %s", js)
+	}
+}
+
+// Counts populate correctly from findings.
+func TestAIQG_AssuranceCountsSumFindings(t *testing.T) {
+	em := &events.MemoryEmitter{}
+	stampingHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionInbound, map[string]int{"low": 3, "medium": 2})
+		StampGatekeeperFindings(r.Context(), GatekeeperDirectionOutbound, map[string]int{"high": 1})
+		w.WriteHeader(http.StatusOK)
+	})
+	mw := NewAIQG(AIQGConfig{Strict: true, Logger: silentLogger(), Emitter: em})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	req.Header.Set("TAS-Auth", "tas_qg_live_abc")
+	req.Header.Set("Authorization", "Bearer sk")
+	rec := httptest.NewRecorder()
+	mw(stampingHandler).ServeHTTP(rec, req)
+
+	a := em.Responses()[0].Data.Assurance
+	if a.InboundCount != 5 {
+		t.Errorf("InboundCount=%d want=5 (3+2)", a.InboundCount)
+	}
+	if a.OutboundCount != 1 {
+		t.Errorf("OutboundCount=%d want=1", a.OutboundCount)
+	}
+}
+
 // Clean scan (ScanRan=true, no findings) → Assurance = 100, summary
 // emitted with empty maps + no worst severity.
 func TestAIQG_CleanScanScoresAssurance100(t *testing.T) {

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -239,6 +239,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	var assuranceSummary *AssuranceSummary
 	if routing.ScanRan {
 		assuranceSummary = &AssuranceSummary{
+			InboundCount:     sumCounts(routing.InboundFindings),
+			OutboundCount:    sumCounts(routing.OutboundFindings),
 			InboundFindings:  routing.InboundFindings,
 			OutboundFindings: routing.OutboundFindings,
 			WorstSeverity:    worstSeverityIn(routing.InboundFindings, routing.OutboundFindings),
@@ -326,6 +328,18 @@ func clientIP(r *http.Request) string {
 		return r.RemoteAddr
 	}
 	return host
+}
+
+// sumCounts totals the values in a per-severity count map. Used to
+// populate AssuranceSummary.InboundCount / OutboundCount so dashboards
+// have a concrete number to aggregate even on clean scans (where the
+// per-severity maps would be stripped by omitempty).
+func sumCounts(m map[string]int) int {
+	total := 0
+	for _, v := range m {
+		total += v
+	}
+	return total
 }
 
 // worstSeverityIn returns the highest severity present across either

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -186,7 +186,15 @@ type TokenAccounting struct {
 // aether-shared/data-models/aiqg/tag-set.md). This summary keeps the
 // event payload small while still letting Spark/dashboards segment
 // by severity and direction.
+//
+// InboundCount / OutboundCount are total finding counts per direction.
+// They always emit (no `omitempty`) — zero is a meaningful value
+// ("scan ran, found nothing") and dashboards need a concrete number
+// to aggregate. The per-severity maps stay omitempty so a clean scan
+// doesn't bloat the event payload with empty objects.
 type AssuranceSummary struct {
+	InboundCount     int            `json:"inbound_count"`
+	OutboundCount    int            `json:"outbound_count"`
 	InboundFindings  map[string]int `json:"inbound_findings,omitempty"`
 	OutboundFindings map[string]int `json:"outbound_findings,omitempty"`
 	WorstSeverity    string         `json:"worst_severity,omitempty"`


### PR DESCRIPTION
## Summary
Live events were emitting \`\"assurance\": {}\` on clean Gatekeeper scans — observed on every \`aiqg-v5.*\` rollout. The parent struct allocated but its inner fields were all empty: per-severity maps stripped by \`omitempty\`, \`worst_severity\` an empty string. Useless for dashboards that want to slice by finding volume.

Add \`InboundCount\` + \`OutboundCount\` int fields with **no \`omitempty\`** so zero always emits. The per-severity maps stay \`omitempty\` to keep payloads small on clean scans.

## Before / after

| | Before | After |
|---|---|---|
| Clean scan emit | \`\"assurance\": {}\` | \`\"assurance\": {\"inbound_count\": 0, \"outbound_count\": 0}\` |
| With findings | \`\"assurance\": {\"inbound_findings\": {...}, \"worst_severity\": \"medium\"}\` | adds \`inbound_count: N\`, \`outbound_count: N\` |

Dashboards can now \`SUM(assurance.outbound_count)\` for total finding volume regardless of severity distribution, and filter \`assurance.inbound_count == 0\` to identify clean traffic.

## Test plan
- [x] \`make test\` clean
- [x] \`TestAIQG_CleanScanEmitsExplicitCounts\` — verifies \`\"inbound_count\":0\` always appears in marshalled JSON
- [x] \`TestAIQG_AssuranceCountsSumFindings\` — counts correctly sum across severities + directions
- [ ] Roll to K3s, smoke a request, confirm Loki event carries non-empty \`assurance\` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)