### PR TITLE
feat: promote AIQG event fields to top-level logrus labels

### DIFF
--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -43,6 +43,11 @@ type LogEmitter struct {
 
 // Emit logs both envelopes at INFO with the CloudEvents type as a field
 // for downstream filtering (LogQL: `{...} | json | type="com.tas.aiqg.request.v1"`).
+//
+// Top-level fields are promoted via WithFields so LogQL can query them
+// directly (e.g. `{...} | json | clear_composite > 75`) without
+// double-parsing the embedded `payload` string. The payload itself is
+// kept verbatim for consumers that want the full envelope.
 func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseEnvelope) error {
 	if e.Logger == nil {
 		return nil
@@ -55,13 +60,32 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 	if err != nil {
 		return err
 	}
-	e.Logger.WithFields(logrus.Fields{
+
+	reqFields := logrus.Fields{
 		"ce_type":          req.Type,
 		"ce_id":            req.ID,
 		"request_event_id": req.Data.RequestEventID,
 		"payload":          string(reqJSON),
-	}).Info("aiqg request event")
-	e.Logger.WithFields(logrus.Fields{
+		// Routing + attribution — empty strings stay empty in JSON but
+		// LogQL can still filter on them when populated.
+		"vendor":           req.Data.Vendor,
+		"model":            req.Data.Model,
+		"endpoint":         req.Data.Endpoint,
+		"workflow":         req.Data.Workflow,
+		"streaming":        req.Data.Streaming,
+		"region":           req.Data.Region,
+		"tenant_id":        req.Data.TenantID,
+		"aiqg_account_id":  req.Data.AIQGAccountID,
+		"source_app":       req.Data.SourceApp,
+		"dry_run":          req.Data.DryRun,
+		"gateway_version":  req.Data.GatewayVersion,
+	}
+	if req.Data.PolicyBundle != "" {
+		reqFields["policy_bundle"] = req.Data.PolicyBundle
+	}
+	e.Logger.WithFields(reqFields).Info("aiqg request event")
+
+	respFields := logrus.Fields{
 		"ce_type":           resp.Type,
 		"ce_id":             resp.ID,
 		"response_event_id": resp.Data.ResponseEventID,
@@ -69,8 +93,51 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		"http_status":       resp.Data.HTTPStatus,
 		"status":            resp.Data.Status,
 		"chunk_count":       resp.Data.ChunkCount,
+		"streamed":          resp.Data.Streamed,
+		"finish_reason":     resp.Data.FinishReason,
+		"tenant_id":         resp.Data.TenantID,
+		"aiqg_account_id":   resp.Data.AIQGAccountID,
+		"gateway_version":   resp.Data.GatewayVersion,
+		"scoring_version":   resp.Data.ScoringVersion,
 		"payload":           string(respJSON),
-	}).Info("aiqg response event")
+	}
+	// Token accounting — nil-safe; either fully populated or omitted.
+	if ta := resp.Data.TokenAccounting; ta != nil {
+		respFields["prompt_tokens"] = ta.PromptTokens
+		respFields["completion_tokens"] = ta.CompletionTokens
+		respFields["total_tokens"] = ta.TotalTokens
+		respFields["total_cost_usd"] = ta.TotalCostUSD
+	}
+	// CLEAR scores — pointer-fielded; promote each non-nil dimension.
+	if c := resp.Data.CLEAR; c != nil {
+		if c.Cost != nil {
+			respFields["clear_cost"] = *c.Cost
+		}
+		if c.Latency != nil {
+			respFields["clear_latency"] = *c.Latency
+		}
+		if c.Efficacy != nil {
+			respFields["clear_efficacy"] = *c.Efficacy
+		}
+		if c.Assurance != nil {
+			respFields["clear_assurance"] = *c.Assurance
+		}
+		if c.Reliability != nil {
+			respFields["clear_reliability"] = *c.Reliability
+		}
+		if c.Composite != nil {
+			respFields["clear_composite"] = *c.Composite
+		}
+	}
+	// Assurance summary — counts always emit, worst severity when set.
+	if a := resp.Data.Assurance; a != nil {
+		respFields["assurance_inbound_count"] = a.InboundCount
+		respFields["assurance_outbound_count"] = a.OutboundCount
+		if a.WorstSeverity != "" {
+			respFields["assurance_worst_severity"] = a.WorstSeverity
+		}
+	}
+	e.Logger.WithFields(respFields).Info("aiqg response event")
 	return nil
 }
 

--- a/pkg/aiqg/events/event_test.go
+++ b/pkg/aiqg/events/event_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
+	"github.com/tributary-ai/llm-router-waf/pkg/clear"
 )
 
 func TestStatusFromHTTP(t *testing.T) {
@@ -306,6 +307,160 @@ func TestLogEmitter(t *testing.T) {
 
 	// Nil logger must not panic.
 	(&LogEmitter{Logger: nil}).Emit(context.Background(), reqEnv, respEnv)
+}
+
+// fieldCapture is a logrus hook that captures every emitted Entry's
+// Data map for inspection. Used to verify the top-level field
+// promotions on LogEmitter.
+type fieldCapture struct {
+	entries []map[string]any
+}
+
+func (f *fieldCapture) Levels() []logrus.Level { return logrus.AllLevels }
+func (f *fieldCapture) Fire(e *logrus.Entry) error {
+	row := map[string]any{"msg": e.Message}
+	for k, v := range e.Data {
+		row[k] = v
+	}
+	f.entries = append(f.entries, row)
+	return nil
+}
+
+// Field-promotion test: nested values should ride as top-level logrus
+// fields so LogQL can filter on them directly without parsing payload.
+func TestLogEmitter_PromotesNestedFields(t *testing.T) {
+	cap := &fieldCapture{}
+	l := logrus.New()
+	l.SetOutput(testWriter{t})
+	l.AddHook(cap)
+	e := &LogEmitter{Logger: l}
+
+	cost, latency, composite := int16(80), int16(95), int16(88)
+	reqEnv := RequestEnvelope{
+		Type: TypeRequest, ID: "req-1",
+		Data: RequestEvent{
+			RequestEventID: "req-1",
+			Vendor:         "openai",
+			Model:          "gpt-4o-mini",
+			Endpoint:       "/v1/chat/completions",
+			Workflow:       "rag",
+			TenantID:       "tenant-a",
+			AIQGAccountID:  "account-a",
+			SourceApp:      "billing",
+			Streaming:      true,
+			DryRun:         false,
+			GatewayVersion: "aiqg-v5.5+test",
+			PolicyBundle:   "prod-strict",
+		},
+	}
+	respEnv := ResponseEnvelope{
+		Type: TypeResponse, ID: "resp-1",
+		Data: ResponseEvent{
+			ResponseEventID: "resp-1",
+			RequestEventID:  "req-1",
+			Status:          StatusSuccess,
+			HTTPStatus:      200,
+			Streamed:        true,
+			ChunkCount:      42,
+			FinishReason:    "stop",
+			TenantID:        "tenant-a",
+			AIQGAccountID:   "account-a",
+			GatewayVersion:  "aiqg-v5.5+test",
+			ScoringVersion:  "clear-v0.1-mvp",
+			TokenAccounting: &TokenAccounting{
+				PromptTokens:     100,
+				CompletionTokens: 200,
+				TotalTokens:      300,
+				TotalCostUSD:     0.0012,
+			},
+			Assurance: &AssuranceSummary{
+				InboundCount:  2,
+				OutboundCount: 0,
+				WorstSeverity: "medium",
+			},
+		},
+	}
+	// Wire a clear.Scores manually — events imports pkg/clear so this
+	// avoids re-importing it in the test by spinning up a minimal one.
+	// We rely on the LogEmitter's nil-safe code path: if CLEAR is nil
+	// the promoted fields are simply absent. For a population test
+	// we set the field by writing the marshalled JSON; here we use
+	// a helper that constructs the Scores directly.
+	respEnv.Data.CLEAR = makeScoresForTest(&cost, &latency, &composite)
+
+	if err := e.Emit(context.Background(), reqEnv, respEnv); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	if len(cap.entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(cap.entries))
+	}
+
+	req := cap.entries[0]
+	requireField(t, req, "vendor", "openai")
+	requireField(t, req, "model", "gpt-4o-mini")
+	requireField(t, req, "workflow", "rag")
+	requireField(t, req, "tenant_id", "tenant-a")
+	requireField(t, req, "source_app", "billing")
+	requireField(t, req, "streaming", true)
+	requireField(t, req, "policy_bundle", "prod-strict")
+
+	resp := cap.entries[1]
+	requireField(t, resp, "status", StatusSuccess)
+	requireField(t, resp, "streamed", true)
+	requireField(t, resp, "finish_reason", "stop")
+	requireField(t, resp, "prompt_tokens", 100)
+	requireField(t, resp, "total_tokens", 300)
+	requireField(t, resp, "total_cost_usd", 0.0012)
+	requireField(t, resp, "clear_cost", int16(80))
+	requireField(t, resp, "clear_latency", int16(95))
+	requireField(t, resp, "clear_composite", int16(88))
+	requireField(t, resp, "assurance_inbound_count", 2)
+	requireField(t, resp, "assurance_outbound_count", 0)
+	requireField(t, resp, "assurance_worst_severity", "medium")
+}
+
+// Empty/nil nested structs leave their promoted fields absent without
+// panicking — important because not every request has TokenAccounting,
+// CLEAR, or Assurance populated.
+func TestLogEmitter_NilNestedStructs(t *testing.T) {
+	cap := &fieldCapture{}
+	l := logrus.New()
+	l.SetOutput(testWriter{t})
+	l.AddHook(cap)
+	e := &LogEmitter{Logger: l}
+
+	if err := e.Emit(context.Background(),
+		RequestEnvelope{Type: TypeRequest, ID: "r"},
+		ResponseEnvelope{Type: TypeResponse, ID: "s", Data: ResponseEvent{Status: StatusGatewayError}},
+	); err != nil {
+		t.Fatalf("Emit: %v", err)
+	}
+	resp := cap.entries[1]
+	// CLEAR / TokenAccounting / Assurance all nil — promoted fields absent.
+	for _, absent := range []string{
+		"clear_cost", "clear_composite", "prompt_tokens", "total_cost_usd",
+		"assurance_inbound_count", "assurance_worst_severity",
+	} {
+		if _, ok := resp[absent]; ok {
+			t.Errorf("field %q should be absent when nested struct is nil", absent)
+		}
+	}
+}
+
+func requireField(t *testing.T, fields map[string]any, key string, want any) {
+	t.Helper()
+	got, ok := fields[key]
+	if !ok {
+		t.Errorf("field %q missing", key)
+		return
+	}
+	if got != want {
+		t.Errorf("field %q = %v (%T), want %v (%T)", key, got, got, want, want)
+	}
+}
+
+func makeScoresForTest(cost, latency, composite *int16) *clear.Scores {
+	return &clear.Scores{Cost: cost, Latency: latency, Composite: composite}
 }
 
 func TestMemoryEmitter(t *testing.T) {


### PR DESCRIPTION
## Summary
Precursor to the Grafana dashboards (Tier 1.2). LogQL queries against the AIQG event stream currently require double-parsing because the rich data (CLEAR scores, token costs, attribution) lives inside an escaped JSON string in the \`payload\` field. This promotes the high-cardinality filter fields and numeric metrics to top-level \`WithFields\` so dashboards can query them directly.

## Before / after

**Before** — needed to peel \`payload\` apart in every panel:
\`\`\`logql
{namespace=\"tas-llm-router\"} |= \"aiqg response event\"
  | json
  | line_format \"{{.payload}}\"
  | json data=\"data\"
  | line_format \"{{.data}}\"
  | json
  | clear_composite > 75
\`\`\`

**After**:
\`\`\`logql
{namespace=\"tas-llm-router\"} |= \"aiqg response event\"
  | json
  | clear_composite > 75
\`\`\`

## What gets promoted

**Request event**: \`vendor\`, \`model\`, \`endpoint\`, \`workflow\`, \`streaming\`, \`region\`, \`tenant_id\`, \`aiqg_account_id\`, \`source_app\`, \`dry_run\`, \`gateway_version\`, \`policy_bundle\` (when set)

**Response event**: \`status\`, \`http_status\`, \`chunk_count\`, \`streamed\`, \`finish_reason\`, \`tenant_id\`, \`aiqg_account_id\`, \`gateway_version\`, \`scoring_version\`, \`prompt_tokens\`/\`completion_tokens\`/\`total_tokens\`/\`total_cost_usd\` (from TokenAccounting), \`clear_cost\`/\`latency\`/\`efficacy\`/\`assurance\`/\`reliability\`/\`composite\` (each per-dimension nil-safe), \`assurance_inbound_count\`/\`outbound_count\`/\`worst_severity\`

The full \`payload\` JSON stays for consumers that want the complete envelope.

## Test plan
- [x] \`make test\` clean
- [x] \`TestLogEmitter_PromotesNestedFields\` — uses a logrus Hook to capture every Entry's Data map and asserts the new top-level fields populate from CLEAR / TokenAccounting / AssuranceSummary
- [x] \`TestLogEmitter_NilNestedStructs\` — nil sub-structs leave their promoted fields absent (no panic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)