### PR TITLE
fix(clear): tighten Latency + Cost curves for modern LLM traffic

### DIFF
--- a/pkg/clear/clear.go
+++ b/pkg/clear/clear.go
@@ -171,9 +171,14 @@ func scoreLatency(in Input) *Score {
 // domain-specific guidance (§2.2.1: 3s customer-support, 30s code-gen)
 // and extended for the workflow enum in workflow-classification.md §1.1.
 //
-// The unknown / unmapped case returns 10s — the median of the explicit
-// thresholds, chosen so a misclassified workflow scores conservatively
-// in the middle rather than passing or failing trivially.
+// The unknown / unmapped case returns 3s — same as single_turn_qa, the
+// most common shape of unclassified traffic (OpenAI-compatible chat
+// completions without a workflow hint). Tightened from 10s on
+// 2026-06-06 after dashboard testing showed every sub-target request
+// scored 100, collapsing the chart to a flat line. A misclassified
+// long-running workflow now scores worse than its actual SLA would
+// permit, which is the right way to fail: operators notice and
+// re-classify.
 func slaMsForWorkflow(workflow string) int64 {
 	switch workflow {
 	case "single_turn_qa":
@@ -189,7 +194,7 @@ func slaMsForWorkflow(workflow string) int64 {
 	case "agentic":
 		return 30000
 	default:
-		return 10000
+		return 3000
 	}
 }
 

--- a/pkg/clear/clear_test.go
+++ b/pkg/clear/clear_test.go
@@ -24,9 +24,12 @@ func TestSLAMap(t *testing.T) {
 		{"summarization", 15000},
 		{"code_generation", 30000},
 		{"agentic", 30000},
-		{"", 10000},        // unknown → median default
-		{"unknown", 10000}, // explicit unknown → same
-		{"misspelled_workflow_name", 10000},
+		// Unknown workflow → 3s (was 10s). Tightened 2026-06-06 so
+		// unclassified small-context chat requests produce visible
+		// latency signal instead of clamping to 100.
+		{"", 3000},
+		{"unknown", 3000},
+		{"misspelled_workflow_name", 3000},
 	}
 	for _, c := range cases {
 		if got := slaMsForWorkflow(c.workflow); got != c.want {

--- a/pkg/clear/cost.go
+++ b/pkg/clear/cost.go
@@ -82,20 +82,21 @@ func DollarCost(vendor, model string, promptTokens, completionTokens int) (cost 
 }
 
 // scoreCost converts the request's USD cost into a 0-100 score with a
-// logarithmic curve. The boundary points are chosen so the score maps
-// to source-spec §2.1.3's Healthy / Marginal / Failing tiers at round
-// cost values:
+// logarithmic curve. Tightened on 2026-06-06 by shifting the reference
+// point one decade — modern small-context LLM calls (~$0.0005) were
+// pegged at 100 under the old reference, so the chart never showed
+// cost pressure for normal traffic. The new curve:
 //
-//	$0.001 / request → 100 (Healthy)
-//	$0.01  / request → 75  (Healthy / Marginal boundary)
-//	$0.10  / request → 50  (Marginal / Failing boundary)
-//	$1.00  / request → 25
-//	$10+   / request → 0
+//	$0.0001 / request → 100 (Healthy)
+//	$0.001  / request → 75  (typical small chat — now visible signal)
+//	$0.01   / request → 50  (Marginal / Failing boundary)
+//	$0.10   / request → 25
+//	$1.00+  / request → 0
 //
-// Formula: score = 100 − 25 × log10(cost_usd × 1000), clamped to [0,100].
-// The 25-per-decade slope spans 4 orders of magnitude — wide enough to
-// distinguish a $0.001 classifier call from a $1 long-context summary
-// without collapsing every score into the same band.
+// Formula: score = 100 − 25 × log10(cost_usd × 10000), clamped to [0,100].
+// Same 25-per-decade slope as before; just shifted left by one decade
+// so the Healthy/Marginal/Failing bands cover the cost ranges actually
+// observed in production rather than the spec's pre-LLM-era examples.
 //
 // Returns nil when:
 //   - HTTPStatus is 0 (gateway-blocked; cost is meaningless)
@@ -128,7 +129,7 @@ func scoreCost(in Input) *Score {
 		s := Score(100)
 		return &s
 	}
-	score := 100.0 - 25.0*math.Log10(cost*1000.0)
+	score := 100.0 - 25.0*math.Log10(cost*10000.0)
 	switch {
 	case score > 100:
 		score = 100

--- a/pkg/clear/cost_test.go
+++ b/pkg/clear/cost_test.go
@@ -64,26 +64,27 @@ func TestDollarCost(t *testing.T) {
 
 func TestScoreCost_Curve(t *testing.T) {
 	// Boundary checks for the documented curve points using gpt-4o-mini
-	// rates. We feed prompt-only tokens (output rate 4× input) so the
-	// math stays predictable: cost = prompt_tokens × 0.00015/1000.
+	// rates ($0.00015 / 1k input). The curve was tightened one decade
+	// on 2026-06-06 so realistic LLM costs (~$0.0005) score below 100.
+	// cost = prompt_tokens × 0.00015 / 1000.
 	//
-	//   cost $0.001   → 100  → need promptTokens ≈ 6,667
-	//   cost $0.01    → 75   → ≈ 66,667
-	//   cost $0.10    → 50   → ≈ 666,667
-	//   cost $1.00    → 25   → ≈ 6,666,667
-	//   cost $10+     → 0    → ≥ 66,666,667
+	//   cost $0.0001  → 100  → need promptTokens ≈ 667
+	//   cost $0.001   → 75   → ≈ 6,667
+	//   cost $0.01    → 50   → ≈ 66,667
+	//   cost $0.10    → 25   → ≈ 666,667
+	//   cost $1.00+   → 0    → ≥ 6,666,667
 	cases := []struct {
 		name   string
 		prompt int
 		wantLo Score
 		wantHi Score
 	}{
-		{"sub_001_dollar_clamps_to_100", 100, 100, 100},
-		{"around_001_dollar", 6667, 99, 100},
-		{"around_01_dollar", 66_667, 74, 76},
-		{"around_10_cents", 666_667, 49, 51},
-		{"around_1_dollar", 6_666_667, 24, 26},
-		{"around_10_dollars_clamps_to_0", 66_666_667, 0, 1},
+		{"sub_0001_dollar_clamps_to_100", 100, 100, 100},
+		{"around_0001_dollar", 667, 99, 100},
+		{"around_001_dollar", 6_667, 74, 76},
+		{"around_01_dollar", 66_667, 49, 51},
+		{"around_10_cents", 666_667, 24, 26},
+		{"around_1_dollar_clamps_to_0", 6_666_667, 0, 1},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -146,15 +147,19 @@ func TestCompute_PopulatesCostAndComposite(t *testing.T) {
 	if s.Cost == nil {
 		t.Fatalf("Cost nil despite vendor/model/tokens")
 	}
-	// 1k+0.5k for gpt-4o-mini = $0.00045 → ~$0.0005, well in Healthy.
-	if *s.Cost < 90 {
-		t.Errorf("Cost=%d, expected >=90 for cheap request", *s.Cost)
+	// 1k+0.5k for gpt-4o-mini = $0.00045. Under the tightened
+	// 2026-06-06 curve this maps to Score ≈ 83 (Healthy band but
+	// no longer pinned to 100). Old curve placed this at 100.
+	if *s.Cost < 75 || *s.Cost > 95 {
+		t.Errorf("Cost=%d, expected ~83 (Healthy band but below 100) for $0.00045 request", *s.Cost)
 	}
 	if s.Composite == nil {
 		t.Fatalf("Composite nil")
 	}
-	// (Latency + Cost) / 2 ≈ (100 + ~108-clamped-to-100) / 2 = 100
-	if *s.Composite != 100 {
-		t.Errorf("Composite=%d want=100", *s.Composite)
+	// Composite is now (Latency=100 + Cost≈83) / 2 ≈ 91. Healthy
+	// but visible signal — the chart will actually move when this
+	// dimension shifts.
+	if *s.Composite < 85 || *s.Composite > 95 {
+		t.Errorf("Composite=%d want ~91 (Healthy band)", *s.Composite)
 	}
 }


### PR DESCRIPTION
## Summary
Dashboard testing showed every healthy request scoring flat 100 across the board — composite never moved because the curves were calibrated against the source spec's pre-LLM-era examples and clamped sub-target traffic to 100 forever.

## Latency
- Unknown-workflow SLA dropped from 10s to 3s (matches `single_turn_qa`, the most common shape of unclassified OpenAI-compatible chat).
- A 500ms request still scores 100; a 4s request now scores 75; a 9s opus call now scores 0 (was 50).

## Cost
- Reference curve shifted left one decade. Was: \$0.001=100 / \$0.01=75 / \$0.10=50 / \$1.00=25 / \$10+=0. Now: \$0.0001=100 / \$0.001=75 / \$0.01=50 / \$0.10=25 / \$1.00+=0.
- Same 25-per-decade slope; the Healthy/Marginal/Failing bands now cover the cost ranges real LLM traffic actually occupies. A typical 500-token haiku call (\$0.0005) used to clamp to 100; now scores ~83.

## Test plan (verified)
- [x] `go test ./pkg/clear/...` — curve boundary tests updated; `TestSLAMap`, `TestScoreCost_Curve`, `TestCompute_PopulatesCostAndComposite` all pass
- [x] Built + rolled `aiqg-v5.10` to both `llm-router` and `llm-router-aiqg`
- [x] 3 prod scenarios produce distinct CLEAR vectors:
  - Haiku tight max_tokens → composite=91 (efficacy=60)
  - Opus 9.5s call → composite=67 (cost=39, lat=0, eff=100)
  - Healthy haiku baseline → composite=100

🤖 Generated with [Claude Code](https://claude.com/claude-code)