### PR TITLE
fix(clear): score Cost + Efficacy on real production traffic

### DIFF
--- a/pkg/clear/cost.go
+++ b/pkg/clear/cost.go
@@ -8,7 +8,7 @@ import "math"
 //
 // Format: `pricing-vYYYY-MM-DD` reflecting the publication date of the
 // rates encoded in modelPricing.
-const PricingVersion = "pricing-v2026-06-01"
+const PricingVersion = "pricing-v2026-06-05"
 
 // modelPricingEntry is the input/output rate pair for one vendor:model.
 // Rates are USD per 1,000 tokens (matches source-spec §2.1.3's CNA/CPS
@@ -34,7 +34,18 @@ var modelPricing = map[string]modelPricingEntry{
 	"openai:gpt-4-turbo":           {InputCostPer1K: 0.01000, OutputCostPer1K: 0.03000},
 	"openai:gpt-3.5-turbo":         {InputCostPer1K: 0.00050, OutputCostPer1K: 0.00150},
 
-	// Anthropic
+	// Anthropic — Claude 4.x family (current TAS deployment, see
+	// tas-llm-router/configs/config.yaml). Keep rates in sync with that
+	// file; the config and this table can drift independently because
+	// the config doesn't feed the scorer (the table is the
+	// authoritative source for CLEAR.Cost).
+	"anthropic:claude-opus-4-6":            {InputCostPer1K: 0.01500, OutputCostPer1K: 0.07500},
+	"anthropic:claude-sonnet-4-6":          {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
+	"anthropic:claude-haiku-4-5-20251001":  {InputCostPer1K: 0.00080, OutputCostPer1K: 0.00400},
+
+	// Anthropic — Claude 3.x family (legacy, kept for replay /
+	// historical re-scoring; remove once Spark re-score has caught up
+	// to the 4.x cutover).
 	"anthropic:claude-3-7-sonnet-20250219": {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
 	"anthropic:claude-3-5-sonnet-20241022": {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
 	"anthropic:claude-3-5-haiku-20241022":  {InputCostPer1K: 0.00080, OutputCostPer1K: 0.00400},

--- a/pkg/clear/cost_test.go
+++ b/pkg/clear/cost_test.go
@@ -14,6 +14,22 @@ func TestLookupPricing_Known(t *testing.T) {
 	}
 }
 
+// Regression for the empty-CLEAR-chart bug: the Claude 4.x family is
+// what TAS actually serves, but the pricing table only knew about the
+// 3.x line. Cost dropped to nil on every real request and the
+// composite chart never moved.
+func TestLookupPricing_Claude4xCovered(t *testing.T) {
+	for _, model := range []string{
+		"claude-haiku-4-5-20251001",
+		"claude-sonnet-4-6",
+		"claude-opus-4-6",
+	} {
+		if _, _, ok := LookupPricing("anthropic", model); !ok {
+			t.Errorf("anthropic:%s should be priced (it's in configs/config.yaml)", model)
+		}
+	}
+}
+
 func TestLookupPricing_UnknownReturnsFalse(t *testing.T) {
 	for _, c := range []struct{ vendor, model string }{
 		{"openai", "gpt-99-imaginary"},

--- a/pkg/clear/efficacy.go
+++ b/pkg/clear/efficacy.go
@@ -6,20 +6,23 @@ package clear
 // + implicit-acceptance + groundedness sub-metrics need response-body
 // capture (deferred slice).
 //
-// Mapping:
+// Vendor vocabulary is normalized first so the OpenAI ("stop", "length"
+// …) and Anthropic ("end_turn", "max_tokens", "tool_use" …) families
+// score the same outcome the same way. New vendors only need an entry
+// in normalizeFinishReason — the score table stays one source of truth.
 //
-//	finish_reason   | score | rationale
-//	"stop"          | 100   | clean completion — vendor signaled the model finished naturally
-//	"tool_calls"    | 100   | function-calling success path
-//	"function_call" | 100   | legacy OpenAI function-call path
-//	"length"        |  60   | truncated at max_tokens — output is partial; usable but degraded
-//	"content_filter"|   0   | vendor blocked output — content policy violation
-//	""              |  nil  | finish_reason not captured (streaming truncation, gateway block, vendor outage)
+// Mapping (after normalization):
 //
-// 60 for "length" sits in the Marginal band (50-74 per spec §2.2 default)
-// — partial output isn't a hard failure but it's not Healthy either.
-// 0 for "content_filter" mirrors how Assurance handles critical
-// findings: hard policy outcomes shouldn't be diluted.
+//	normalized        | score | rationale
+//	"stop"            | 100   | clean completion — model finished naturally
+//	"tool_calls"      | 100   | function-calling / tool-use success path
+//	"length"          |  60   | truncated at max_tokens — partial output
+//	"content_filter"  |   0   | vendor blocked output — policy violation
+//	"" / unknown      |  nil  | not captured; dashboards flag for code update
+//
+// 60 for "length" sits in the Marginal band (50-74 per spec §2.2 default).
+// 0 for "content_filter" mirrors how Assurance handles critical findings:
+// hard policy outcomes shouldn't be diluted.
 //
 // HTTPStatus=0 (gateway-blocked) returns nil — no vendor response means
 // no finish_reason means no Efficacy signal.
@@ -31,18 +34,48 @@ func scoreEfficacy(in Input) *Score {
 		return nil
 	}
 	var v Score
-	switch in.FinishReason {
-	case "stop", "tool_calls", "function_call":
+	switch normalizeFinishReason(in.FinishReason) {
+	case "stop", "tool_calls":
 		v = 100
 	case "length":
 		v = 60
 	case "content_filter":
 		v = 0
 	default:
-		// Unknown finish_reason — emerging values like "max_tokens" or
-		// "end_turn" we haven't seen yet. Return nil rather than guess
-		// so dashboards can flag the request and prompt a code update.
+		// Unknown finish_reason after normalization — return nil so
+		// dashboards can flag the request and prompt a code update.
 		return nil
 	}
 	return &v
+}
+
+// normalizeFinishReason maps each vendor's native finish-reason
+// vocabulary onto a single canonical set. Vendors don't agree:
+//   - OpenAI: "stop", "length", "tool_calls", "function_call", "content_filter"
+//   - Anthropic: "end_turn", "max_tokens", "stop_sequence", "tool_use"
+//   - Google (future): "STOP", "MAX_TOKENS", "SAFETY", "RECITATION"
+//
+// Both case "stop_sequence" (user-defined stop hit) and "end_turn"
+// (model decided it was done) collapse to "stop" — same outcome from
+// the caller's POV (clean completion, full response). If we ever want
+// to score "asked us to stop early" differently, split here.
+func normalizeFinishReason(r string) string {
+	switch r {
+	// OpenAI passthrough
+	case "stop", "length", "content_filter":
+		return r
+	case "tool_calls", "function_call":
+		return "tool_calls"
+
+	// Anthropic
+	case "end_turn", "stop_sequence":
+		return "stop"
+	case "max_tokens":
+		return "length"
+	case "tool_use":
+		return "tool_calls"
+
+	default:
+		return r
+	}
 }

--- a/pkg/clear/efficacy_test.go
+++ b/pkg/clear/efficacy_test.go
@@ -6,13 +6,19 @@ func TestScoreEfficacy_FinishReasonMap(t *testing.T) {
 	cases := []struct {
 		reason string
 		want   Score
-		hasVal bool
 	}{
-		{"stop", 100, true},
-		{"tool_calls", 100, true},
-		{"function_call", 100, true},
-		{"length", 60, true},
-		{"content_filter", 0, true},
+		// OpenAI vocabulary
+		{"stop", 100},
+		{"tool_calls", 100},
+		{"function_call", 100},
+		{"length", 60},
+		{"content_filter", 0},
+
+		// Anthropic vocabulary (normalized onto the same table)
+		{"end_turn", 100},
+		{"stop_sequence", 100},
+		{"tool_use", 100},
+		{"max_tokens", 60},
 	}
 	for _, c := range cases {
 		t.Run(c.reason, func(t *testing.T) {
@@ -38,8 +44,12 @@ func TestScoreEfficacy_EmptyIsNil(t *testing.T) {
 // Unknown finish_reason (emerging vendor value we haven't mapped yet)
 // → nil rather than a guess. Lets dashboards surface the unmapped
 // value and prompt a code update.
+//
+// "STOP" (uppercase) is the Google Gemini convention — not yet
+// normalized, kept here as a forward-compat reminder that the next
+// vendor wiring needs to extend normalizeFinishReason.
 func TestScoreEfficacy_UnknownIsNil(t *testing.T) {
-	for _, r := range []string{"end_turn", "max_tokens", "unknown_value", "STOP"} { // STOP — case matters
+	for _, r := range []string{"unknown_value", "STOP", "MAX_TOKENS", "SAFETY"} {
 		if s := scoreEfficacy(Input{HTTPStatus: 200, FinishReason: r}); s != nil {
 			t.Errorf("unknown %q should produce nil, got %d", r, *s)
 		}


### PR DESCRIPTION
## Summary
The dashboard chart was stuck at a flat composite=100 because two scorer dimensions silently returned nil for every Anthropic Claude 4.x request — the only family this cluster actually serves.

## Cost
- \`modelPricing\` only knew the Claude 3.x line. \`LookupPricing\` returned `ok=false` for `claude-haiku-4-5-20251001` / `claude-sonnet-4-6` / `claude-opus-4-6`, so `scoreCost` dropped to nil → `clear.cost` stripped from the event payload → composite collapsed to the equal-weight mean of just Latency/Assurance/Reliability (all 100 in steady state).
- Added the three Claude 4.x entries with rates matching `configs/config.yaml` (the authoritative customer-facing list).
- Kept the 3.x rows for historical replay / Spark re-score jobs that haven't caught up to the 4.x cutover.
- `PricingVersion` bumped to `pricing-v2026-06-05` so re-score jobs can identify pre-fix rows.

## Efficacy
- The `finish_reason` switch only knew OpenAI's vocabulary. Anthropic returns `end_turn` / `max_tokens` / `stop_sequence` / `tool_use`, which fell into the default branch → nil.
- Introduced `normalizeFinishReason()` that collapses both vendor vocabularies onto one canonical set. The score table stays one source of truth; adding a future vendor (Google's `STOP`/`MAX_TOKENS`/`SAFETY`) only requires extending normalization.
- `end_turn` / `stop_sequence` → `stop` (100), `max_tokens` → `length` (60), `tool_use` → `tool_calls` (100).

## Test plan (verified)
- [x] `go test ./pkg/clear/...` — new regression test asserts the Claude 4.x family is priced; Efficacy table covers Anthropic vocab
- [x] Pre-existing build failures in other packages are environmental (missing `pkg-config` for hyperscan) — every package that builds passes
- [x] Built `aiqg-v5.9`, rolled to both `llm-router` and `llm-router-aiqg` deployments
- [x] 3 prod smoke requests with varied prompt sizes produced distinct CLEAR vectors (composite 91/100/100, cost 99/100/100, efficacy 60/100/100)
- [x] `token_accounting.total_cost_usd` now reports real dollars ($0.0010408 / $0.000108 / $0.0000288)

🤖 Generated with [Claude Code](https://claude.com/claude-code)