### PR TITLE
feat(aiqg): promote end_to_end_ms to top-level event fields

### DIFF
--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -138,6 +138,15 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		respFields["total_tokens"] = ta.TotalTokens
 		respFields["total_cost_usd"] = ta.TotalCostUSD
 	}
+	// Promote end_to_end_ms so LogQL can unwrap it directly — needed
+	// for the dashboard /reports/preview p50/p95 latency queries.
+	// Without this, latency is only reachable by parsing the embedded
+	// `payload` JSON, which LogQL handles awkwardly. Skipped when nil
+	// (request never completed) so dashboards distinguish "not
+	// captured" from "captured as zero".
+	if ms := resp.Data.EventTimestamps.EndToEndMs; ms != nil {
+		respFields["end_to_end_ms"] = *ms
+	}
 	// CLEAR scores — pointer-fielded; promote each non-nil dimension.
 	if c := resp.Data.CLEAR; c != nil {
 		if c.Cost != nil {


### PR DESCRIPTION
## Summary
The dashboard's `/api/v1/reports/preview` endpoint needs to compute p50/p95 latency via Loki's `quantile_over_time + unwrap`, which only works against top-level promoted fields. `end_to_end_ms` previously lived only inside the embedded `event_timestamps` JSON.

3-line addition to the LogEmitter respFields block. Skipped when nil (request never completed) so dashboards distinguish \"not captured\" from \"captured as zero\".

Image bumped to `aiqg-v5.12`. Pairs with `aiqg-dashboard-be#9` (reports/preview handler).

## Test plan (verified)
- [x] `go test ./pkg/aiqg/events/...`
- [x] Built + rolled `aiqg-v5.12` to both `llm-router` and `llm-router-aiqg`
- [x] Fresh request emits `end_to_end_ms` as a promoted field (visible in Loki)
- [x] Dashboard's `/api/v1/reports/preview?days=1` now returns `latency.p50_ms` + `latency.p95_ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)