### PR TITLE
feat(aiqg): auto-classify workflow from request shape

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -235,6 +235,7 @@ func routingView(r *Routing) events.RoutingView {
 		AttemptCount:     s.AttemptCount,
 		FallbackUsed:     s.FallbackUsed,
 		RetrySet:         s.RetrySet,
+		Workflow:         s.Workflow,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -47,6 +47,13 @@ type Routing struct {
 	attemptCount int
 	fallbackUsed bool
 	retrySet     bool
+
+	// Auto-classified workflow string (rag / code_generation / etc.)
+	// from internal/workflow.Classify. Empty when classification was
+	// skipped or returned no match. The events package uses this as a
+	// fallback when the TAS-Workflow header was NOT supplied —
+	// header value always wins to preserve customer intent.
+	workflow string
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -93,6 +100,11 @@ type RoutingSnapshot struct {
 	AttemptCount int
 	FallbackUsed bool
 	RetrySet     bool
+
+	// Auto-classified workflow from internal/workflow.Classify.
+	// Empty when not classified; events.Build uses this as a
+	// fallback when the TAS-Workflow header wasn't sent.
+	Workflow string
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -116,6 +128,7 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		AttemptCount:     r.attemptCount,
 		FallbackUsed:     r.fallbackUsed,
 		RetrySet:         r.retrySet,
+		Workflow:         r.workflow,
 	}
 }
 
@@ -164,6 +177,27 @@ func StampVendor(ctx context.Context, vendor string) {
 	defer r.mu.Unlock()
 	if r.vendor == "" {
 		r.vendor = vendor
+	}
+}
+
+// StampWorkflow records the auto-classified workflow string (rag,
+// code_generation, etc.) for the request. Always loses to the
+// TAS-Workflow header — the events.Build path prefers the header
+// value when set. First write wins. Empty string is a no-op so the
+// classifier can call this unconditionally without overwriting a
+// later, better-informed classification.
+func StampWorkflow(ctx context.Context, workflow string) {
+	if workflow == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.workflow == "" {
+		r.workflow = workflow
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/gatekeeper"
 	"github.com/tributary-ai/llm-router-waf/internal/middleware"
 	"github.com/tributary-ai/llm-router-waf/internal/providers"
+	"github.com/tributary-ai/llm-router-waf/internal/workflow"
 	"github.com/tributary-ai/llm-router-waf/internal/routing"
 	"github.com/tributary-ai/llm-router-waf/internal/security"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
@@ -455,6 +456,10 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// sidecar so the response event carries them. No-op outside AIQG mode.
 	middleware.StampModel(r.Context(), req.Model)
 	middleware.StampStreaming(r.Context(), req.Stream)
+	// AIQG: heuristically classify the workflow from request shape so
+	// the CLEAR latency scorer uses a sensible SLA when the caller
+	// didn't send a TAS-Workflow header. Empty result is a no-op.
+	middleware.StampWorkflow(r.Context(), workflow.Classify(&req))
 
 	// Gatekeeper: check bypass token
 	scanBypassed := false

--- a/internal/workflow/classifier.go
+++ b/internal/workflow/classifier.go
@@ -1,0 +1,196 @@
+// Package workflow heuristically classifies an incoming chat request
+// into one of the AIQG workflow types so the CLEAR latency scorer
+// uses a sensible SLA. Customer-supplied TAS-Workflow headers always
+// win; this code only fires when no header was set.
+//
+// Classifier philosophy:
+//   - Be quick (called on the hot path of every request).
+//   - Be CONSERVATIVE about over-claiming code_generation /
+//     summarization / agentic — when in doubt, return "" and let the
+//     event carry an unknown workflow (3s SLA per pkg/clear). False
+//     negatives are far cheaper than false positives because the
+//     "wrong" SLA distorts the dashboard chart.
+//   - Don't read message body content twice; the caller passes the
+//     already-decoded ChatRequest.
+//
+// Heuristic priority (first match wins):
+//   1. tools / functions present → agentic
+//   2. ANY message looks like a summarization prompt → summarization
+//   3. ANY message looks like a code-generation prompt → code_generation
+//   4. ANY message looks like classification / extraction → classification_extraction
+//   5. prompt contains >=3 RAG-style separators → rag
+//   6. exactly one user message under 500 chars → single_turn_qa
+//   7. otherwise → "" (unknown, falls through to default SLA)
+package workflow
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+// Workflow enum values. Must match validWorkflows in
+// internal/middleware/aiqg_headers.go and slaMsForWorkflow in
+// pkg/clear/clear.go. We keep the strings here as constants rather
+// than re-importing to avoid a middleware → workflow → middleware
+// import cycle.
+const (
+	WorkflowSingleTurnQA            = "single_turn_qa"
+	WorkflowRAG                     = "rag"
+	WorkflowAgentic                 = "agentic"
+	WorkflowSummarization           = "summarization"
+	WorkflowCodeGeneration          = "code_generation"
+	WorkflowClassificationExtract   = "classification_extraction"
+
+	// Single-turn QA upper bound on user-message length. Anything
+	// longer than this is "not a quick question" and falls through to
+	// later rules or unknown.
+	singleTurnQAMaxChars = 500
+	// RAG requires at least N separator hits to be confident this is
+	// retrieval-augmented context rather than incidental document
+	// references.
+	ragMinSeparators = 3
+)
+
+// Separator pattern for RAG detection — same shape as the
+// aiqg-bloated-context Gatekeeper matcher. Reused-by-similarity, not
+// reused-by-import, because Gatekeeper imports the scan engine which
+// adds compile-time bulk this hot path doesn't need.
+var ragSeparatorRe = regexp.MustCompile(`(?i)\b(document|context|source|chunk|passage|reference)(\s*#?\s*\d+)?\s*:`)
+
+// summarizationCues fire when ANY non-system message hints at a
+// summarization task. "Summarize" / "summary" / "tl;dr" / "in X
+// bullet points" / "key takeaways".
+var summarizationCues = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(summari[sz]e|summary|tl;?dr)\b`),
+	regexp.MustCompile(`(?i)\bin\s+\d+\s+(bullet|sentence|paragraph|point)s?\b`),
+	regexp.MustCompile(`(?i)\bkey\s+(takeaway|point|finding)s?\b`),
+}
+
+// codeGenCues fire when a message asks for code. The presence of a
+// fenced code block alone isn't enough — that can be context for a
+// non-code question. We require an explicit ask. The .*? between
+// verb and noun tolerates intervening modifiers (e.g. "write a
+// Python function").
+var codeGenCues = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(write|implement|generate|refactor|fix|debug)\b[^.!?\n]{0,40}\b(code|function|class|method|module|script|program|implementation|unit\s+test|test)\b`),
+	regexp.MustCompile(`(?i)\b(?:in|using)\s+(?:python|javascript|typescript|java|go|golang|rust|c\+\+|c#|ruby|kotlin|swift)\b.*\b(?:function|class|method|implementation|code)\b`),
+	regexp.MustCompile(`(?i)\bcomplete\s+(?:the|this)\s+(?:function|method|class|implementation)\b`),
+}
+
+// classificationCues fire when the request looks like a labeling /
+// extraction task — discrete output expected.
+var classificationCues = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)\b(?:classify|categor(?:i[sz]e|y)|label|tag)\s+(?:the|this|each|every|following)\b`),
+	// "Is this X a Y or Z (sentiment)?" — tolerate an optional
+	// trailing noun before the question mark / sentence end.
+	regexp.MustCompile(`(?i)\bis\s+(?:the|this)\s+\w+\s+(?:a|an)\s+\w+\s+or\s+\w+(?:\s+\w+)?[?.!]`),
+	regexp.MustCompile(`(?i)\bextract\s+(?:the|all|every)?\s*\w+\s+from\b`),
+	regexp.MustCompile(`(?i)\bwhich\s+(?:category|class|label|type)\b`),
+}
+
+// Classify returns one of the WorkflowXxx constants or "" when no
+// confident classification was found. Pure heuristic, no I/O.
+func Classify(req *types.ChatRequest) string {
+	if req == nil {
+		return ""
+	}
+
+	// Rule 1: tool / function calling → agentic.
+	if len(req.Tools) > 0 || len(req.Functions) > 0 {
+		return WorkflowAgentic
+	}
+
+	// Concatenate user-role message text once so each cue scans the
+	// same buffer. System prompts are excluded because long system
+	// prompts shouldn't dominate the classification.
+	var userText strings.Builder
+	var userMsgCount int
+	var longestUserMsg int
+	for _, m := range req.Messages {
+		if m.Role != "user" {
+			continue
+		}
+		s := messageText(m)
+		if s == "" {
+			continue
+		}
+		userMsgCount++
+		if len(s) > longestUserMsg {
+			longestUserMsg = len(s)
+		}
+		if userText.Len() > 0 {
+			userText.WriteString("\n")
+		}
+		userText.WriteString(s)
+	}
+	body := userText.String()
+	if body == "" {
+		return ""
+	}
+
+	// Rules 2-4: cue-pattern matches. Order chosen so the most
+	// specific intent wins — summarization implies bulk text input
+	// but doesn't always co-occur with the code-gen cues, etc.
+	if anyMatch(body, summarizationCues) {
+		return WorkflowSummarization
+	}
+	if anyMatch(body, codeGenCues) {
+		return WorkflowCodeGeneration
+	}
+	if anyMatch(body, classificationCues) {
+		return WorkflowClassificationExtract
+	}
+
+	// Rule 5: RAG-style multi-document context.
+	if len(ragSeparatorRe.FindAllStringIndex(body, -1)) >= ragMinSeparators {
+		return WorkflowRAG
+	}
+
+	// Rule 6: short single-turn QA.
+	if userMsgCount == 1 && longestUserMsg <= singleTurnQAMaxChars {
+		return WorkflowSingleTurnQA
+	}
+
+	// Fallthrough — unknown. Better to let the default SLA apply than
+	// guess wrong.
+	return ""
+}
+
+func anyMatch(s string, res []*regexp.Regexp) bool {
+	for _, re := range res {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+// messageText extracts the string body from a Message.Content union
+// (string OR []ContentPart for multimodal). For multimodal messages
+// we concatenate every text part — image parts contribute nothing
+// to text-cue matching.
+func messageText(m types.Message) string {
+	switch c := m.Content.(type) {
+	case string:
+		return c
+	case []any:
+		var sb strings.Builder
+		for _, part := range c {
+			pm, ok := part.(map[string]any)
+			if !ok {
+				continue
+			}
+			if t, ok := pm["text"].(string); ok {
+				if sb.Len() > 0 {
+					sb.WriteString("\n")
+				}
+				sb.WriteString(t)
+			}
+		}
+		return sb.String()
+	default:
+		return ""
+	}
+}

--- a/internal/workflow/classifier_test.go
+++ b/internal/workflow/classifier_test.go
@@ -1,0 +1,128 @@
+package workflow
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+func msg(role, content string) types.Message {
+	return types.Message{Role: role, Content: content}
+}
+
+func TestClassify_Agentic_Tools(t *testing.T) {
+	req := &types.ChatRequest{
+		Messages: []types.Message{msg("user", "help me with my tasks")},
+		Tools:    []types.Tool{{}},
+	}
+	if got := Classify(req); got != WorkflowAgentic {
+		t.Errorf("expected agentic, got %q", got)
+	}
+}
+
+func TestClassify_Summarization(t *testing.T) {
+	for _, prompt := range []string{
+		"Please summarize this report.",
+		"In 5 bullet points, recap the meeting.",
+		"What are the key takeaways from this article?",
+		"tl;dr the discussion above.",
+	} {
+		t.Run(prompt[:20], func(t *testing.T) {
+			req := &types.ChatRequest{Messages: []types.Message{msg("user", prompt)}}
+			if got := Classify(req); got != WorkflowSummarization {
+				t.Errorf("prompt %q → %q, want summarization", prompt, got)
+			}
+		})
+	}
+}
+
+func TestClassify_CodeGeneration(t *testing.T) {
+	for _, prompt := range []string{
+		"Write a Python function that reverses a string.",
+		"Implement the binary search method in Go.",
+		"Complete this function: def hello(...)",
+		"Refactor this code to remove the duplication.",
+	} {
+		t.Run(prompt[:20], func(t *testing.T) {
+			req := &types.ChatRequest{Messages: []types.Message{msg("user", prompt)}}
+			if got := Classify(req); got != WorkflowCodeGeneration {
+				t.Errorf("prompt %q → %q, want code_generation", prompt, got)
+			}
+		})
+	}
+}
+
+func TestClassify_Classification(t *testing.T) {
+	for _, prompt := range []string{
+		"Classify the following email as spam or not spam.",
+		"Is this review a positive or negative sentiment?",
+		"Extract the dates from this paragraph.",
+		"Which category does this product belong to?",
+	} {
+		t.Run(prompt[:20], func(t *testing.T) {
+			req := &types.ChatRequest{Messages: []types.Message{msg("user", prompt)}}
+			if got := Classify(req); got != WorkflowClassificationExtract {
+				t.Errorf("prompt %q → %q, want classification_extraction", prompt, got)
+			}
+		})
+	}
+}
+
+func TestClassify_RAG(t *testing.T) {
+	body := "Question: what's mentioned?\n\n" +
+		"Document 1: foo\nDocument 2: bar\nDocument 3: baz\nDocument 4: qux"
+	req := &types.ChatRequest{Messages: []types.Message{msg("user", body)}}
+	if got := Classify(req); got != WorkflowRAG {
+		t.Errorf("expected rag, got %q", got)
+	}
+}
+
+func TestClassify_SingleTurnQA(t *testing.T) {
+	req := &types.ChatRequest{Messages: []types.Message{msg("user", "What's the capital of France?")}}
+	if got := Classify(req); got != WorkflowSingleTurnQA {
+		t.Errorf("expected single_turn_qa, got %q", got)
+	}
+}
+
+func TestClassify_Empty(t *testing.T) {
+	if got := Classify(nil); got != "" {
+		t.Errorf("nil request should classify to empty, got %q", got)
+	}
+	if got := Classify(&types.ChatRequest{}); got != "" {
+		t.Errorf("empty request should classify to empty, got %q", got)
+	}
+}
+
+// A long single-turn user message shouldn't trigger single_turn_qa
+// (>500 chars). Should fall through to "" — better unknown than wrong.
+func TestClassify_LongSingleMessage_FallsThrough(t *testing.T) {
+	long := strings.Repeat("filler text ", 80) // ~960 chars
+	req := &types.ChatRequest{Messages: []types.Message{msg("user", long)}}
+	if got := Classify(req); got != "" {
+		t.Errorf("long single message should fall through to unknown, got %q", got)
+	}
+}
+
+// Multiple user turns + short messages → not single_turn_qa.
+func TestClassify_MultiTurn_NotSingleTurnQA(t *testing.T) {
+	req := &types.ChatRequest{Messages: []types.Message{
+		msg("user", "hi"),
+		msg("assistant", "hello"),
+		msg("user", "how are you"),
+	}}
+	if got := Classify(req); got != "" {
+		t.Errorf("multi-turn → %q, want \"\"", got)
+	}
+}
+
+// Priority test — when tools are present, ALL other cues are ignored.
+func TestClassify_Priority_AgenticOverSummarize(t *testing.T) {
+	req := &types.ChatRequest{
+		Messages: []types.Message{msg("user", "summarize this for me")},
+		Tools:    []types.Tool{{}},
+	}
+	if got := Classify(req); got != WorkflowAgentic {
+		t.Errorf("agentic must win over summarization, got %q", got)
+	}
+}

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -68,6 +68,12 @@ type RoutingView struct {
 	AttemptCount int
 	FallbackUsed bool
 	RetrySet     bool
+
+	// Auto-classified workflow from internal/workflow.Classify.
+	// Used as a fallback when the TAS-Workflow header isn't set —
+	// the header always wins because it represents the customer's
+	// explicit declaration of intent.
+	Workflow string
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -178,7 +184,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		IsAIQGMode:                true,
 		DryRun:                    headers.DryRun,
 		TraceReturned:             headers.Trace,
-		Workflow:                  headers.Workflow,
+		Workflow:                  preferredWorkflow(headers.Workflow, routing.Workflow),
 		PolicyNames:               headers.Policy,
 		PolicyBundle:              headers.PolicyBundle,
 		// SourceApp override from header was already captured above; the
@@ -204,7 +210,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		EndToEndMs:                 snap.EndToEndMs,
 		GatewayOverheadMs:          snap.GatewayOverheadMs,
 		VendorTTFTMs:               snap.VendorTTFTMs,
-		Workflow:                   headers.Workflow,
+		Workflow:                   preferredWorkflow(headers.Workflow, routing.Workflow),
 		HTTPStatus:                 opts.HTTPStatus,
 		Vendor:                     routing.Vendor,
 		Model:                      routing.Model,
@@ -373,4 +379,16 @@ func isStreaming(r *http.Request) bool {
 		}
 	}
 	return false
+}
+
+// preferredWorkflow picks the customer-supplied workflow over the
+// auto-classified value when both are present. Customer intent wins
+// because the classifier is heuristic and may miscategorize legitimate
+// edge cases (a single_turn_qa that happens to contain code blocks,
+// for instance). An empty header falls through to the classifier.
+func preferredWorkflow(headerVal, classified string) string {
+	if headerVal != "" {
+		return headerVal
+	}
+	return classified
 }

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -129,6 +129,11 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		"aiqg_account_id":   resp.Data.AIQGAccountID,
 		"gateway_version":   resp.Data.GatewayVersion,
 		"scoring_version":   resp.Data.ScoringVersion,
+		// Workflow is on the RequestEvent in the schema, but copy it
+		// onto the response log line too so per-workflow dashboard
+		// queries can filter the response stream directly (e.g.
+		// {namespace="tas-llm-router"} | json | workflow="code_generation").
+		"workflow":          req.Data.Workflow,
 		"payload":           string(respJSON),
 	}
 	// Token accounting — nil-safe; either fully populated or omitted.


### PR DESCRIPTION
## Summary
Until now every request without an explicit `TAS-Workflow` header defaulted to unknown → 3s SLA in `clear.scoreLatency`. A legitimate 9s code-gen call scored latency=0 because the scorer treated it as a 3-second single-turn-QA budget. The dashboard chart penalized perfectly-healthy code-gen / summarization / RAG workflows unfairly.

## Classifier (`internal/workflow/classifier.go`)
Pure heuristic, no I/O. Priority order:

1. tools / functions present → `agentic`
2. summarize / tl;dr / \"in N bullet points\" → `summarization`
3. write|implement|generate <code|function|class> → `code_generation`
4. classify / extract / \"is this X or Y\" → `classification_extraction`
5. >=3 RAG-style separators (Document N:, Context:, …) → `rag`
6. single short user message → `single_turn_qa`
7. otherwise → `\"\"` (let default SLA apply — false positives are worse than fallthrough)

## Plumbing
- New `middleware.StampWorkflow` + `workflow` field on the routing snapshot. Customer `TAS-Workflow` header always wins; classifier fills in only when header is absent (`preferredWorkflow` helper in `events.Build`).
- `server.handleChatCompletion` calls `Classify(&req)` right after decode, before routing.
- LogEmitter promotes the resolved workflow on both request AND response log lines so dashboards can filter by workflow.

## Test plan (verified)
- [x] `go test ./internal/workflow/...` — full cue coverage incl. priority + fallthrough cases
- [x] Built + rolled `aiqg-v5.14` to both deployments
- [x] Prod smoke: code-gen / single_turn_qa / summarization prompts each classified correctly; latency scored against the right SLA

🤖 Generated with [Claude Code](https://claude.com/claude-code)