### PR TITLE
chore: bump Makefile VERSION default to aiqg-v5.21

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Variables
 BINARY_NAME=llm-router
 DOCKER_IMAGE=llm-router-waf
-VERSION?=v1.0.0
+VERSION?=aiqg-v5.21
 BUILD_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 GIT_COMMIT=$(shell git rev-parse --short HEAD)
 


### PR DESCRIPTION
Aligns the Makefile default with what's actually running in production. Without this bump, the next `make docker-build` tags as `v1.0.0` — unrelated to the `aiqg-vN.MM` scheme that dashboards use to identify the gateway version on emitted events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)