### PR TITLE
feat(aiqg): NIST AI RMF mapping for Gatekeeper findings

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -236,6 +236,7 @@ func routingView(r *Routing) events.RoutingView {
 		FallbackUsed:     s.FallbackUsed,
 		RetrySet:         s.RetrySet,
 		Workflow:         s.Workflow,
+		NISTFindings:     s.NISTFindings,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -54,6 +54,12 @@ type Routing struct {
 	// fallback when the TAS-Workflow header was NOT supplied —
 	// header value always wins to preserve customer intent.
 	workflow string
+
+	// NIST AI RMF characteristic → finding count for this request.
+	// Driven by MapPatternToNIST in nist_classifier.go. Keyed by the
+	// NIST<Characteristic> constants. Direction-agnostic — Section 5
+	// of the Day-1 Report shows the aggregate, not in/out split.
+	nistFindings map[string]int
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -105,6 +111,11 @@ type RoutingSnapshot struct {
 	// Empty when not classified; events.Build uses this as a
 	// fallback when the TAS-Workflow header wasn't sent.
 	Workflow string
+
+	// NIST AI RMF characteristic → finding count for this request.
+	// Direction-agnostic aggregate; Day-1 Report Section 5 renders
+	// these per-characteristic. Nil when no findings.
+	NISTFindings map[string]int
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -129,6 +140,7 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		FallbackUsed:     r.fallbackUsed,
 		RetrySet:         r.retrySet,
 		Workflow:         r.workflow,
+		NISTFindings:     copyCounts(r.nistFindings),
 	}
 }
 
@@ -337,5 +349,29 @@ func StampGatekeeperFindings(ctx context.Context, direction string, severityCoun
 		if count > (*target)[sev] {
 			(*target)[sev] = count
 		}
+	}
+}
+
+// StampNISTFindings accumulates per-NIST-characteristic finding
+// counts onto the routing sidecar. Direction-agnostic — Section 5
+// of the Day-1 Report shows the request-wide aggregate. Counts are
+// SUMMED across calls (vs StampGatekeeperFindings which takes the
+// max) because inbound+outbound findings of the same characteristic
+// are distinct events, not the same event reported twice.
+func StampNISTFindings(ctx context.Context, nistCounts map[string]int) {
+	if len(nistCounts) == 0 {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.nistFindings == nil {
+		r.nistFindings = make(map[string]int, len(nistCounts))
+	}
+	for k, v := range nistCounts {
+		r.nistFindings[k] += v
 	}
 }

--- a/internal/middleware/nist_classifier.go
+++ b/internal/middleware/nist_classifier.go
@@ -1,0 +1,104 @@
+package middleware
+
+// nist_classifier.go — maps Gatekeeper finding pattern IDs onto the
+// four NIST AI RMF (AI Risk Management Framework) characteristics
+// the AIQG dashboard reports under "Trustworthiness":
+//
+//   - Secure & Resilient   — resists adversarial input (injection, jailbreak)
+//   - Privacy-Enhanced     — protects sensitive personal data
+//   - Valid & Reliable     — produces accurate, consistent outputs
+//   - Safe                 — refuses unsafe / non-compliant requests
+//
+// The mapping lives here (tas-llm-router) rather than inside
+// Gatekeeper because it's AIQG-specific and the rest of TAS doesn't
+// need to know about it. Other Gatekeeper consumers see only raw
+// findings; AIQG enriches them with NIST classification before the
+// event is emitted.
+//
+// Categorization scheme: a single PatternID maps to exactly one
+// characteristic. When a future matcher straddles two characteristics
+// (e.g. a "leaked PII via injection" pattern), pick the more
+// actionable bucket — Privacy-Enhanced for PII exposure, since the
+// remediation is data protection.
+
+// NIST AI RMF characteristic constants. Use these strings as map
+// keys throughout the pipeline so the dashboard stays in sync.
+const (
+	NISTSecureResilient  = "secure_resilient"
+	NISTPrivacyEnhanced  = "privacy_enhanced"
+	NISTValidReliable    = "valid_reliable"
+	NISTSafe             = "safe"
+
+	// nistOther is a fallback bucket for findings whose pattern ID
+	// isn't in the table (e.g. a new matcher landed before the
+	// mapping was extended). Surfaces in logs so the gap is visible
+	// but never inflates the headline characteristic counts.
+	nistOther = "other"
+)
+
+// nistByPatternID maps every known Gatekeeper matcher ID to its
+// NIST AI RMF characteristic. Keep alphabetized by ID for easy
+// audit. When a new matcher lands in Gatekeeper, add a row here
+// in the same PR so findings never silently fall into nistOther.
+var nistByPatternID = map[string]string{
+	// AIQG quality matchers (Gatekeeper#8). Bloated context and
+	// refusal both surface as Valid & Reliable failures — degraded
+	// input quality drives degraded output. Role-claim is a soft
+	// prompt injection → Secure & Resilient.
+	"aiqg-bloated-context": NISTValidReliable,
+	"aiqg-refusal":         NISTValidReliable,
+	"aiqg-role-claim":      NISTSecureResilient,
+
+	// Credential exposure — leaked secrets are a privacy issue
+	// (someone's secret in an LLM transcript = data leak).
+	"cred-api-key":          NISTPrivacyEnhanced,
+	"cred-aws-access-key":   NISTPrivacyEnhanced,
+	"cred-aws-secret-key":   NISTPrivacyEnhanced,
+	"cred-azure-key":        NISTPrivacyEnhanced,
+	"cred-connection-string": NISTPrivacyEnhanced,
+	"cred-gcp-key":          NISTPrivacyEnhanced,
+	"cred-jwt-token":        NISTPrivacyEnhanced,
+	"cred-oauth-token":      NISTPrivacyEnhanced,
+	"cred-private-key":      NISTPrivacyEnhanced,
+
+	// Injection — by definition adversarial input.
+	"injection-prompt": NISTSecureResilient,
+	"injection-sql":    NISTSecureResilient,
+	"injection-xss":    NISTSecureResilient,
+
+	// PII — every type is a privacy finding.
+	"pii-address":          NISTPrivacyEnhanced,
+	"pii-bank-account":     NISTPrivacyEnhanced,
+	"pii-credit-card":      NISTPrivacyEnhanced,
+	"pii-dob":              NISTPrivacyEnhanced,
+	"pii-drivers-license":  NISTPrivacyEnhanced,
+	"pii-email":            NISTPrivacyEnhanced,
+	"pii-ip-address":       NISTPrivacyEnhanced,
+	"pii-mrn":              NISTPrivacyEnhanced,
+	"pii-name":             NISTPrivacyEnhanced,
+	"pii-passport":         NISTPrivacyEnhanced,
+	"pii-phone":            NISTPrivacyEnhanced,
+	"pii-ssn":              NISTPrivacyEnhanced,
+}
+
+// MapPatternToNIST returns the NIST characteristic for a Gatekeeper
+// pattern ID. Unknown IDs return nistOther — caller should log so
+// the mapping can be extended.
+func MapPatternToNIST(patternID string) string {
+	if c, ok := nistByPatternID[patternID]; ok {
+		return c
+	}
+	return nistOther
+}
+
+// AllNISTCharacteristics returns the four canonical characteristic
+// strings in display order. Used by the dashboard handler and tests
+// so the Trustworthiness panel's section order is stable.
+func AllNISTCharacteristics() []string {
+	return []string{
+		NISTSecureResilient,
+		NISTPrivacyEnhanced,
+		NISTValidReliable,
+		NISTSafe,
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -510,12 +510,18 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 			// counts and stamp onto the routing sidecar. Drives the
 			// CLEAR.Assurance score and the AssuranceSummary on the
 			// emitted event. Empty counts still flip ScanRan true so
-			// Assurance scores as Healthy=100 rather than nil.
+			// Assurance scores as Healthy=100 rather than nil. Also
+			// computes per-NIST-AI-RMF-characteristic counts so the
+			// Day-1 Report Trustworthiness section can break findings
+			// down by characteristic, not just severity.
 			counts := map[string]int{}
+			nistCounts := map[string]int{}
 			for _, f := range result.ScanResult.Findings {
 				counts[string(f.Severity)]++
+				nistCounts[middleware.MapPatternToNIST(f.PatternID)]++
 			}
 			middleware.StampGatekeeperFindings(r.Context(), middleware.GatekeeperDirectionInbound, counts)
+			middleware.StampNISTFindings(r.Context(), nistCounts)
 		}
 	}
 
@@ -716,13 +722,18 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 			// and stamp on the routing sidecar. Same pattern as the
 			// inbound stamp in handleChatCompletion. Empty counts
 			// still stamp so the outbound side participates in the
-			// AssuranceSummary even on a clean scan.
+			// AssuranceSummary even on a clean scan. Per-NIST-
+			// characteristic counts get stamped alongside, summed
+			// with any inbound NIST counts already on the snapshot.
 			if result != nil && result.ScanResult != nil {
 				counts := map[string]int{}
+				nistCounts := map[string]int{}
 				for _, f := range result.ScanResult.Findings {
 					counts[string(f.Severity)]++
+					nistCounts[middleware.MapPatternToNIST(f.PatternID)]++
 				}
 				middleware.StampGatekeeperFindings(r.Context(), middleware.GatekeeperDirectionOutbound, counts)
+				middleware.StampNISTFindings(r.Context(), nistCounts)
 			}
 		}
 	}

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -74,6 +74,12 @@ type RoutingView struct {
 	// the header always wins because it represents the customer's
 	// explicit declaration of intent.
 	Workflow string
+
+	// NIST AI RMF characteristic → count for this request. Stamped
+	// by the middleware after each scan call. Surfaces on the
+	// AssuranceSummary so the Day-1 Report Trustworthiness section
+	// can render per-characteristic findings.
+	NISTFindings map[string]int
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -250,6 +256,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 			InboundFindings:  routing.InboundFindings,
 			OutboundFindings: routing.OutboundFindings,
 			WorstSeverity:    worstSeverityIn(routing.InboundFindings, routing.OutboundFindings),
+			NISTFindings:     routing.NISTFindings,
 		}
 	}
 

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -180,6 +180,12 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		if a.WorstSeverity != "" {
 			respFields["assurance_worst_severity"] = a.WorstSeverity
 		}
+		// Promote NIST AI RMF per-characteristic counts as flat
+		// top-level fields so LogQL can sum_over_time them directly
+		// in the Day-1 Report Trustworthiness query.
+		for k, v := range a.NISTFindings {
+			respFields["nist_"+k] = v
+		}
 	}
 	e.Logger.WithFields(respFields).Info("aiqg response event")
 	return nil

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -198,6 +198,12 @@ type AssuranceSummary struct {
 	InboundFindings  map[string]int `json:"inbound_findings,omitempty"`
 	OutboundFindings map[string]int `json:"outbound_findings,omitempty"`
 	WorstSeverity    string         `json:"worst_severity,omitempty"`
+	// NISTFindings buckets findings by NIST AI RMF characteristic
+	// (secure_resilient / privacy_enhanced / valid_reliable / safe).
+	// Computed from per-finding pattern IDs via
+	// middleware.MapPatternToNIST. Drives the Day-1 Report
+	// Trustworthiness section. omitempty when no findings.
+	NISTFindings map[string]int `json:"nist_findings,omitempty"`
 }
 
 // Status enum values for ResponseEvent.Status.


### PR DESCRIPTION
## Summary
Unblocks the Day-1 Report \"Trustworthiness\" section (spec §4 Screen 5, Section 5). Each Gatekeeper finding now carries a NIST AI RMF characteristic alongside its severity.

## Mapping
NIST classifier lives in `tas-llm-router/internal/middleware/nist_classifier.go` — not in Gatekeeper, because Gatekeeper is multi-tenant and other consumers don't need AIQG-specific classification. Static table keyed by `PatternMatcher.GetID()`:

| Characteristic | Matchers |
|---|---|
| Secure & Resilient | `injection-sql`, `injection-xss`, `injection-prompt`, `aiqg-role-claim` |
| Privacy-Enhanced | `pii-*` (12), `cred-*` (9) |
| Valid & Reliable | `aiqg-bloated-context`, `aiqg-refusal` |
| Safe | (empty for now — no safety matchers shipped; honest empty state) |

## Plumbing
- New `StampNISTFindings` on the routing snapshot. Sums across calls (vs `StampGatekeeperFindings` which takes the max — inbound and outbound NIST counts are distinct events).
- `routing.NISTFindings` → `events.RoutingView` → `events.AssuranceSummary.NISTFindings`.
- LogEmitter promotes each NIST counter as a top-level Loki field (`nist_secure_resilient`, etc.) so the report handler can `sum_over_time | unwrap` directly.

## Test plan (verified)
- [x] `go test ./internal/middleware/... ./pkg/aiqg/events/...`
- [x] Built + rolled `aiqg-v5.15`
- [x] Role-claim only request → `nist_secure_resilient=2`
- [x] Role-claim + bloated-context request → `nist_secure_resilient=1` + `nist_valid_reliable=1`

Pairs with `aiqg-dashboard-be#12` (preview handler) and `aiqg-ui#15` (Trustworthiness card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)