### PR TITLE
feat(nist): map aiqg-citation-marker to Valid+Reliable

### DIFF
--- a/internal/middleware/nist_classifier.go
+++ b/internal/middleware/nist_classifier.go
@@ -53,6 +53,14 @@ var nistByPatternID = map[string]string{
 	"aiqg-repetition":          NISTValidReliable,
 	"aiqg-hallucination-hedge": NISTValidReliable,
 	"aiqg-malformed-output":    NISTValidReliable,
+	// Citation marker (Gatekeeper#12, Phase 2.4). Presence of citations
+	// in a response is a positive signal for groundedness — a request
+	// that grounded its output in retrieved context is more reliable
+	// than one that didn't. Lives in Valid & Reliable for two reasons:
+	// (a) citation absence on a RAG response is the meaningful signal,
+	// and absence is an unreliability proxy; (b) keeps the Trustworthiness
+	// panel on the report scoring this as quality rather than safety.
+	"aiqg-citation-marker": NISTValidReliable,
 
 	// Safety / policy matchers (Gatekeeper#10). Populate the Safe
 	// characteristic — until this PR landed it was always 0 on the


### PR DESCRIPTION
Wires Gatekeeper's new \`aiqg-citation-marker\` matcher (PR Gatekeeper#12) into the NIST classifier. Citation presence on a response is a positive groundedness signal; citation ABSENCE on a RAG-workflow response is the meaningful unreliability proxy.

Lives in **Valid & Reliable** because:
1. Citation absence on RAG responses is an unreliability proxy (quality, not safety)
2. Keeps the Trustworthiness panel scoring this as quality

🤖 Generated with [Claude Code](https://claude.com/claude-code)