### PR TITLE
fix: use tcpSocket probes for strict AIQG Deployment

### DIFF
--- a/k8s/deployment-aiqg-strict.yaml
+++ b/k8s/deployment-aiqg-strict.yaml
@@ -85,18 +85,26 @@ spec:
         - name: AIQG_TOKENS_FILE
           value: /app/secrets/aiqg/aiqg-tokens.yaml
 
+        # tcpSocket (not httpGet /health) matches the live internal
+        # Deployment pattern. The /health endpoint legitimately returns
+        # 503 in some configurations (Gatekeeper degraded, upstream
+        # checks failing) which kills the liveness probe; tcpSocket
+        # only checks that the process is binding the port. The
+        # /health endpoint itself remains available for ad-hoc probing.
         livenessProbe:
-          httpGet:
-            path: /health
+          tcpSocket:
             port: 8086
           initialDelaySeconds: 30
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         readinessProbe:
-          httpGet:
-            path: /health
+          tcpSocket:
             port: 8086
-          initialDelaySeconds: 5
+          initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
 
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
## Summary
PR #40 used \`httpGet /health\` probes per the internal Deployment's **source** pattern, but the live internal Deployment was manually patched to \`tcpSocket\` long ago — and applying the source-pattern manifest produced 503-on-/health CrashLoopBackOff for the new strict pods.

## What happened
- The \`/health\` endpoint legitimately returns 503 under some upstream-degraded configurations (Gatekeeper checks, dependency probes).
- Strict pods came up, /health returned 503, kubelet killed them on liveness failure, infinite restart loop.
- Internal pods (already patched to tcpSocket out-of-band) kept serving fine.

## Fix
Switch the strict Deployment's probes to \`tcpSocket\` to match operational reality. The \`/health\` endpoint stays available for ad-hoc probing; tcpSocket only checks the process is binding the port.

## Verified live (after patch)
\`\`\`
$ curl -sk gateway.aiqg.tas.scharber.com/v1/chat/completions
HTTP 401  missing_header: TAS-Auth

$ curl -sk -H 'TAS-Auth: tas_qg_live_x' ...
HTTP 401  missing_header: Authorization

$ curl -sk -H 'TAS-Auth: ...' -H 'Authorization: Bearer sk-noop' ...
HTTP 200  + AIQG event in Loki
\`\`\`

## Follow-up
Fixing the underlying /health endpoint to be tolerant of upstream degradation is a separate slice (it's been broken on both the internal and strict Deployments since before any AIQG work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)