### PR TITLE
feat(aiqg): promote latency-decomposition fields on response events

### DIFF
--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -151,14 +151,39 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		respFields["total_tokens"] = ta.TotalTokens
 		respFields["total_cost_usd"] = ta.TotalCostUSD
 	}
-	// Promote end_to_end_ms so LogQL can unwrap it directly — needed
-	// for the dashboard /reports/preview p50/p95 latency queries.
-	// Without this, latency is only reachable by parsing the embedded
-	// `payload` JSON, which LogQL handles awkwardly. Skipped when nil
-	// (request never completed) so dashboards distinguish "not
-	// captured" from "captured as zero".
-	if ms := resp.Data.EventTimestamps.EndToEndMs; ms != nil {
+	// Promote the timing decomposition so LogQL can unwrap each
+	// component directly. instrumentation.Snapshot captures the full
+	// breakdown — gateway ingress → vendor TTFB → vendor TTFT →
+	// vendor generation → gateway egress — but only end_to_end_ms
+	// reaches dashboards unless we surface the rest here. Phase 2.3
+	// (latency decomposition card) consumes these fields.
+	//
+	// Every duration is *int64; nil means "not captured" (skipped) so
+	// dashboards distinguish "no data" from "0 ms".
+	ts := resp.Data.EventTimestamps
+	if ms := ts.EndToEndMs; ms != nil {
 		respFields["end_to_end_ms"] = *ms
+	}
+	if ms := ts.GatewayIngressMs; ms != nil {
+		respFields["gateway_ingress_ms"] = *ms
+	}
+	if ms := ts.GatewayEgressMs; ms != nil {
+		respFields["gateway_egress_ms"] = *ms
+	}
+	if ms := ts.GatewayOverheadMs; ms != nil {
+		respFields["gateway_overhead_ms"] = *ms
+	}
+	if ms := ts.VendorTTFBMs; ms != nil {
+		respFields["vendor_ttfb_ms"] = *ms
+	}
+	if ms := ts.VendorTTFTMs; ms != nil {
+		respFields["vendor_ttft_ms"] = *ms
+	}
+	if ms := ts.VendorGenerationMs; ms != nil {
+		respFields["vendor_generation_ms"] = *ms
+	}
+	if ms := ts.MedianInterTokenMs; ms != nil {
+		respFields["median_inter_token_ms"] = *ms
 	}
 	// CLEAR scores — pointer-fielded; promote each non-nil dimension.
 	if c := resp.Data.CLEAR; c != nil {

--- a/pkg/aiqg/events/event_test.go
+++ b/pkg/aiqg/events/event_test.go
@@ -380,6 +380,20 @@ func TestLogEmitter_PromotesNestedFields(t *testing.T) {
 				OutboundCount: 0,
 				WorstSeverity: "medium",
 			},
+			// Timing decomposition — every field promoted to top-level
+			// logrus so LogQL can unwrap each component independently.
+			// Phase 2.3 latency-decomposition card on the Health Report
+			// consumes these fields.
+			EventTimestamps: instrumentation.Snapshot{
+				EndToEndMs:         ptrI64(2500),
+				GatewayIngressMs:   ptrI64(12),
+				GatewayEgressMs:    ptrI64(8),
+				GatewayOverheadMs:  ptrI64(20),
+				VendorTTFBMs:       ptrI64(180),
+				VendorTTFTMs:       ptrI64(220),
+				VendorGenerationMs: ptrI64(2260),
+				MedianInterTokenMs: ptrI64(35),
+			},
 		},
 	}
 	// Wire a clear.Scores manually — events imports pkg/clear so this
@@ -423,7 +437,23 @@ func TestLogEmitter_PromotesNestedFields(t *testing.T) {
 	requireField(t, resp, "assurance_inbound_count", 2)
 	requireField(t, resp, "assurance_outbound_count", 0)
 	requireField(t, resp, "assurance_worst_severity", "medium")
+	// Timing decomposition — every component promoted as int64 so LogQL
+	// `unwrap` works directly. nil snapshot fields stay absent (separate
+	// regression in TestLogEmitter_NilNestedStructs).
+	requireField(t, resp, "end_to_end_ms", int64(2500))
+	requireField(t, resp, "gateway_ingress_ms", int64(12))
+	requireField(t, resp, "gateway_egress_ms", int64(8))
+	requireField(t, resp, "gateway_overhead_ms", int64(20))
+	requireField(t, resp, "vendor_ttfb_ms", int64(180))
+	requireField(t, resp, "vendor_ttft_ms", int64(220))
+	requireField(t, resp, "vendor_generation_ms", int64(2260))
+	requireField(t, resp, "median_inter_token_ms", int64(35))
 }
+
+// ptrI64 returns a pointer to an int64 literal. Used only by tests
+// that need to populate Snapshot fields without spinning up a full
+// instrumentation.Collector run.
+func ptrI64(v int64) *int64 { return &v }
 
 // Empty/nil nested structs leave their promoted fields absent without
 // panicking — important because not every request has TokenAccounting,


### PR DESCRIPTION
## Summary

\`instrumentation.Snapshot\` has captured the full per-component timing breakdown for months — gateway ingress, vendor TTFB/TTFT, vendor generation, gateway egress/overhead, median inter-token gap — but the \`LogEmitter\` only promoted \`end_to_end_ms\` to a top-level logrus field. Everything else was reachable only by parsing the embedded \`payload\` JSON, which LogQL handles awkwardly.

This PR promotes 7 additional duration fields so \`| unwrap <field>\` works directly in LogQL:

| Field | Meaning |
|---|---|
| \`gateway_ingress_ms\` | request hits gateway → forwarded to vendor |
| \`gateway_egress_ms\` | last vendor byte → response complete |
| \`gateway_overhead_ms\` | total gateway-side time (ingress + egress) |
| \`vendor_ttfb_ms\` | request forwarded → first byte from vendor |
| \`vendor_ttft_ms\` | request forwarded → first content token |
| \`vendor_generation_ms\` | first token → last token (streaming spread) |
| \`median_inter_token_ms\` | median ms between adjacent chunks (≥3 chunks) |

Each is \`*int64\`; nil values stay absent from the log fields so dashboards distinguish "not captured" from "0 ms". \`KafkaEmitter\` needs no change — it ships the full marshalled envelope.

**Unblocks** aiqg-dashboard-be / aiqg-ui **Phase 2.3 (latency decomposition card)** on the Health Report. Phase 2.4 (RAG groundedness) still needs scorer + response-body capture work — not addressed here.

## Test plan
- [x] \`TestLogEmitter_PromotesNestedFields\` extended with a populated \`Snapshot\` and 8 new \`requireField\` assertions (\`end_to_end_ms\` + 7 new decomposition fields)
- [x] \`TestLogEmitter_NilNestedStructs\` unchanged — confirms nil Snapshot fields leave their promoted entries absent without panicking
- [x] \`go test ./pkg/aiqg/...\` — all packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)