### PR TITLE
fix(aiqg): bump DashboardResolver timeout 500ms → 2s

### DIFF
--- a/pkg/aiqg/tokens/dashboard_resolver.go
+++ b/pkg/aiqg/tokens/dashboard_resolver.go
@@ -25,9 +25,16 @@ import (
 //	5xx / network errors → generic error → middleware emits 503
 //	      "token_resolver_unavailable" to the customer
 //
-// Tight 500ms HTTP timeout — this call is on the hot path of every
-// AIQG request. If dashboard-be is degraded, we'd rather fail fast
-// and surface the 503 to the customer than hold open a request slot.
+// 2s HTTP timeout — this call is on the hot path of every AIQG
+// request, but the original 500ms budget was too tight: a cold
+// dashboard-be replica (BestEffort QoS, fresh PG connection pool)
+// could need ~500-1000ms just to round-trip the validate call,
+// returning 503 token_resolver_unavailable to the customer even
+// though dashboard-be was healthy. Bumped on 2026-06-06 after
+// observed 503s on production smoke traffic. Keep-alive on the
+// shared http.Transport keeps subsequent calls fast (~5-15ms in
+// cluster), so the 2s ceiling only applies to first-after-rollout
+// requests.
 type DashboardResolver struct {
 	HTTP              *http.Client
 	BaseURL           string
@@ -51,11 +58,11 @@ func NewDashboardResolver(baseURL, internalAuthToken string) (*DashboardResolver
 	}
 	return &DashboardResolver{
 		HTTP: &http.Client{
-			// Short timeout — this is on every AIQG request's hot path.
-			// If the dashboard-be is degraded the upstream middleware
-			// returns 503 to the customer, which is the right signal:
-			// retry, don't block.
-			Timeout: 500 * time.Millisecond,
+			// 2s — see the DashboardResolver doc comment for the
+			// "why bumped from 500ms" rationale. Steady-state cluster
+			// roundtrip is ~5-15ms; this only really applies to the
+			// first call after a dashboard-be replica wakes up.
+			Timeout: 2 * time.Second,
 		},
 		BaseURL:           baseURL,
 		InternalAuthToken: internalAuthToken,

--- a/pkg/aiqg/tokens/dashboard_resolver_test.go
+++ b/pkg/aiqg/tokens/dashboard_resolver_test.go
@@ -161,10 +161,18 @@ func TestDashboardResolver_EmptyBearer_ShortCircuits(t *testing.T) {
 	}
 }
 
+// The HTTP timeout caps the AIQG request hot path. 5s would be
+// painful (every cold dashboard-be replica wakeup blocks a customer
+// LLM call for 5s); sub-200ms would 503 on legitimate cold-pool
+// queries. Lock the bound here so a future "just bump it" doesn't
+// silently degrade tail latency.
 func TestDashboardResolver_TimeoutBoundsHotPath(t *testing.T) {
 	r, _ := NewDashboardResolver("http://x", "y")
-	if r.HTTP.Timeout > time.Second {
-		t.Errorf("DashboardResolver timeout=%v should be sub-second (this is on the hot path)", r.HTTP.Timeout)
+	if r.HTTP.Timeout > 3*time.Second {
+		t.Errorf("DashboardResolver timeout=%v too generous — capped at 3s for hot-path responsiveness", r.HTTP.Timeout)
+	}
+	if r.HTTP.Timeout < 500*time.Millisecond {
+		t.Errorf("DashboardResolver timeout=%v too tight — cold dashboard-be replicas need ≥500ms", r.HTTP.Timeout)
 	}
 }
 


### PR DESCRIPTION
## Summary
Production smoke traffic intermittently returned **503 token_resolver_unavailable** to customers even though dashboard-be was healthy. Root cause: the resolver's 500ms HTTP timeout was too tight for the first call to a cold dashboard-be replica (BestEffort QoS, fresh PG connection pool, ~500-1000ms to validate).

- Timeout bumped to 2s. Keep-alive on the shared `http.Transport` keeps every subsequent call to that pod fast (~5-15ms in cluster), so the 2s ceiling really only applies to the first-after-rollout request. Net hot-path budget still sub-2s.
- `TestDashboardResolver_TimeoutBoundsHotPath` updated to bound the timeout at `[500ms, 3s]` so a future \"just bump it again\" doesn't silently degrade tail latency.

## Test plan (verified)
- [x] `go test ./pkg/aiqg/tokens/...`
- [x] Built + rolled `aiqg-v5.11` to both `llm-router` and `llm-router-aiqg`
- [x] 8 mixed haiku/opus requests through the gateway: **8/8 OK**. Pre-fix the same pattern saw ~50% 503 on opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)