### PR TITLE
feat(nist): map 3 inbound antipatterns to Valid & Reliable

### DIFF
--- a/internal/middleware/nist_classifier.go
+++ b/internal/middleware/nist_classifier.go
@@ -61,6 +61,13 @@ var nistByPatternID = map[string]string{
 	"aiqg-credential-solicitation": NISTSafe,
 	"aiqg-explicit-jailbreak":      NISTSafe,
 
+	// Inbound input-quality antipatterns (Gatekeeper#11). Vague /
+	// overloaded / unbounded prompts produce unreliable outputs
+	// regardless of intent → Valid & Reliable.
+	"aiqg-vague-prompt":         NISTValidReliable,
+	"aiqg-instruction-stuffing": NISTValidReliable,
+	"aiqg-unbounded-loop":       NISTValidReliable,
+
 	// Credential exposure — leaked secrets are a privacy issue
 	// (someone's secret in an LLM transcript = data leak).
 	"cred-api-key":          NISTPrivacyEnhanced,


### PR DESCRIPTION
## Summary
Three-row extension to `nist_classifier.go` covering the matchers from `Gatekeeper#11`:

- `aiqg-vague-prompt` → `valid_reliable`
- `aiqg-instruction-stuffing` → `valid_reliable`
- `aiqg-unbounded-loop` → `valid_reliable`

Image already rolled as `aiqg-v5.18` during matcher smoke verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)