### PR TITLE
feat(aiqg): denormalize vendor+model onto response events (schema-complete)

### DIFF
--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -177,26 +177,26 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	}
 
 	reqEvent := RequestEvent{
-		RequestEventID:            reqID,
-		TenantID:                  token.TenantID,
-		AIQGAccountID:             token.AIQGAccountID,
-		TASAuthTokenID:            token.TASAuthTokenID,
-		ReceivedAt:                receivedAt,
-		Endpoint:                  r.URL.Path,
-		Method:                    r.Method,
-		SourceIP:                  clientIP(r),
-		SourceApp:                 sourceApp,
-		ClientRequestID:           r.Header.Get("X-Request-ID"),
-		Region:                    opts.Region,
-		Vendor:                    routing.Vendor,
-		Model:                     routing.Model,
-		Streaming:                 streaming,
-		IsAIQGMode:                true,
-		DryRun:                    headers.DryRun,
-		TraceReturned:             headers.Trace,
-		Workflow:                  preferredWorkflow(headers.Workflow, routing.Workflow),
-		PolicyNames:               headers.Policy,
-		PolicyBundle:              headers.PolicyBundle,
+		RequestEventID:  reqID,
+		TenantID:        token.TenantID,
+		AIQGAccountID:   token.AIQGAccountID,
+		TASAuthTokenID:  token.TASAuthTokenID,
+		ReceivedAt:      receivedAt,
+		Endpoint:        r.URL.Path,
+		Method:          r.Method,
+		SourceIP:        clientIP(r),
+		SourceApp:       sourceApp,
+		ClientRequestID: r.Header.Get("X-Request-ID"),
+		Region:          opts.Region,
+		Vendor:          routing.Vendor,
+		Model:           routing.Model,
+		Streaming:       streaming,
+		IsAIQGMode:      true,
+		DryRun:          headers.DryRun,
+		TraceReturned:   headers.Trace,
+		Workflow:        preferredWorkflow(headers.Workflow, routing.Workflow),
+		PolicyNames:     headers.Policy,
+		PolicyBundle:    headers.PolicyBundle,
 		// SourceApp override from header was already captured above; the
 		// AIQGHeadersView populates it for the field assignment below.
 		CorrelatedResponseEventID: respID,
@@ -268,8 +268,10 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	respEvent := ResponseEvent{
 		ResponseEventID:   respID,
 		RequestEventID:    reqID,
-		TenantID:          token.TenantID,        // denormalized per response-event.md §"Denormalization rationale"
-		AIQGAccountID:     token.AIQGAccountID,   // ditto
+		TenantID:          token.TenantID,      // denormalized per response-event.md §"Denormalization rationale"
+		AIQGAccountID:     token.AIQGAccountID, // ditto
+		Vendor:            routing.Vendor,      // denormalized from routing decision (same as RequestEvent)
+		Model:             routing.Model,       // ditto — powers per-vendor/model dashboards off the response stream
 		CompleteAt:        completeAt,
 		Status:            status,
 		HTTPStatus:        opts.HTTPStatus,

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -98,17 +98,17 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		"payload":          string(reqJSON),
 		// Routing + attribution — empty strings stay empty in JSON but
 		// LogQL can still filter on them when populated.
-		"vendor":           req.Data.Vendor,
-		"model":            req.Data.Model,
-		"endpoint":         req.Data.Endpoint,
-		"workflow":         req.Data.Workflow,
-		"streaming":        req.Data.Streaming,
-		"region":           req.Data.Region,
-		"tenant_id":        req.Data.TenantID,
-		"aiqg_account_id":  req.Data.AIQGAccountID,
-		"source_app":       req.Data.SourceApp,
-		"dry_run":          req.Data.DryRun,
-		"gateway_version":  req.Data.GatewayVersion,
+		"vendor":          req.Data.Vendor,
+		"model":           req.Data.Model,
+		"endpoint":        req.Data.Endpoint,
+		"workflow":        req.Data.Workflow,
+		"streaming":       req.Data.Streaming,
+		"region":          req.Data.Region,
+		"tenant_id":       req.Data.TenantID,
+		"aiqg_account_id": req.Data.AIQGAccountID,
+		"source_app":      req.Data.SourceApp,
+		"dry_run":         req.Data.DryRun,
+		"gateway_version": req.Data.GatewayVersion,
 	}
 	if req.Data.PolicyBundle != "" {
 		reqFields["policy_bundle"] = req.Data.PolicyBundle
@@ -133,15 +133,16 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		// onto the response log line too so per-workflow dashboard
 		// queries can filter the response stream directly (e.g.
 		// {namespace="tas-llm-router"} | json | workflow="code_generation").
-		"workflow":          req.Data.Workflow,
-		// Vendor/model live on the RequestEvent, but copy them onto the
-		// response log line too so dashboards can group cost/tokens by
-		// vendor/model directly off the response stream (e.g.
-		// sum by (vendor) (sum_over_time(... | unwrap total_cost_usd))).
-		// Empty strings stay empty in JSON but LogQL filters when populated.
-		"vendor":            req.Data.Vendor,
-		"model":             req.Data.Model,
-		"payload":           string(respJSON),
+		"workflow": req.Data.Workflow,
+		// Vendor/model are denormalized onto the ResponseEvent itself
+		// (builder.go), so promote them from the response — dashboards
+		// group cost/tokens by vendor/model directly off the response
+		// stream (e.g. sum by (vendor) (sum_over_time(... | unwrap
+		// total_cost_usd))). Empty strings stay empty in JSON but LogQL
+		// filters when populated.
+		"vendor":  resp.Data.Vendor,
+		"model":   resp.Data.Model,
+		"payload": string(respJSON),
 	}
 	// Token accounting — nil-safe; either fully populated or omitted.
 	if ta := resp.Data.TokenAccounting; ta != nil {

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -122,6 +122,14 @@ type ResponseEvent struct {
 	TenantID        string `json:"tenant_id,omitempty"`
 	AIQGAccountID   string `json:"aiqg_account_id,omitempty"`
 
+	// Routing attribution — denormalized from the request's routing
+	// decision so the response event is self-describing: per-vendor and
+	// per-model cost/token dashboards read these directly off the
+	// response stream, and they survive a lost request event (see
+	// response-event.md KI-2). Same values as the paired RequestEvent.
+	Vendor string `json:"vendor,omitempty"`
+	Model  string `json:"model,omitempty"`
+
 	// Outcome
 	CompleteAt      time.Time `json:"complete_at"`
 	Status          string    `json:"status"` // success | vendor_error | gateway_error | policy_blocked | client_disconnect | timeout
@@ -224,12 +232,12 @@ const (
 
 // Lifecycle state enum values for RequestEvent.LifecycleState.
 const (
-	LifecycleReceived            = "received"
-	LifecycleValidated           = "validated"
-	LifecyclePolicyResolved      = "policy_resolved"
-	LifecycleForwarded           = "forwarded"
-	LifecyclePairedWithResponse  = "paired_with_response"
-	LifecycleArchived            = "archived"
+	LifecycleReceived           = "received"
+	LifecycleValidated          = "validated"
+	LifecyclePolicyResolved     = "policy_resolved"
+	LifecycleForwarded          = "forwarded"
+	LifecyclePairedWithResponse = "paired_with_response"
+	LifecycleArchived           = "archived"
 )
 
 // StatusFromHTTP maps an HTTP status code to the spec's status enum.

--- a/pkg/aiqg/events/event_test.go
+++ b/pkg/aiqg/events/event_test.go
@@ -245,10 +245,10 @@ func TestEnvelopeMarshalsToCloudEventsShape(t *testing.T) {
 // when StreamingSet=true; otherwise the heuristic wins.
 func TestBuild_StreamingPrecedence(t *testing.T) {
 	cases := []struct {
-		name      string
-		url       string
-		view      RoutingView
-		want      bool
+		name string
+		url  string
+		view RoutingView
+		want bool
 	}{
 		{"url_says_yes_view_unset", "/v1/chat/completions?stream=true", RoutingView{}, true},
 		{"url_says_no_view_unset", "/v1/chat/completions", RoutingView{}, false},
@@ -358,6 +358,8 @@ func TestLogEmitter_PromotesNestedFields(t *testing.T) {
 		Data: ResponseEvent{
 			ResponseEventID: "resp-1",
 			RequestEventID:  "req-1",
+			Vendor:          "openai",
+			Model:           "gpt-4o-mini",
 			Status:          StatusSuccess,
 			HTTPStatus:      200,
 			Streamed:        true,
@@ -408,6 +410,10 @@ func TestLogEmitter_PromotesNestedFields(t *testing.T) {
 	requireField(t, resp, "status", StatusSuccess)
 	requireField(t, resp, "streamed", true)
 	requireField(t, resp, "finish_reason", "stop")
+	// Vendor/model are denormalized onto the response event and promoted
+	// onto its log line so dashboards group cost/tokens by vendor/model.
+	requireField(t, resp, "vendor", "openai")
+	requireField(t, resp, "model", "gpt-4o-mini")
 	requireField(t, resp, "prompt_tokens", 100)
 	requireField(t, resp, "total_tokens", 300)
 	requireField(t, resp, "total_cost_usd", 0.0012)


### PR DESCRIPTION
## What
Adds `vendor` and `model` as first-class fields on the AIQG **ResponseEvent**, denormalized from the routing decision (same source/values as the paired RequestEvent).

Previously vendor/model lived only on the request event, so response-based dashboards (cost/tokens per vendor/model) and the Spark aggregator's per-model rollup had nothing to group on — the per-vendor/model panels were empty.

## Changes
- `pkg/aiqg/events/event.go` — `ResponseEvent` gains `Vendor`/`Model` (`json:"...,omitempty"`), per response-event.md §2.2 "Routing Attribution".
- `pkg/aiqg/events/builder.go` — `respEvent` populates them from the `RoutingView`.
- `pkg/aiqg/events/emitter.go` — response log line promotes from the response's own fields (self-contained) instead of reaching into the request.
- `pkg/aiqg/events/event_test.go` — response envelope sets + asserts vendor/model promotion.

Schema docs updated in aether-shared (companion PR).

## Test / release
- `go test ./pkg/aiqg/events/` passes.
- Built and deployed as gateway **`aiqg-v5.20`** (`gateway_version=aiqg-v5.20+0548884`); `llm-router-aiqg` is running it (2/2).
- New response events will carry vendor/model as traffic flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)