### PR TITLE
chore: source-sync AIQG_DASHBOARD_URL into k8s/configmap.yaml

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -83,3 +83,9 @@ data:
   AIQG_ENABLED: "true"
   AIQG_STRICT: "false"
   AIQG_REGION: "us-east"
+  # When set, the AIQG middleware uses a DashboardResolver (HTTP
+  # client of aiqg-dashboard-be's /internal/auth/validate) instead of
+  # the K8s-Secret-mounted token list. The Internal-Auth shared
+  # secret comes from llm-router-secret (out-of-band managed) as
+  # AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN.
+  AIQG_DASHBOARD_URL: "http://aiqg-dashboard-be.aiqg.svc.cluster.local:8095"


### PR DESCRIPTION
Patched live during the DashboardResolver rollout. Sync to source so the next `kubectl apply -k k8s/` doesn't quietly remove the key. The Internal-Auth shared secret stays in the out-of-band-managed `llm-router-secret` per the deployment-hygiene lesson from PR #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)