### PR TITLE
fix(aiqg): wire production instrumentation for latency decomposition

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -344,6 +344,25 @@ func (w *statusCapturingResponseWriter) status() int {
 	return w.code
 }
 
+// Flush delegates to the wrapped ResponseWriter when it implements
+// http.Flusher. Streaming response handlers (chat completions with
+// stream=true) type-assert the ResponseWriter to http.Flusher and
+// panic when the assertion fails. Without this delegation the AIQG
+// middleware silently broke all streaming traffic — confirmed via
+// a "interface conversion: *statusCapturingResponseWriter is not
+// http.Flusher" panic surfaced in Loki on 2026-06-09.
+//
+// Net/http's chunked-encoding path requires Flush to push bytes onto
+// the wire; in streaming mode every chunk handler calls Flush after
+// each Write. Without this, chunks buffer until the response ends —
+// turning a streaming response back into a non-streaming one (or
+// panicking with an unchecked type assertion).
+func (w *statusCapturingResponseWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // rejectPathA emits the strict-mode 401 response and the
 // path_a_auth_rejected audit event (per audit-log-entry.md §97). The
 // response body names the missing header so customers can self-diagnose

--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -93,6 +93,12 @@ func (p *AnthropicProvider) ChatCompletion(ctx context.Context, req *types.ChatR
 		return nil, fmt.Errorf("failed to convert request: %w", err)
 	}
 
+	// AIQG: mirror StreamCompletion — stamp forwarded + wire httptrace
+	// so the response event carries gateway_ingress_ms and
+	// vendor_ttfb_ms. Both are no-ops outside AIQG mode.
+	instrumentation.StampForwarded(ctx)
+	ctx = instrumentation.Attach(ctx)
+
 	// Make the API call
 	resp, err := p.client.Messages.New(ctx, *anthropicReq)
 	if err != nil {
@@ -113,9 +119,10 @@ func (p *AnthropicProvider) StreamCompletion(ctx context.Context, req *types.Cha
 		return nil, fmt.Errorf("failed to convert request: %w", err)
 	}
 
-	// AIQG: stamp the moment the request is handed to the vendor client.
-	// No-op when no TimingCollector is attached to ctx.
+	// AIQG: stamp forwarded + wire httptrace so GotFirstResponseByte
+	// → StampTTFB populates vendor_ttfb_ms. Both no-ops outside AIQG mode.
 	instrumentation.StampForwarded(ctx)
+	ctx = instrumentation.Attach(ctx)
 
 	// Create the streaming request
 	stream := p.client.Messages.NewStreaming(ctx, *anthropicReq)
@@ -128,6 +135,7 @@ func (p *AnthropicProvider) StreamCompletion(ctx context.Context, req *types.Cha
 		defer close(chunks)
 		defer instrumentation.StampLastChunk(ctx)
 
+		ttftStamped := false
 		message := anthropic.Message{}
 		for stream.Next() {
 			event := stream.Current()
@@ -144,7 +152,12 @@ func (p *AnthropicProvider) StreamCompletion(ctx context.Context, req *types.Cha
 			// hasContent is true only for ContentBlockDelta events with
 			// non-empty TextDelta (or future tool-use delta types that
 			// carry generated arguments).
-			instrumentation.StampChunk(ctx, anthropicEventHasContent(event))
+			hasContent := anthropicEventHasContent(event)
+			if hasContent && !ttftStamped {
+				instrumentation.StampTTFT(ctx)
+				ttftStamped = true
+			}
+			instrumentation.StampChunk(ctx, hasContent)
 
 			// Convert event to our chunk format
 			chunk := p.convertStreamEvent(event, req, &message)

--- a/internal/providers/openai/provider.go
+++ b/internal/providers/openai/provider.go
@@ -95,6 +95,12 @@ func (p *OpenAIProvider) ChatCompletion(ctx context.Context, req *types.ChatRequ
 		return nil, fmt.Errorf("failed to convert request: %w", err)
 	}
 
+	// AIQG: mirror StreamCompletion — stamp forwarded + wire httptrace
+	// so the response event carries gateway_ingress_ms and
+	// vendor_ttfb_ms. Both are no-ops outside AIQG mode.
+	instrumentation.StampForwarded(ctx)
+	ctx = instrumentation.Attach(ctx)
+
 	// Make the API call
 	resp, err := p.client.CreateChatCompletion(ctx, *openaiReq)
 	if err != nil {
@@ -118,9 +124,11 @@ func (p *OpenAIProvider) StreamCompletion(ctx context.Context, req *types.ChatRe
 	// Enable streaming
 	openaiReq.Stream = true
 
-	// AIQG: stamp the moment the request is handed to the vendor client.
-	// No-op when no TimingCollector is attached to ctx (non-AIQG callers).
+	// AIQG: stamp the moment the request is handed to the vendor client
+	// and wire httptrace so GotFirstResponseByte → StampTTFB populates
+	// vendor_ttfb_ms. Both are no-ops outside AIQG mode.
 	instrumentation.StampForwarded(ctx)
+	ctx = instrumentation.Attach(ctx)
 
 	// Make the streaming API call
 	stream, err := p.client.CreateChatCompletionStream(ctx, *openaiReq)
@@ -138,6 +146,7 @@ func (p *OpenAIProvider) StreamCompletion(ctx context.Context, req *types.ChatRe
 		defer stream.Close()
 		defer instrumentation.StampLastChunk(ctx)
 
+		ttftStamped := false
 		for {
 			response, err := stream.Recv()
 			if err != nil {
@@ -154,7 +163,12 @@ func (p *OpenAIProvider) StreamCompletion(ctx context.Context, req *types.ChatRe
 			// generated content. hasContent below is true only when the
 			// chunk carries actual model output (content text or a
 			// tool-call argument fragment).
-			instrumentation.StampChunk(ctx, openaiChunkHasContent(&response))
+			hasContent := openaiChunkHasContent(&response)
+			if hasContent && !ttftStamped {
+				instrumentation.StampTTFT(ctx)
+				ttftStamped = true
+			}
+			instrumentation.StampChunk(ctx, hasContent)
 
 			// Convert chunk to our format
 			chunk := p.convertFromOpenAIChunk(&response, req)


### PR DESCRIPTION
## Summary

The emitter promotion in #56 didn't actually produce populated values because **four bugs in the production code path** left the underlying instrumentation untouched. This PR fixes all four.

### 1. \`statusCapturingResponseWriter\` didn't implement \`http.Flusher\`
**Severity: high — silent regression on all AIQG streaming traffic.** Confirmed via a Loki panic: \`interface conversion: *middleware.statusCapturingResponseWriter is not http.Flusher: missing method Flush\`. Every streaming chat-completion through AIQG-strict was silently panicking; \`stream:true\` responses came back as non-streaming (or 502). Added a \`Flush\` method that delegates to the wrapped \`ResponseWriter\` when it implements \`Flusher\`.

### 2. \`OpenAIProvider.ChatCompletion\` never called \`StampForwarded\`
Only \`StreamCompletion\` stamped it, so \`gateway_ingress_ms\` was always nil for the non-streaming path. Mirrored the streaming wiring.

### 3. Neither provider wired httptrace into ctx
\`GotFirstResponseByte\` never fired \`StampTTFB\`, leaving \`vendor_ttfb_ms\` nil on every event. Added \`instrumentation.Attach(ctx)\` before each vendor API call.

### 4. \`StampTTFT\` was never called in production code
Only existed in tests. \`vendor_ttft_ms\` was always nil despite the existing comments in both providers describing exactly what should fire it. Both streaming paths now stamp TTFT on the first \`hasContent=true\` chunk.

## Smoke test results (live cluster, 2026-06-09)

Streaming chat completion now produces an event with **7 of 8** timing fields populated:

| Field | Value (ms) |
|---|---|
| \`end_to_end_ms\` | 2825 |
| \`vendor_ttfb_ms\` | 2817 |
| \`vendor_ttft_ms\` | 2825 |
| \`gateway_ingress_ms\` | 0 |
| \`gateway_egress_ms\` | 0 |
| \`gateway_overhead_ms\` | 0 |
| \`vendor_generation_ms\` | 0 |
| \`median_inter_token_ms\` | absent — needs ≥3 content chunks (haiku was too short) |

\`median_inter_token_ms\` populates naturally for longer responses.

## Test plan
- [x] \`go test ./internal/middleware/ ./internal/providers/... ./pkg/aiqg/...\` — all green
- [x] Image rolled to both \`llm-router-aiqg\` replicas; streaming SSE chunks come back cleanly (previously panicked)
- [x] Loki shows the new event with 7 populated decomposition fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)