### PR TITLE
feat(aiqg): per-pattern_id finding counts on events

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -237,6 +237,7 @@ func routingView(r *Routing) events.RoutingView {
 		RetrySet:         s.RetrySet,
 		Workflow:         s.Workflow,
 		NISTFindings:     s.NISTFindings,
+		TagFindings:      s.TagFindings,
 	}
 }
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -60,6 +60,11 @@ type Routing struct {
 	// NIST<Characteristic> constants. Direction-agnostic — Section 5
 	// of the Day-1 Report shows the aggregate, not in/out split.
 	nistFindings map[string]int
+
+	// Gatekeeper pattern_id → count for this request. Powers the
+	// /api/v1/metrics/tags endpoint (which shows "what matchers are
+	// firing most often for this tenant"). Direction-agnostic.
+	tagFindings map[string]int
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -116,6 +121,10 @@ type RoutingSnapshot struct {
 	// Direction-agnostic aggregate; Day-1 Report Section 5 renders
 	// these per-characteristic. Nil when no findings.
 	NISTFindings map[string]int
+
+	// Gatekeeper pattern_id → count for this request. Nil when no
+	// findings. Drives /api/v1/metrics/tags.
+	TagFindings map[string]int
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -141,6 +150,7 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		RetrySet:         r.retrySet,
 		Workflow:         r.workflow,
 		NISTFindings:     copyCounts(r.nistFindings),
+		TagFindings:      copyCounts(r.tagFindings),
 	}
 }
 
@@ -373,5 +383,26 @@ func StampNISTFindings(ctx context.Context, nistCounts map[string]int) {
 	}
 	for k, v := range nistCounts {
 		r.nistFindings[k] += v
+	}
+}
+
+// StampTagFindings accumulates per-pattern_id finding counts.
+// Same SUM semantic as NIST — inbound+outbound counts of the same
+// matcher are distinct findings, not the same one reported twice.
+func StampTagFindings(ctx context.Context, tagCounts map[string]int) {
+	if len(tagCounts) == 0 {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.tagFindings == nil {
+		r.tagFindings = make(map[string]int, len(tagCounts))
+	}
+	for k, v := range tagCounts {
+		r.tagFindings[k] += v
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -516,12 +516,15 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 			// down by characteristic, not just severity.
 			counts := map[string]int{}
 			nistCounts := map[string]int{}
+			tagCounts := map[string]int{}
 			for _, f := range result.ScanResult.Findings {
 				counts[string(f.Severity)]++
 				nistCounts[middleware.MapPatternToNIST(f.PatternID)]++
+				tagCounts[f.PatternID]++
 			}
 			middleware.StampGatekeeperFindings(r.Context(), middleware.GatekeeperDirectionInbound, counts)
 			middleware.StampNISTFindings(r.Context(), nistCounts)
+			middleware.StampTagFindings(r.Context(), tagCounts)
 		}
 	}
 
@@ -728,12 +731,15 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 			if result != nil && result.ScanResult != nil {
 				counts := map[string]int{}
 				nistCounts := map[string]int{}
+				tagCounts := map[string]int{}
 				for _, f := range result.ScanResult.Findings {
 					counts[string(f.Severity)]++
 					nistCounts[middleware.MapPatternToNIST(f.PatternID)]++
+					tagCounts[f.PatternID]++
 				}
 				middleware.StampGatekeeperFindings(r.Context(), middleware.GatekeeperDirectionOutbound, counts)
 				middleware.StampNISTFindings(r.Context(), nistCounts)
+				middleware.StampTagFindings(r.Context(), tagCounts)
 			}
 		}
 	}

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -80,6 +80,10 @@ type RoutingView struct {
 	// AssuranceSummary so the Day-1 Report Trustworthiness section
 	// can render per-characteristic findings.
 	NISTFindings map[string]int
+
+	// Gatekeeper pattern_id → count for this request. Drives the
+	// /api/v1/metrics/tags endpoint. Nil when no findings.
+	TagFindings map[string]int
 }
 
 // TokenView is the subset of resolved-token state the event builder
@@ -257,6 +261,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 			OutboundFindings: routing.OutboundFindings,
 			WorstSeverity:    worstSeverityIn(routing.InboundFindings, routing.OutboundFindings),
 			NISTFindings:     routing.NISTFindings,
+			TagFindings:      routing.TagFindings,
 		}
 	}
 

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -134,6 +134,13 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		// queries can filter the response stream directly (e.g.
 		// {namespace="tas-llm-router"} | json | workflow="code_generation").
 		"workflow":          req.Data.Workflow,
+		// Vendor/model live on the RequestEvent, but copy them onto the
+		// response log line too so dashboards can group cost/tokens by
+		// vendor/model directly off the response stream (e.g.
+		// sum by (vendor) (sum_over_time(... | unwrap total_cost_usd))).
+		// Empty strings stay empty in JSON but LogQL filters when populated.
+		"vendor":            req.Data.Vendor,
+		"model":             req.Data.Model,
 		"payload":           string(respJSON),
 	}
 	// Token accounting — nil-safe; either fully populated or omitted.
@@ -185,6 +192,13 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		// in the Day-1 Report Trustworthiness query.
 		for k, v := range a.NISTFindings {
 			respFields["nist_"+k] = v
+		}
+		// Promote per-pattern_id counts as `tag_<sanitized>` fields.
+		// Hyphens become underscores because LogQL labels need to be
+		// valid identifiers. /api/v1/metrics/tags performs the same
+		// replacement when building its queries.
+		for k, v := range a.TagFindings {
+			respFields["tag_"+sanitizeTagKey(k)] = v
 		}
 	}
 	e.Logger.WithFields(respFields).Info("aiqg response event")
@@ -242,4 +256,22 @@ func (e *MemoryEmitter) Reset() {
 	defer e.mu.Unlock()
 	e.requests = nil
 	e.responses = nil
+}
+
+// sanitizeTagKey converts a Gatekeeper pattern_id ("aiqg-role-claim",
+// "pii-ssn") into a Loki-label-safe identifier (hyphens become
+// underscores). Kept in this package because the matching reverse
+// lookup lives client-side in aiqg-dashboard-be's /metrics/tags
+// handler — they MUST agree on the mapping.
+func sanitizeTagKey(s string) string {
+	var b []byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '-' {
+			b = append(b, '_')
+			continue
+		}
+		b = append(b, c)
+	}
+	return string(b)
 }

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -204,6 +204,12 @@ type AssuranceSummary struct {
 	// middleware.MapPatternToNIST. Drives the Day-1 Report
 	// Trustworthiness section. omitempty when no findings.
 	NISTFindings map[string]int `json:"nist_findings,omitempty"`
+
+	// TagFindings buckets findings by Gatekeeper pattern_id
+	// (aiqg-role-claim, pii-email, …). Drives /api/v1/metrics/tags
+	// — "what matchers are firing most often for this tenant".
+	// omitempty when no findings.
+	TagFindings map[string]int `json:"tag_findings,omitempty"`
 }
 
 // Status enum values for ResponseEvent.Status.


### PR DESCRIPTION
## Summary
Adds the per-matcher counter that powers `aiqg-dashboard-be /api/v1/metrics/tags`. Today's events carry per-severity totals and per-NIST-characteristic counts, but not which specific matcher fired — so the dashboard couldn't answer \"what's firing most often for this tenant.\"

- `Routing.tagFindings` map + `StampTagFindings` (SUM semantics like NIST — inbound+outbound counts of the same matcher are distinct).
- `AssuranceSummary.TagFindings` JSONB field; full routing → events plumbing.
- LogEmitter promotes each as `tag_<sanitized>` (hyphens → underscores; LogQL labels need valid identifiers).

Image bumped to `aiqg-v5.19`. Pairs with `aiqg-dashboard-be#15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)