### PR TITLE
feat(policy): bundle resolver client + middleware integration (Phase 4.0)

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -38,6 +38,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
 
@@ -71,6 +72,14 @@ type AIQGConfig struct {
 	// Once a Resolver is configured, unknown tokens become 401 and
 	// suspended accounts become 403.
 	Resolver tokens.Resolver
+
+	// PolicyResolver picks the AIQG policy_bundle that applies to each
+	// request (Phase 4.0). Nil is allowed — the middleware emits
+	// events without a resolved_policy_bundle field, matching pre-4.0
+	// behavior. When configured but the resolver returns an error,
+	// the middleware falls back to policy.Default() so the event
+	// always has a resolution (the "every request resolves" gate).
+	PolicyResolver policy.Resolver
 }
 
 // NewAIQG returns the middleware constructor. The returned handler is a
@@ -171,6 +180,34 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	}
 	instrumentation.StampReceived(ctx)
 
+	// Phase 4.0 — resolve which policy bundle applies. Observation-only:
+	// stash on the request context so events.Build can stamp it on
+	// the response event. Errors degrade to Default() so "every event
+	// has a resolution" is upheld even when the resolver is down.
+	var bundleResolution policy.Resolution
+	if cfg.PolicyResolver != nil && resolvedToken != nil {
+		res, err := cfg.PolicyResolver.Resolve(ctx, policy.ResolveRequest{
+			TenantID:           resolvedToken.TenantID,
+			AIQGAccountID:      resolvedToken.AIQGAccountID,
+			PolicyBundleHeader: parsed.PolicyBundle,
+			SourceApp:          parsed.SourceApp,
+			Path:               r.URL.Path,
+		})
+		if err != nil {
+			// Don't fail the request — operators see the resolver
+			// degradation via the warning, and the request still
+			// flows with a Default() resolution stamped on its event.
+			cfg.Logger.WithError(err).WithFields(logrus.Fields{
+				"event":     "aiqg.policy_resolve_error",
+				"tenant_id": resolvedToken.TenantID,
+				"bundle":    parsed.PolicyBundle,
+			}).Warn("AIQG policy resolver returned error; defaulting to observe-all")
+		}
+		bundleResolution = res
+	} else {
+		bundleResolution = policy.Default()
+	}
+
 	sw := &statusCapturingResponseWriter{ResponseWriter: w}
 
 	emitter := cfg.Emitter
@@ -186,6 +223,11 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
 			HTTPStatus: sw.status(),
 			Region:     cfg.Region,
+			ResolvedPolicyBundle: &events.ResolvedPolicyBundle{
+				BundleID:   bundleResolution.BundleID,
+				BundleName: bundleResolution.BundleName,
+				Source:     bundleResolution.Source,
+			},
 		})
 		if err := emitter.Emit(ctx, reqEnv, respEnv); err != nil {
 			cfg.Logger.WithError(err).Warn("AIQG event emission failed")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/types"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -238,12 +239,31 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			logger.Info("AIQG token resolver: none — events emit with empty tenant fields")
 		}
 
+		// Phase 4.0 — build the policy bundle resolver alongside the
+		// token resolver. Reuses the same dashboard URL + internal
+		// auth token; only constructed when both are configured.
+		// Nil PolicyResolver leaves events without a
+		// resolved_policy_bundle field (pre-4.0 behavior).
+		var policyResolver policy.Resolver
+		if config.AIQG.DashboardURL != "" && config.AIQG.DashboardInternalAuthToken != "" {
+			pr, err := policy.NewDashboardResolver(config.AIQG.DashboardURL, config.AIQG.DashboardInternalAuthToken)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build AIQG policy.DashboardResolver: %w", err)
+			}
+			policyResolver = pr
+			logger.WithField("dashboard_url", config.AIQG.DashboardURL).
+				Info("AIQG policy resolver: DashboardResolver (Phase 4.0 — observation only)")
+		} else {
+			logger.Info("AIQG policy resolver: none — events emit without resolved_policy_bundle")
+		}
+
 		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{
-			Strict:   config.AIQG.Strict,
-			Logger:   logger,
-			Emitter:  server.aiqgEmitter,
-			Region:   config.AIQG.Region,
-			Resolver: resolver,
+			Strict:         config.AIQG.Strict,
+			Logger:         logger,
+			Emitter:        server.aiqgEmitter,
+			Region:         config.AIQG.Region,
+			Resolver:       resolver,
+			PolicyResolver: policyResolver,
 		})
 		logger.WithFields(logrus.Fields{
 			"strict":           config.AIQG.Strict,

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -117,6 +117,14 @@ type BuildOptions struct {
 	Status       string // explicit status; if empty, derived from HTTPStatus
 	Region       string // deployment region; if empty, omitted from event
 	FinishReason string
+
+	// ResolvedPolicyBundle is the bundle aiqg-dashboard-be picked for
+	// this request (Phase 4.0). Always set in production — the
+	// middleware degrades to a Default() resolution when the resolver
+	// is unavailable so "every event has a resolved_policy_bundle"
+	// holds. Nil pointer → field omitted from the response event
+	// (covers pre-Phase-4.0 callers + non-AIQG middleware).
+	ResolvedPolicyBundle *ResolvedPolicyBundle
 }
 
 // Build constructs the paired (RequestEnvelope, ResponseEnvelope) from
@@ -279,12 +287,13 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		Streamed:          snap.ChunkCount > 0,
 		ChunkCount:        snap.ChunkCount,
 		ContentChunkCount: snap.ContentChunkCount,
-		EventTimestamps:   snap,
-		TokenAccounting:   tokenAcct,
-		Assurance:         assuranceSummary,
-		CLEAR:             clear.Compute(clearInput),
-		ScoringVersion:    ScoringVersion,
-		GatewayVersion:    GatewayVersion,
+		EventTimestamps:      snap,
+		TokenAccounting:      tokenAcct,
+		Assurance:            assuranceSummary,
+		CLEAR:                clear.Compute(clearInput),
+		ScoringVersion:       ScoringVersion,
+		GatewayVersion:       GatewayVersion,
+		ResolvedPolicyBundle: opts.ResolvedPolicyBundle,
 	}
 
 	reqEnv := RequestEnvelope{

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -185,6 +185,15 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 	if ms := ts.MedianInterTokenMs; ms != nil {
 		respFields["median_inter_token_ms"] = *ms
 	}
+	// Resolved policy bundle (Phase 4.0). Always populated when AIQG
+	// middleware is wired; nil for non-AIQG callers (tests, the noop
+	// path). Promote all three fields so LogQL can aggregate
+	// "bundles in use this week" without parsing payload.
+	if rpb := resp.Data.ResolvedPolicyBundle; rpb != nil {
+		respFields["resolved_policy_bundle_id"] = rpb.BundleID
+		respFields["resolved_policy_bundle_name"] = rpb.BundleName
+		respFields["resolved_policy_bundle_source"] = rpb.Source
+	}
 	// CLEAR scores — pointer-fielded; promote each non-nil dimension.
 	if c := resp.Data.CLEAR; c != nil {
 		if c.Cost != nil {

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -167,6 +167,25 @@ type ResponseEvent struct {
 	// Versioning
 	ScoringVersion string `json:"scoring_version"`
 	GatewayVersion string `json:"gateway_version"`
+
+	// ResolvedPolicyBundle is the bundle aiqg-dashboard-be's
+	// /internal/policy/resolve picked for this request (Phase 4.0).
+	// Always populated — nil/empty would defeat the "every request
+	// resolves to exactly one bundle" guarantee. When source="default"
+	// the bundle ID is empty and bundle name is "(default)", and the
+	// (Stage 4.1+) enforcement engine treats this as observe-only.
+	ResolvedPolicyBundle *ResolvedPolicyBundle `json:"resolved_policy_bundle,omitempty"`
+}
+
+// ResolvedPolicyBundle mirrors the dashboard-be ResolveResponse shape.
+// The middleware fills this in after calling the resolver; the emitter
+// promotes the fields to top-level logrus labels (resolved_policy_bundle_id
+// + resolved_policy_bundle_name + resolved_policy_bundle_source) so LogQL
+// can aggregate without parsing the embedded payload.
+type ResolvedPolicyBundle struct {
+	BundleID   string `json:"bundle_id"`
+	BundleName string `json:"bundle_name"`
+	Source     string `json:"source"` // "explicit" | "tenant_active" | "default"
 }
 
 // TokenAccounting carries the vendor-reported token counts and the

--- a/pkg/aiqg/policy/policy.go
+++ b/pkg/aiqg/policy/policy.go
@@ -1,0 +1,187 @@
+// Package policy resolves which AIQG policy bundle applies to a
+// request by calling aiqg-dashboard-be's /internal/policy/resolve
+// endpoint. Phase 4.0 — observation-only: the result rides on the
+// emitted AIQG response event but takes no enforcement action yet.
+//
+// The Resolver interface lets tests swap in deterministic results
+// without spinning up an HTTP server; production wires NewDashboardResolver.
+package policy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Resolution names the bundle that applies to a request along with
+// the precedence rung that picked it. Source values mirror the
+// dashboard-be constants:
+//
+//	"explicit"      — TAS-Policy-Bundle header named a real bundle
+//	"tenant_active" — tenant has a bundle with active=true
+//	"default"       — no configured bundle matched; observe-all sentinel
+type Resolution struct {
+	BundleID   string
+	BundleName string
+	Source     string
+}
+
+// Default returns the sentinel resolution used when the resolver is
+// unavailable or returns an error. Callers can treat the result as
+// "observe-all" — the eventual enforcement engine (Stage 4.1+) maps
+// this to "every rule is action=log."
+func Default() Resolution {
+	return Resolution{BundleName: "(default)", Source: "default"}
+}
+
+// Resolver is the dependency surface the AIQG middleware needs. Errors
+// from Resolve never propagate to the client request — the middleware
+// degrades to Default() instead. Returning an error here just signals
+// "log this so an operator can investigate."
+type Resolver interface {
+	Resolve(ctx context.Context, req ResolveRequest) (Resolution, error)
+}
+
+// ResolveRequest captures the inputs the resolver needs. Only TenantID
+// is required; the other fields slot into Stage 4.1+ precedence rules
+// (route matching) and are plumbed now to keep the contract stable.
+type ResolveRequest struct {
+	TenantID           string
+	AIQGAccountID      string
+	PolicyBundleHeader string // raw TAS-Policy-Bundle header value
+	SourceApp          string
+	Path               string
+}
+
+// DashboardResolver calls aiqg-dashboard-be's POST /internal/policy/resolve.
+// Mirrors the same shape + auth pattern as tokens.DashboardResolver
+// so operators only configure one base URL + internal auth token.
+type DashboardResolver struct {
+	HTTP              *http.Client
+	BaseURL           string
+	InternalAuthToken string
+}
+
+// NewDashboardResolver returns a Resolver pointing at the configured
+// dashboard-be base URL. Same baseURL as tokens.NewDashboardResolver
+// — "http://aiqg-dashboard-be.aiqg.svc.cluster.local:8095" in cluster.
+//
+// The 2s timeout matches tokens.DashboardResolver; the resolver is
+// called once per AIQG request so the per-request cost is bounded.
+// Future: an in-process TTL cache shaves the per-request HTTP if
+// resolution becomes hot (most resolutions for a single tenant will
+// return the same bundle within seconds).
+func NewDashboardResolver(baseURL, internalAuthToken string) (*DashboardResolver, error) {
+	if baseURL == "" {
+		return nil, errors.New("policy.NewDashboardResolver: baseURL required")
+	}
+	if internalAuthToken == "" {
+		return nil, errors.New("policy.NewDashboardResolver: internalAuthToken required")
+	}
+	return &DashboardResolver{
+		HTTP:              &http.Client{Timeout: 2 * time.Second},
+		BaseURL:           baseURL,
+		InternalAuthToken: internalAuthToken,
+	}, nil
+}
+
+// resolveRequest mirrors the JSON shape of aiqg-dashboard-be's
+// internal/handlers/internal_policy.go ResolveRequest. Keeping the
+// types in sync is enforced by a smoke test, not by an import (would
+// drag Gin into this package's dep tree otherwise).
+type resolveRequest struct {
+	TenantID           string `json:"tenant_id"`
+	AIQGAccountID      string `json:"aiqg_account_id,omitempty"`
+	PolicyBundleHeader string `json:"policy_bundle_header,omitempty"`
+	SourceApp          string `json:"source_app,omitempty"`
+	Path               string `json:"path,omitempty"`
+}
+
+type resolveResponse struct {
+	BundleID   string `json:"bundle_id"`
+	BundleName string `json:"bundle_name"`
+	Source     string `json:"source"`
+}
+
+// ErrResolverBadRequest is returned when the dashboard rejects the
+// request body (400). Callers should treat this as a permanent
+// failure for that request shape — retrying won't help — but other
+// requests can still succeed, so degrade to Default() rather than
+// crashing.
+var ErrResolverBadRequest = errors.New("policy.DashboardResolver: dashboard returned 400")
+
+// ErrBundleNotFound maps the 404 response (explicit header named an
+// unknown bundle). Distinguished from generic transport errors so
+// callers can emit a clearer "operator typo on TAS-Policy-Bundle"
+// signal rather than the generic resolver-unavailable warning.
+var ErrBundleNotFound = errors.New("policy.DashboardResolver: bundle not found")
+
+// Resolve returns the bundle resolution for the given request.
+// Errors are returned for transport failures, bad-request, and
+// not-found cases; success returns the resolution + nil. The
+// middleware swallows the error and falls back to Default() so
+// the request never fails because of policy resolution.
+func (r *DashboardResolver) Resolve(ctx context.Context, req ResolveRequest) (Resolution, error) {
+	if req.TenantID == "" {
+		return Default(), errors.New("policy.DashboardResolver: tenant_id required")
+	}
+
+	body, err := json.Marshal(resolveRequest{
+		TenantID:           req.TenantID,
+		AIQGAccountID:      req.AIQGAccountID,
+		PolicyBundleHeader: req.PolicyBundleHeader,
+		SourceApp:          req.SourceApp,
+		Path:               req.Path,
+	})
+	if err != nil {
+		return Default(), fmt.Errorf("policy.DashboardResolver: marshal: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.BaseURL+"/internal/policy/resolve", bytes.NewReader(body))
+	if err != nil {
+		return Default(), fmt.Errorf("policy.DashboardResolver: new request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Internal-Auth", r.InternalAuthToken)
+
+	resp, err := r.HTTP.Do(httpReq)
+	if err != nil {
+		return Default(), fmt.Errorf("policy.DashboardResolver: do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var v resolveResponse
+		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
+			return Default(), fmt.Errorf("policy.DashboardResolver: decode 200: %w", err)
+		}
+		return Resolution{BundleID: v.BundleID, BundleName: v.BundleName, Source: v.Source}, nil
+	case http.StatusNotFound:
+		// Explicit header named an unknown bundle. Caller can log
+		// distinctly so operators see "your TAS-Policy-Bundle header
+		// is wrong" rather than the generic resolver-down warning.
+		return Default(), ErrBundleNotFound
+	case http.StatusBadRequest:
+		return Default(), ErrResolverBadRequest
+	default:
+		return Default(), fmt.Errorf("policy.DashboardResolver: unexpected status %d", resp.StatusCode)
+	}
+}
+
+// StaticResolver is a test helper that always returns the same
+// resolution. Used in unit tests that need to exercise the gateway
+// middleware's resolution-handling logic without a fake HTTP server.
+type StaticResolver struct {
+	Result Resolution
+	Err    error
+}
+
+func (r StaticResolver) Resolve(_ context.Context, _ ResolveRequest) (Resolution, error) {
+	return r.Result, r.Err
+}

--- a/pkg/aiqg/policy/policy_test.go
+++ b/pkg/aiqg/policy/policy_test.go
@@ -1,0 +1,114 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// stubServer returns an httptest.Server that responds with status +
+// body for every /internal/policy/resolve call. The test asserts on
+// request shape and on the Resolution/error the client returns.
+func stubServer(t *testing.T, status int, body string, captureBearer *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/policy/resolve" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if captureBearer != nil {
+			*captureBearer = r.Header.Get("Internal-Auth")
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+func TestDashboardResolver_OK(t *testing.T) {
+	srv := stubServer(t, http.StatusOK,
+		`{"bundle_id":"b1","bundle_name":"prod-strict","source":"explicit"}`, nil)
+	defer srv.Close()
+
+	r, err := NewDashboardResolver(srv.URL, "secret")
+	if err != nil {
+		t.Fatalf("NewDashboardResolver: %v", err)
+	}
+	res, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t1"})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if res.BundleID != "b1" || res.BundleName != "prod-strict" || res.Source != "explicit" {
+		t.Errorf("got %+v", res)
+	}
+}
+
+func TestDashboardResolver_404IsBundleNotFound(t *testing.T) {
+	srv := stubServer(t, http.StatusNotFound, `{}`, nil)
+	defer srv.Close()
+	r, _ := NewDashboardResolver(srv.URL, "secret")
+	_, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t1"})
+	if !errors.Is(err, ErrBundleNotFound) {
+		t.Errorf("err = %v want ErrBundleNotFound", err)
+	}
+}
+
+func TestDashboardResolver_400IsBadRequest(t *testing.T) {
+	srv := stubServer(t, http.StatusBadRequest, `{}`, nil)
+	defer srv.Close()
+	r, _ := NewDashboardResolver(srv.URL, "secret")
+	_, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t1"})
+	if !errors.Is(err, ErrResolverBadRequest) {
+		t.Errorf("err = %v want ErrResolverBadRequest", err)
+	}
+}
+
+func TestDashboardResolver_InternalAuthHeader(t *testing.T) {
+	var seen string
+	srv := stubServer(t, http.StatusOK,
+		`{"bundle_id":"","bundle_name":"(default)","source":"default"}`, &seen)
+	defer srv.Close()
+	r, _ := NewDashboardResolver(srv.URL, "expected-secret")
+	if _, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t1"}); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if seen != "expected-secret" {
+		t.Errorf("Internal-Auth header = %q want expected-secret", seen)
+	}
+}
+
+func TestDashboardResolver_DegradesToDefaultOnError(t *testing.T) {
+	// 5xx — neither ErrBundleNotFound nor ErrResolverBadRequest;
+	// caller still gets a usable Default() resolution.
+	srv := stubServer(t, http.StatusServiceUnavailable, `{}`, nil)
+	defer srv.Close()
+	r, _ := NewDashboardResolver(srv.URL, "secret")
+	res, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t1"})
+	if err == nil {
+		t.Errorf("expected error for 503")
+	}
+	// The caller can still proceed with the returned Default()
+	if res.Source != "default" || res.BundleName != "(default)" {
+		t.Errorf("degraded resolution = %+v, want Default()", res)
+	}
+}
+
+func TestDashboardResolver_RequiresTenantID(t *testing.T) {
+	// Don't stand up a server — the resolver should fail fast on
+	// missing tenant_id without making an HTTP call.
+	r, _ := NewDashboardResolver("http://invalid", "secret")
+	_, err := r.Resolve(context.Background(), ResolveRequest{TenantID: ""})
+	if err == nil || !strings.Contains(err.Error(), "tenant_id required") {
+		t.Errorf("err = %v want tenant_id required", err)
+	}
+}
+
+func TestStaticResolver(t *testing.T) {
+	want := Resolution{BundleID: "x", BundleName: "y", Source: "tenant_active"}
+	r := StaticResolver{Result: want}
+	got, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t"})
+	if err != nil || got != want {
+		t.Errorf("got %+v err=%v want %+v err=nil", got, err, want)
+	}
+}


### PR DESCRIPTION
## Summary

Gateway-side companion to **aiqg-dashboard-be#29**. Adds the policy bundle resolver HTTP client and wires it into the AIQG middleware so every emitted event carries a \`resolved_policy_bundle\`. **Pure observation** — no enforcement yet (that's Stage 4.1+).

### \`pkg/aiqg/policy\` (new)
- \`Resolver\` interface + \`DashboardResolver\` HTTP client mirroring \`tokens.DashboardResolver\` (same base URL + internal auth token, same 2s timeout, same anti-cycle struct typing)
- \`StaticResolver\` test helper
- \`ErrBundleNotFound\` (404 — explicit header named unknown bundle)
- \`ErrResolverBadRequest\` (400)
- \`Default()\` sentinel returned when the resolver is unavailable

### \`pkg/aiqg/events\`
- \`ResolvedPolicyBundle\` struct on \`ResponseEvent\` (pointer-typed; nil omits the field for non-AIQG callers)
- \`BuildOptions.ResolvedPolicyBundle\` stamps it through \`events.Build\`
- \`LogEmitter\` promotes 3 top-level fields: \`resolved_policy_bundle_{id,name,source}\` — LogQL can aggregate "bundles in use this week" without parsing payload

### \`internal/middleware/aiqg\`
- \`AIQGConfig.PolicyResolver\` — **nil-tolerant**. Configured? resolve and stamp. Resolver errors? log warning + fall back to \`Default()\` so requests **never fail because of policy resolution**
- Resolution happens after token resolution (needs tenant_id) and before the next handler — adds ~5–15ms steady-state cluster RTT

### \`internal/server\`
- Builds the policy resolver alongside the token resolver (same dashboard URL + internal auth token)

## Smoke test (2026-06-10, live cluster)
AIQG event for a tenant with no configured bundle:
\`\`\`
resolved_policy_bundle_id     = ''
resolved_policy_bundle_name   = '(default)'
resolved_policy_bundle_source = 'default'
\`\`\`
Proves the **"every event has a resolution"** gate criterion holds even when no bundle is configured.

## Test plan
- [x] 7 unit tests on the resolver client: 200 happy path / 404 ErrBundleNotFound / 400 ErrResolverBadRequest / 5xx degrades to Default / Internal-Auth header threaded / missing tenant_id fails fast / StaticResolver helper
- [x] Existing middleware tests unchanged — \`PolicyResolver\` is nil-safe so they don't need updates
- [x] Image \`aiqg-v5.22\` built + pushed + rolled to both \`llm-router\` and \`llm-router-aiqg\` deployments
- [x] Loki shows the new fields on the post-deploy event

## Companion PR
- aiqg-dashboard-be#29 — server side of the resolver endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)