### PR TITLE
feat(aiqg): wire AIQG emitter to log+kafka (tas.aiqg.events.v1)

### DIFF
--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -89,3 +89,13 @@ data:
   # secret comes from llm-router-secret (out-of-band managed) as
   # AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN.
   AIQG_DASHBOARD_URL: "http://aiqg-dashboard-be.aiqg.svc.cluster.local:8095"
+
+  # AIQG event sink. "both" fans paired CloudEvents to logrus
+  # (→ Loki, the existing read path used by aiqg-dashboard-be) AND
+  # to Kafka topic tas.aiqg.events.v1 (consumed by the Spark
+  # aggregator that materializes the aiqg.event_metrics hypertable
+  # in TimescaleDB). Keeping the Loki path live during the
+  # TimescaleDB cutover is the rollback escape hatch.
+  AIQG_EMITTER_TYPE: "both"
+  AIQG_KAFKA_BROKERS: "kafka-shared.tas-shared:9092"
+  AIQG_KAFKA_TOPIC: "tas.aiqg.events.v1"


### PR DESCRIPTION
## Summary
- Flip `AIQG_EMITTER_TYPE` from `log` (Loki only) to `both` — paired AIQG CloudEvents now fan to both Loki (existing) and Kafka topic `tas.aiqg.events.v1` (new)
- Loki path stays live so the dashboard read path keeps working through the cutover; Kafka is purely additive until the Spark aggregator + TimescaleDB read path lands in PR 2
- Topic `tas.aiqg.events.v1` already provisioned (3 partitions, RF=1) on `kafka-shared.tas-shared:9092`; `aiqg.event_metrics` hypertable + `event_metrics_{1m,1h}` continuous aggregates already in the `tas_events` TimescaleDB

## Test plan
- [x] `kafka-topics --describe tas.aiqg.events.v1` shows 3 partitions, RF=1
- [x] Configmap reload via `kubectl rollout restart` — pods log `AIQG MultiEmitter (log + kafka) wired`
- [x] Synthetic chat completion through `llm-router-aiqg`: paired `(com.tas.aiqg.request.v1, com.tas.aiqg.response.v1)` envelope in Kafka topic
- [x] Same pair still in Loki (zero regression on existing read path)
- [ ] PR 2: Spark aggregator consumes `tas.aiqg.events.v1` → `aiqg.event_metrics` hypertable; dashboard-be dual-reads (TS primary, Loki fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)