### PR TITLE
feat(nist): map 3 safety matchers to NIST Safe

### DIFF
--- a/internal/middleware/nist_classifier.go
+++ b/internal/middleware/nist_classifier.go
@@ -54,6 +54,13 @@ var nistByPatternID = map[string]string{
 	"aiqg-hallucination-hedge": NISTValidReliable,
 	"aiqg-malformed-output":    NISTValidReliable,
 
+	// Safety / policy matchers (Gatekeeper#10). Populate the Safe
+	// characteristic — until this PR landed it was always 0 on the
+	// Day-1 Report Trustworthiness panel.
+	"aiqg-harm-request":            NISTSafe,
+	"aiqg-credential-solicitation": NISTSafe,
+	"aiqg-explicit-jailbreak":      NISTSafe,
+
 	// Credential exposure — leaked secrets are a privacy issue
 	// (someone's secret in an LLM transcript = data leak).
 	"cred-api-key":          NISTPrivacyEnhanced,


### PR DESCRIPTION
## Summary
Closes the empty Safe characteristic on the Day-1 Report Trustworthiness panel. Extends the classifier with the matchers from `Gatekeeper#10`:

- `aiqg-harm-request` → `safe`
- `aiqg-credential-solicitation` → `safe`
- `aiqg-explicit-jailbreak` → `safe`

Image already rolled as `aiqg-v5.17` during matcher smoke verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)