### PR TITLE
feat: DashboardResolver — HTTP client of aiqg-dashboard-be's /internal/auth/validate

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -180,3 +180,16 @@ aiqg:
   kafka:
     brokers: []
     topic: ""
+
+  # Dashboard backend integration. When BOTH dashboard_url +
+  # dashboard_internal_auth_token are set, the AIQG middleware uses
+  # a DashboardResolver (HTTP client of aiqg-dashboard-be's
+  # /internal/auth/validate endpoint) INSTEAD of the in-memory
+  # `tokens:` list above. The Tokens list becomes a bootstrap
+  # fallback for when the dashboard-be is degraded at startup.
+  #
+  # Env overrides:
+  #   AIQG_DASHBOARD_URL
+  #   AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN
+  dashboard_url: ""
+  dashboard_internal_auth_token: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,18 @@ type AIQGConfig struct {
 	// Env overrides: AIQG_KAFKA_BROKERS (comma-separated),
 	// AIQG_KAFKA_TOPIC.
 	Kafka AIQGKafkaConfig `yaml:"kafka"`
+
+	// Dashboard backend integration. When both DashboardURL +
+	// DashboardInternalAuthToken are set, the AIQG middleware uses
+	// an HTTP DashboardResolver against aiqg-dashboard-be's
+	// /internal/auth/validate endpoint instead of the in-memory
+	// Tokens list. The Tokens list becomes a bootstrap fallback.
+	//
+	// Env overrides:
+	//   AIQG_DASHBOARD_URL
+	//   AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN
+	DashboardURL               string `yaml:"dashboard_url"`
+	DashboardInternalAuthToken string `yaml:"dashboard_internal_auth_token"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Defined here (not in
@@ -430,6 +442,12 @@ func (c *Config) loadFromEnv() {
 	if topic := os.Getenv("AIQG_KAFKA_TOPIC"); topic != "" {
 		c.AIQG.Kafka.Topic = topic
 	}
+	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
+		c.AIQG.DashboardURL = u
+	}
+	if t := os.Getenv("AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN"); t != "" {
+		c.AIQG.DashboardInternalAuthToken = t
+	}
 	// AIQG_TOKENS_FILE points to a separate YAML file containing the
 	// token list (typically mounted from a Kubernetes Secret so the
 	// list never sits in a ConfigMap). When set + readable, the file's
@@ -601,10 +619,12 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 		return nil
 	}
 	out := &server.AIQGServerConfig{
-		Enabled:     c.AIQG.Enabled,
-		Strict:      c.AIQG.Strict,
-		Region:      c.AIQG.Region,
-		EmitterType: c.AIQG.EmitterType,
+		Enabled:                    c.AIQG.Enabled,
+		Strict:                     c.AIQG.Strict,
+		Region:                     c.AIQG.Region,
+		EmitterType:                c.AIQG.EmitterType,
+		DashboardURL:               c.AIQG.DashboardURL,
+		DashboardInternalAuthToken: c.AIQG.DashboardInternalAuthToken,
 		Kafka: server.AIQGKafkaConfig{
 			Brokers: c.AIQG.Kafka.Brokers,
 			Topic:   c.AIQG.Kafka.Topic,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -127,12 +127,21 @@ type AIQGServerConfig struct {
 	Strict  bool   `yaml:"strict"`
 	Region  string `yaml:"region"`
 
-	// Tokens is the MVP in-memory token store. Production deployments
-	// swap to a dashboard-backend resolver via a separate config knob
-	// (TBD when aiqg-dashboard-be ships). Empty/omitted means no
-	// resolver is wired — tokens stay opaque and events carry empty
-	// tenant fields. Suitable for incremental rollout.
+	// Tokens is the MVP in-memory token store. Used as a fallback
+	// when DashboardURL is unset OR when the dashboard-be is
+	// degraded at startup. Empty/omitted means no MapResolver is
+	// built — events emit with empty tenant fields per the original
+	// incremental-rollout path.
 	Tokens []tokens.ConfigToken `yaml:"tokens"`
+
+	// Dashboard backend integration. When DashboardURL +
+	// DashboardInternalAuthToken are both set, the AIQG middleware
+	// uses a DashboardResolver (HTTP client of
+	// POST /internal/auth/validate) instead of the in-memory
+	// MapResolver. This is the production path; the Secret-mounted
+	// Tokens list becomes a bootstrap fallback only.
+	DashboardURL               string `yaml:"dashboard_url"`
+	DashboardInternalAuthToken string `yaml:"dashboard_internal_auth_token"`
 
 	// EmitterType selects how AIQG events are published:
 	//   "log"   — logrus → Loki (default; works without infra)
@@ -201,15 +210,31 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 		}
 		server.aiqgEmitter = emitter
 
-		// Build the token resolver when tokens are configured. Without
-		// a resolver the middleware accepts any TAS-Auth bearer but
-		// emits events with empty tenant fields — useful for an early
-		// rollout where the token store hasn't shipped yet.
+		// Build the token resolver. Priority:
+		//   1. DashboardResolver (HTTP client of aiqg-dashboard-be) —
+		//      production path, lets ops manage tokens through the
+		//      dashboard UI instead of redeploying the Secret.
+		//   2. MapResolver from the K8s Secret — bootstrap / fallback
+		//      for when dashboard-be isn't yet reachable.
+		//   3. Nil — middleware accepts any bearer as opaque, events
+		//      carry empty tenant fields (incremental-rollout path).
 		var resolver tokens.Resolver
-		if len(config.AIQG.Tokens) > 0 {
+		switch {
+		case config.AIQG.DashboardURL != "" && config.AIQG.DashboardInternalAuthToken != "":
+			dr, err := tokens.NewDashboardResolver(config.AIQG.DashboardURL, config.AIQG.DashboardInternalAuthToken)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build AIQG DashboardResolver: %w", err)
+			}
+			resolver = dr
+			logger.WithField("dashboard_url", config.AIQG.DashboardURL).
+				Info("AIQG token resolver: DashboardResolver (HTTP client of aiqg-dashboard-be)")
+		case len(config.AIQG.Tokens) > 0:
 			mr := tokens.NewMapResolver(config.AIQG.Tokens)
 			resolver = mr
-			logger.WithField("token_count", mr.Len()).Info("AIQG token resolver loaded (in-memory)")
+			logger.WithField("token_count", mr.Len()).
+				Info("AIQG token resolver: MapResolver (K8s Secret) — set aiqg.dashboard_url to switch to the dashboard-be HTTP resolver")
+		default:
+			logger.Info("AIQG token resolver: none — events emit with empty tenant fields")
 		}
 
 		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{

--- a/pkg/aiqg/tokens/dashboard_resolver.go
+++ b/pkg/aiqg/tokens/dashboard_resolver.go
@@ -1,0 +1,171 @@
+package tokens
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// DashboardResolver resolves tas_qg_live_* bearers by calling
+// aiqg-dashboard-be's POST /internal/auth/validate endpoint. Replaces
+// the K8s-Secret-mounted MapResolver for any deployment where the
+// dashboard backend is reachable.
+//
+// HTTP semantic mapping (must match aiqg-dashboard-be PR #3):
+//
+//	200 → populated Token
+//	401 → ErrTokenNotFound  ("token_unknown")
+//	403 → ErrTokenSuspended (still returns the Token so the upstream
+//	      middleware can log the resolved tenant for triage)
+//	5xx / network errors → generic error → middleware emits 503
+//	      "token_resolver_unavailable" to the customer
+//
+// Tight 500ms HTTP timeout — this call is on the hot path of every
+// AIQG request. If dashboard-be is degraded, we'd rather fail fast
+// and surface the 503 to the customer than hold open a request slot.
+type DashboardResolver struct {
+	HTTP              *http.Client
+	BaseURL           string
+	InternalAuthToken string
+}
+
+// NewDashboardResolver builds a Resolver pointed at the configured
+// dashboard-be base URL. baseURL is everything before /internal/auth/validate
+// — typically "http://aiqg-dashboard-be.aiqg.svc.cluster.local:8095" in
+// cluster.
+//
+// The internalAuthToken is the shared secret required by the
+// /internal/* route group; the dashboard-be middleware does a
+// constant-time compare against this value.
+func NewDashboardResolver(baseURL, internalAuthToken string) (*DashboardResolver, error) {
+	if baseURL == "" {
+		return nil, errors.New("tokens.NewDashboardResolver: baseURL required")
+	}
+	if internalAuthToken == "" {
+		return nil, errors.New("tokens.NewDashboardResolver: internalAuthToken required (else dashboard-be rejects)")
+	}
+	return &DashboardResolver{
+		HTTP: &http.Client{
+			// Short timeout — this is on every AIQG request's hot path.
+			// If the dashboard-be is degraded the upstream middleware
+			// returns 503 to the customer, which is the right signal:
+			// retry, don't block.
+			Timeout: 500 * time.Millisecond,
+		},
+		BaseURL:           baseURL,
+		InternalAuthToken: internalAuthToken,
+	}, nil
+}
+
+// validateRequest and validateResponse mirror the shapes in
+// aiqg-dashboard-be/internal/handlers/internal_auth.go. Kept in this
+// repo verbatim rather than imported to avoid a circular dep (the
+// dashboard repo doesn't import this one, but importing it here would
+// pull in Gin etc. just for two struct definitions).
+type validateRequest struct {
+	Bearer string `json:"bearer"`
+}
+
+type validateResponse struct {
+	TokenID       string `json:"token_id"`
+	TenantID      string `json:"tenant_id"`
+	AIQGAccountID string `json:"aiqg_account_id"`
+	SourceApp     string `json:"source_app"`
+	Suspended     bool   `json:"suspended"`
+}
+
+// Resolve calls the dashboard-be validate endpoint and converts its
+// response to the Resolver contract. Always sends a JSON body even
+// for empty bearer (the upstream middleware never calls with empty,
+// so the early ErrTokenNotFound short-circuit here is defense in depth).
+func (r *DashboardResolver) Resolve(ctx context.Context, bearer string) (*Token, error) {
+	if bearer == "" {
+		return nil, ErrTokenNotFound
+	}
+
+	body, err := json.Marshal(validateRequest{Bearer: bearer})
+	if err != nil {
+		return nil, fmt.Errorf("tokens.DashboardResolver: marshal: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.BaseURL+"/internal/auth/validate", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("tokens.DashboardResolver: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Internal-Auth", r.InternalAuthToken)
+
+	resp, err := r.HTTP.Do(req)
+	if err != nil {
+		// Network failure, DNS, timeout — all surface as transport
+		// errors that the upstream middleware logs + maps to 503.
+		return nil, fmt.Errorf("tokens.DashboardResolver: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var v validateResponse
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return nil, fmt.Errorf("tokens.DashboardResolver: decode 200: %w", err)
+		}
+		return &Token{
+			TokenID:       v.TokenID,
+			TenantID:      v.TenantID,
+			AIQGAccountID: v.AIQGAccountID,
+			SourceApp:     v.SourceApp,
+			Suspended:     v.Suspended,
+		}, nil
+
+	case http.StatusUnauthorized:
+		// dashboard-be returns 401 for both "token_unknown" and
+		// "internal_auth_invalid" / "internal_auth_missing". The
+		// latter two are misconfig on OUR side — surface them with
+		// a distinct log so the operator can fix without thinking
+		// it's a customer-bearer issue.
+		body, _ := io.ReadAll(resp.Body)
+		if bodyMentions(body, "internal_auth") {
+			return nil, fmt.Errorf("tokens.DashboardResolver: dashboard-be rejected Internal-Auth (check INTERNAL_AUTH_TOKEN config): %s", string(body))
+		}
+		return nil, ErrTokenNotFound
+
+	case http.StatusForbidden:
+		// Suspended account — surface the resolved Token alongside
+		// the error so the middleware can log the resolved tenant.
+		var partial struct {
+			TokenID       string `json:"token_id"`
+			TenantID      string `json:"tenant_id"`
+			AIQGAccountID string `json:"aiqg_account_id"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&partial)
+		return &Token{
+			TokenID:       partial.TokenID,
+			TenantID:      partial.TenantID,
+			AIQGAccountID: partial.AIQGAccountID,
+			Suspended:     true,
+		}, ErrTokenSuspended
+
+	default:
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("tokens.DashboardResolver: unexpected status %d: %s",
+			resp.StatusCode, string(body))
+	}
+}
+
+// bodyMentions is a substring check used to disambiguate the two
+// reasons dashboard-be returns 401. Keep tight to literal field
+// names from the dashboard-be JSON shape.
+func bodyMentions(body []byte, needle string) bool {
+	for i := 0; i+len(needle) <= len(body); i++ {
+		if string(body[i:i+len(needle)]) == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/aiqg/tokens/dashboard_resolver_test.go
+++ b/pkg/aiqg/tokens/dashboard_resolver_test.go
@@ -1,0 +1,172 @@
+package tokens
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewDashboardResolver_Validation(t *testing.T) {
+	if _, err := NewDashboardResolver("", "x"); err == nil {
+		t.Errorf("expected error for empty baseURL")
+	}
+	if _, err := NewDashboardResolver("http://x", ""); err == nil {
+		t.Errorf("expected error for empty internalAuthToken")
+	}
+}
+
+func TestDashboardResolver_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/auth/validate" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method=%q", r.Method)
+		}
+		if r.Header.Get("Internal-Auth") != "secret-x" {
+			t.Errorf("Internal-Auth header missing or wrong: %q", r.Header.Get("Internal-Auth"))
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Content-Type=%q", r.Header.Get("Content-Type"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"bearer":"tas_qg_live_abc"`) {
+			t.Errorf("body doesn't contain bearer: %s", body)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"token_id":        "tok-1",
+			"tenant_id":       "tenant-a",
+			"aiqg_account_id": "account-a",
+			"source_app":      "billing",
+			"suspended":       false,
+		})
+	}))
+	defer srv.Close()
+
+	r, err := NewDashboardResolver(srv.URL, "secret-x")
+	if err != nil {
+		t.Fatalf("NewDashboardResolver: %v", err)
+	}
+	tok, err := r.Resolve(context.Background(), "tas_qg_live_abc")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if tok.TenantID != "tenant-a" || tok.AIQGAccountID != "account-a" || tok.TokenID != "tok-1" || tok.SourceApp != "billing" {
+		t.Errorf("token mismatch: %#v", tok)
+	}
+}
+
+func TestDashboardResolver_Unauthorized_TokenUnknown(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{"code": "token_unknown", "message": "bearer not recognized"},
+		})
+	}))
+	defer srv.Close()
+
+	r, _ := NewDashboardResolver(srv.URL, "x")
+	_, err := r.Resolve(context.Background(), "tas_qg_live_unknown")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+// dashboard-be also returns 401 when our Internal-Auth header is
+// wrong — distinct from a customer "token_unknown". Disambiguate
+// via the body so the operator sees the right error in logs.
+func TestDashboardResolver_Unauthorized_InternalAuthInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]string{"code": "internal_auth_invalid", "message": "Internal-Auth header did not match"},
+		})
+	}))
+	defer srv.Close()
+
+	r, _ := NewDashboardResolver(srv.URL, "x")
+	_, err := r.Resolve(context.Background(), "tas_qg_live_x")
+	if err == nil || errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("expected misconfig error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Internal-Auth") {
+		t.Errorf("error should mention Internal-Auth: %v", err)
+	}
+}
+
+func TestDashboardResolver_Forbidden_Suspended(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error":           map[string]string{"code": "account_suspended"},
+			"token_id":        "tok-suspended",
+			"tenant_id":       "tenant-b",
+			"aiqg_account_id": "account-b",
+		})
+	}))
+	defer srv.Close()
+
+	r, _ := NewDashboardResolver(srv.URL, "x")
+	tok, err := r.Resolve(context.Background(), "tas_qg_live_suspended")
+	if !errors.Is(err, ErrTokenSuspended) {
+		t.Fatalf("expected ErrTokenSuspended, got %v", err)
+	}
+	if tok == nil {
+		t.Fatalf("Token must be populated even on suspended (for triage logging)")
+	}
+	if tok.TenantID != "tenant-b" || !tok.Suspended {
+		t.Errorf("partial token mismatch: %#v", tok)
+	}
+}
+
+func TestDashboardResolver_500_ReturnsGenericError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	r, _ := NewDashboardResolver(srv.URL, "x")
+	_, err := r.Resolve(context.Background(), "tas_qg_live_x")
+	if err == nil {
+		t.Fatalf("expected error on 500")
+	}
+	// Must NOT be ErrTokenNotFound / ErrTokenSuspended — upstream
+	// middleware needs the distinction to choose 503 vs 401 vs 403.
+	if errors.Is(err, ErrTokenNotFound) || errors.Is(err, ErrTokenSuspended) {
+		t.Errorf("500 should not map to known errors, got %v", err)
+	}
+}
+
+func TestDashboardResolver_NetworkError_ReturnsError(t *testing.T) {
+	// Resolver pointed at an unreachable URL.
+	r, _ := NewDashboardResolver("http://127.0.0.1:1/no-such-port", "x")
+	r.HTTP.Timeout = 50 * time.Millisecond
+	_, err := r.Resolve(context.Background(), "tas_qg_live_x")
+	if err == nil {
+		t.Errorf("expected network error")
+	}
+}
+
+func TestDashboardResolver_EmptyBearer_ShortCircuits(t *testing.T) {
+	r, _ := NewDashboardResolver("http://stub", "x")
+	_, err := r.Resolve(context.Background(), "")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("empty bearer should short-circuit to ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestDashboardResolver_TimeoutBoundsHotPath(t *testing.T) {
+	r, _ := NewDashboardResolver("http://x", "y")
+	if r.HTTP.Timeout > time.Second {
+		t.Errorf("DashboardResolver timeout=%v should be sub-second (this is on the hot path)", r.HTTP.Timeout)
+	}
+}
+
+// Compile-time assertion that DashboardResolver satisfies Resolver.
+var _ Resolver = (*DashboardResolver)(nil)


### PR DESCRIPTION
## Summary
Retires the K8s-Secret-mounted MapResolver as the production token resolution path. When configured, the AIQG middleware calls aiqg-dashboard-be's \`POST /internal/auth/validate\` over private cluster DNS to resolve bearers — ops manages live tokens through the dashboard UI instead of a Secret + rollout.

## Resolver precedence
| Condition | Resolver | Notes |
|---|---|---|
| \`AIQG_DASHBOARD_URL\` + \`AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN\` both set | **DashboardResolver** | Production path |
| Only \`aiqg.tokens\` list populated | MapResolver | Bootstrap / fallback |
| Neither | none | Middleware accepts any bearer as opaque, events emit with empty tenant fields |

## HTTP semantic mapping
Mirrors aiqg-dashboard-be PR #3:
| Backend response | Resolver output |
|---|---|
| 200 | populated \`Token\` |
| 401 \`token_unknown\` | \`ErrTokenNotFound\` |
| 401 \`internal_auth_invalid\` | distinct misconfig error (logged loudly so operators don't blame customer bearers) |
| 403 | \`ErrTokenSuspended\` + partial Token (for triage logging) |
| 5xx / network / timeout | generic error → middleware emits 503 \`token_resolver_unavailable\` |

500ms HTTP timeout. This is on every AIQG request's hot path; fail fast and let the middleware return 503 rather than hold a request slot.

## New config knobs
\`\`\`yaml
aiqg:
  dashboard_url: \"http://aiqg-dashboard-be.aiqg.svc.cluster.local:8095\"
  dashboard_internal_auth_token: \"<from-INTERNAL_AUTH_TOKEN-env>\"
\`\`\`
Env overrides: \`AIQG_DASHBOARD_URL\`, \`AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN\`.

## Test plan
- [x] \`make test\` clean across 14 packages
- [x] **dashboard_resolver_test.go**: happy path with header + body assertions, 401 token_unknown → ErrTokenNotFound, 401 internal_auth_invalid → distinct error, 403 → ErrTokenSuspended + partial token, 500 → generic error, network unreachable → error, empty bearer short-circuit, timeout-bound sanity, compile-time Resolver interface assertion
- [ ] Deploy: bump tas-llm-router image with \`AIQG_DASHBOARD_URL\` + \`AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN\` env vars wired; verify startup log shows \"AIQG token resolver: DashboardResolver\"; smoke test with the existing demo bearer from Tier 2.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)