### PR TITLE
AIQG identity plumbing: baggage + TAS-Agent-* + traceparent

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -6,16 +6,16 @@
 //
 // Decision logic (per build-vs-reuse §2.2 + §7.3 strict resolution):
 //
-//   1. Both TAS-Auth and Authorization present → enter Path A:
-//      - parse the TAS-* header taxonomy and attach to ctx
-//      - create a TimingCollector and attach to ctx
-//      - stamp StampReceived on entry, StampComplete on response end
-//      - hand off to the downstream chain
-//   2. TAS-Auth present but Authorization missing → 401 (cfg.Strict only)
-//   3. TAS-Auth missing → depends on cfg.Strict:
-//      - Strict (customer-facing ingress): 401, diagnostic body
-//      - Permissive (internal ingress): pass through unchanged, no
-//        AIQG state attached — preserves existing internal-routing behavior
+//  1. Both TAS-Auth and Authorization present → enter Path A:
+//     - parse the TAS-* header taxonomy and attach to ctx
+//     - create a TimingCollector and attach to ctx
+//     - stamp StampReceived on entry, StampComplete on response end
+//     - hand off to the downstream chain
+//  2. TAS-Auth present but Authorization missing → 401 (cfg.Strict only)
+//  3. TAS-Auth missing → depends on cfg.Strict:
+//     - Strict (customer-facing ingress): 401, diagnostic body
+//     - Permissive (internal ingress): pass through unchanged, no
+//     AIQG state attached — preserves existing internal-routing behavior
 //
 // The middleware never persists Authorization. The header value is
 // already in r.Header for the rest of the chain; Path A's promise
@@ -250,6 +250,15 @@ func headersView(h AIQGHeaders) events.AIQGHeadersView {
 		PolicyBundle: h.PolicyBundle,
 		DryRun:       h.DryRun,
 		Trace:        h.Trace,
+
+		AgentID:          h.AgentID,
+		AgentName:        h.AgentName,
+		AgentVersion:     h.AgentVersion,
+		FlowID:           h.FlowID,
+		ConversationID:   h.ConversationID,
+		TraceID:          h.TraceID,
+		BaggageUserID:    h.Baggage["user.id"],
+		BaggageSessionID: h.Baggage["session.id"],
 	}
 }
 

--- a/internal/middleware/aiqg_headers.go
+++ b/internal/middleware/aiqg_headers.go
@@ -32,6 +32,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -48,6 +49,17 @@ type AIQGHeaders struct {
 	Trace                 bool     // TAS-Trace=1
 	DryRun                bool     // TAS-Dry-Run=1
 	SourceApp             string   // TAS-Source-App (max 128 chars)
+
+	// Identity (additive, observability attribution — see
+	// docs/AIQG-AGENT-FLOW-ATTRIBUTION.md). Self-asserted; never
+	// authenticated here. All optional; parse never fails on these.
+	AgentID        string            // TAS-Agent-Id
+	AgentName      string            // TAS-Agent-Name
+	AgentVersion   string            // TAS-Agent-Version
+	FlowID         string            // TAS-Flow-Id (explicit run id)
+	ConversationID string            // TAS-Conversation-Id
+	TraceID        string            // W3C traceparent trace-id (read, not stripped)
+	Baggage        map[string]string // W3C baggage (user.id, session.id, account.id, …)
 }
 
 // IsZero reports whether any AIQG header was set. Used by the Path A
@@ -71,6 +83,15 @@ var canonicalHeaderNames = []string{
 	"TAS-Trace",
 	"TAS-Dry-Run",
 	"TAS-Source-App",
+	// Identity headers — stripped before the vendor. `baggage` carries
+	// end-user identity and MUST NOT leak upstream. (`traceparent` is a
+	// standard tracing header and is intentionally NOT stripped.)
+	"TAS-Agent-Id",
+	"TAS-Agent-Name",
+	"TAS-Agent-Version",
+	"TAS-Flow-Id",
+	"TAS-Conversation-Id",
+	"baggage",
 }
 
 // validWorkflows is the closed enum from
@@ -128,6 +149,14 @@ func ParseHeaders(req *http.Request) (AIQGHeaders, error) {
 		Trace:                 req.Header.Get("TAS-Trace") == "1",
 		DryRun:                req.Header.Get("TAS-Dry-Run") == "1",
 		SourceApp:             strings.TrimSpace(req.Header.Get("TAS-Source-App")),
+
+		AgentID:        strings.TrimSpace(req.Header.Get("TAS-Agent-Id")),
+		AgentName:      strings.TrimSpace(req.Header.Get("TAS-Agent-Name")),
+		AgentVersion:   strings.TrimSpace(req.Header.Get("TAS-Agent-Version")),
+		FlowID:         strings.TrimSpace(req.Header.Get("TAS-Flow-Id")),
+		ConversationID: strings.TrimSpace(req.Header.Get("TAS-Conversation-Id")),
+		TraceID:        parseTraceparentTraceID(req.Header.Get("traceparent")),
+		Baggage:        parseBaggage(req.Header.Get("baggage")),
 	}
 
 	if raw := req.Header.Get("TAS-Policy"); raw != "" {
@@ -163,6 +192,56 @@ func ParseHeaders(req *http.Request) (AIQGHeaders, error) {
 	}
 
 	return h, nil
+}
+
+// parseBaggage parses a W3C `baggage` header — a comma-separated list of
+// key=value pairs, each with optional ;-properties that we ignore. Used
+// to lift the cross-app identity keys (user.id, session.id, account.id —
+// the Datadog/OTel defaults) onto the AIQG event. Defensive: malformed
+// pairs are skipped, never panics. Returns nil for an empty header.
+func parseBaggage(raw string) map[string]string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	out := make(map[string]string)
+	for _, pair := range strings.Split(raw, ",") {
+		if i := strings.IndexByte(pair, ';'); i >= 0 {
+			pair = pair[:i] // drop ;-properties
+		}
+		kv := strings.SplitN(pair, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		k := strings.TrimSpace(kv[0])
+		v := strings.TrimSpace(kv[1])
+		if k == "" || v == "" {
+			continue
+		}
+		if dv, err := url.QueryUnescape(v); err == nil {
+			v = dv
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// parseTraceparentTraceID extracts the 32-hex trace-id from a W3C
+// `traceparent` header ("version-traceid-spanid-flags"). Returns "" if
+// absent or malformed — never panics.
+func parseTraceparentTraceID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	parts := strings.Split(raw, "-")
+	if len(parts) < 4 || len(parts[1]) != 32 {
+		return ""
+	}
+	return parts[1]
 }
 
 // StripFromOutbound removes every TAS-* header from req.Header. Call this

--- a/internal/middleware/aiqg_headers_test.go
+++ b/internal/middleware/aiqg_headers_test.go
@@ -375,6 +375,13 @@ func TestCanonicalHeaderListExhaustive(t *testing.T) {
 		"TAS-Trace":                  {},
 		"TAS-Dry-Run":                {},
 		"TAS-Source-App":             {},
+		// Identity headers (stripped before vendor).
+		"TAS-Agent-Id":        {},
+		"TAS-Agent-Name":      {},
+		"TAS-Agent-Version":   {},
+		"TAS-Flow-Id":         {},
+		"TAS-Conversation-Id": {},
+		"baggage":             {},
 	}
 	if len(canonicalHeaderNames) != len(expected) {
 		t.Fatalf("canonicalHeaderNames len=%d want=%d", len(canonicalHeaderNames), len(expected))
@@ -383,5 +390,63 @@ func TestCanonicalHeaderListExhaustive(t *testing.T) {
 		if _, ok := expected[n]; !ok {
 			t.Errorf("unexpected header in canonical list: %q", n)
 		}
+	}
+}
+
+func TestParseHeaders_Identity(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"TAS-Agent-Id":        "agent-7",
+		"TAS-Agent-Name":      "Planner",
+		"TAS-Conversation-Id": "conv-9",
+		"traceparent":         "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+		"baggage":             "user.id=u_42,session.id=s_99,account.id=acct_1",
+	})
+	h, err := ParseHeaders(req)
+	if err != nil {
+		t.Fatalf("ParseHeaders: %v", err)
+	}
+	if h.AgentID != "agent-7" || h.AgentName != "Planner" {
+		t.Errorf("agent fields: %+v", h)
+	}
+	if h.ConversationID != "conv-9" {
+		t.Errorf("conversation: %q", h.ConversationID)
+	}
+	if h.TraceID != "0af7651916cd43dd8448eb211c80319c" {
+		t.Errorf("trace id: %q", h.TraceID)
+	}
+	if h.Baggage["user.id"] != "u_42" || h.Baggage["session.id"] != "s_99" || h.Baggage["account.id"] != "acct_1" {
+		t.Errorf("baggage: %+v", h.Baggage)
+	}
+}
+
+func TestParseBaggage_Malformed(t *testing.T) {
+	// Empty, junk, and ;-properties must not panic and parse defensively.
+	if parseBaggage("") != nil {
+		t.Errorf("empty baggage should be nil")
+	}
+	got := parseBaggage("user.id=u1;meta=x, =bad, novalue=, k=v")
+	if got["user.id"] != "u1" || got["k"] != "v" {
+		t.Errorf("baggage parse: %+v", got)
+	}
+	if _, ok := got["novalue"]; ok {
+		t.Errorf("empty-value pair should be dropped: %+v", got)
+	}
+}
+
+func TestStripFromOutbound_IdentityHeaders(t *testing.T) {
+	req := newReq(t, map[string]string{
+		"baggage":      "user.id=u_42",
+		"TAS-Agent-Id": "agent-7",
+		"traceparent":  "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+	})
+	StripFromOutbound(req)
+	if req.Header.Get("baggage") != "" {
+		t.Errorf("baggage must be stripped before vendor")
+	}
+	if req.Header.Get("TAS-Agent-Id") != "" {
+		t.Errorf("TAS-Agent-Id must be stripped before vendor")
+	}
+	if req.Header.Get("traceparent") == "" {
+		t.Errorf("traceparent must NOT be stripped (standard header)")
 	}
 }

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -23,6 +23,19 @@ type AIQGHeadersView struct {
 	PolicyBundle string
 	DryRun       bool
 	Trace        bool
+
+	// Identity (additive, self-asserted). The middleware projects these
+	// from its parsed AIQGHeaders (TAS-Agent-* / traceparent) and the two
+	// baggage keys it cares about. Build assembles them — with the token
+	// principal — into the event AgentContext.
+	AgentID          string
+	AgentName        string
+	AgentVersion     string
+	FlowID           string
+	ConversationID   string
+	TraceID          string
+	BaggageUserID    string
+	BaggageSessionID string
 }
 
 // RoutingView is the subset of routing-layer state the event builder
@@ -152,6 +165,55 @@ type BuildOptions struct {
 // auth failures don't reach Build (per spec §273), so token is either
 // fully populated from a successful resolve or fully empty (resolver
 // not configured / non-AIQG path).
+// buildAgentContext resolves the self-asserted identity ladder for a
+// request (docs/AIQG-AGENT-FLOW-ATTRIBUTION.md): baggage user.id is the
+// cross-app user key; TAS-Agent-* / traceparent supply agent/flow; the
+// AIQG token supplies the always-present principal tier. identity_source
+// records the strongest tier that produced an identity. Returns nil only
+// when nothing at all resolved (no token, no headers).
+func buildAgentContext(h AIQGHeadersView, t TokenView) *AgentContext {
+	ac := &AgentContext{
+		AgentID:      h.AgentID,
+		AgentName:    h.AgentName,
+		AgentVersion: h.AgentVersion,
+		UserID:       h.BaggageUserID,
+	}
+	// conversation: explicit header wins, else baggage session.id
+	ac.ConversationID = h.ConversationID
+	if ac.ConversationID == "" {
+		ac.ConversationID = h.BaggageSessionID
+	}
+	// flow: explicit header wins, else traceparent trace-id
+	ac.FlowID = h.FlowID
+	if ac.FlowID == "" {
+		ac.FlowID = h.TraceID
+	}
+	// principal: token source_app, else token id (always present in AIQG mode)
+	ac.PrincipalID = t.SourceApp
+	if ac.PrincipalID == "" {
+		ac.PrincipalID = t.TASAuthTokenID
+	}
+
+	switch {
+	case ac.UserID != "":
+		ac.IdentitySource = "baggage"
+	case ac.AgentID != "" || h.FlowID != "" || h.ConversationID != "":
+		ac.IdentitySource = "asserted"
+	case h.TraceID != "":
+		ac.IdentitySource = "trace"
+	case ac.PrincipalID != "":
+		ac.IdentitySource = "principal"
+	default:
+		ac.IdentitySource = "unattributed"
+	}
+
+	if ac.AgentID == "" && ac.AgentName == "" && ac.UserID == "" &&
+		ac.ConversationID == "" && ac.FlowID == "" && ac.PrincipalID == "" {
+		return nil
+	}
+	return ac
+}
+
 func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token TokenView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
 	reqID := newUUID()
 	respID := newUUID()
@@ -184,6 +246,9 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		sourceApp = token.SourceApp
 	}
 
+	// Self-asserted identity attribution (shared by both events).
+	agentCtx := buildAgentContext(headers, token)
+
 	reqEvent := RequestEvent{
 		RequestEventID:  reqID,
 		TenantID:        token.TenantID,
@@ -211,6 +276,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		ScoringVersion:            ScoringVersion,
 		GatewayVersion:            GatewayVersion,
 		LifecycleState:            LifecyclePairedWithResponse,
+		AgentContext:              agentCtx,
 	}
 
 	// Routing's FinishReason wins over BuildOptions.FinishReason when
@@ -274,19 +340,19 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	}
 
 	respEvent := ResponseEvent{
-		ResponseEventID:   respID,
-		RequestEventID:    reqID,
-		TenantID:          token.TenantID,      // denormalized per response-event.md §"Denormalization rationale"
-		AIQGAccountID:     token.AIQGAccountID, // ditto
-		Vendor:            routing.Vendor,      // denormalized from routing decision (same as RequestEvent)
-		Model:             routing.Model,       // ditto — powers per-vendor/model dashboards off the response stream
-		CompleteAt:        completeAt,
-		Status:            status,
-		HTTPStatus:        opts.HTTPStatus,
-		FinishReason:      finishReason,
-		Streamed:          snap.ChunkCount > 0,
-		ChunkCount:        snap.ChunkCount,
-		ContentChunkCount: snap.ContentChunkCount,
+		ResponseEventID:      respID,
+		RequestEventID:       reqID,
+		TenantID:             token.TenantID,      // denormalized per response-event.md §"Denormalization rationale"
+		AIQGAccountID:        token.AIQGAccountID, // ditto
+		Vendor:               routing.Vendor,      // denormalized from routing decision (same as RequestEvent)
+		Model:                routing.Model,       // ditto — powers per-vendor/model dashboards off the response stream
+		CompleteAt:           completeAt,
+		Status:               status,
+		HTTPStatus:           opts.HTTPStatus,
+		FinishReason:         finishReason,
+		Streamed:             snap.ChunkCount > 0,
+		ChunkCount:           snap.ChunkCount,
+		ContentChunkCount:    snap.ContentChunkCount,
 		EventTimestamps:      snap,
 		TokenAccounting:      tokenAcct,
 		Assurance:            assuranceSummary,
@@ -294,6 +360,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		ScoringVersion:       ScoringVersion,
 		GatewayVersion:       GatewayVersion,
 		ResolvedPolicyBundle: opts.ResolvedPolicyBundle,
+		AgentContext:         agentCtx,
 	}
 
 	reqEnv := RequestEnvelope{

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -236,6 +236,35 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 			respFields["tag_"+sanitizeTagKey(k)] = v
 		}
 	}
+	// Promote self-asserted identity attribution so dashboards can
+	// `| json | user_id="…"` / group by (agent_id) / by (flow_id)
+	// without parsing the payload. Only non-empty fields are promoted.
+	if ac := resp.Data.AgentContext; ac != nil {
+		if ac.AgentID != "" {
+			respFields["agent_id"] = ac.AgentID
+		}
+		if ac.AgentName != "" {
+			respFields["agent_name"] = ac.AgentName
+		}
+		if ac.AgentVersion != "" {
+			respFields["agent_version"] = ac.AgentVersion
+		}
+		if ac.UserID != "" {
+			respFields["user_id"] = ac.UserID
+		}
+		if ac.ConversationID != "" {
+			respFields["conversation_id"] = ac.ConversationID
+		}
+		if ac.FlowID != "" {
+			respFields["flow_id"] = ac.FlowID
+		}
+		if ac.PrincipalID != "" {
+			respFields["principal_id"] = ac.PrincipalID
+		}
+		if ac.IdentitySource != "" {
+			respFields["identity_source"] = ac.IdentitySource
+		}
+	}
 	e.Logger.WithFields(respFields).Info("aiqg response event")
 	return nil
 }

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -112,6 +112,27 @@ type RequestEvent struct {
 	ScoringVersion string `json:"scoring_version"`
 	GatewayVersion string `json:"gateway_version"`
 	LifecycleState string `json:"lifecycle_state"`
+
+	// Identity attribution (additive) — see AgentContext.
+	AgentContext *AgentContext `json:"agent_context,omitempty"`
+}
+
+// AgentContext is the self-asserted identity attribution for a request:
+// the cross-app user/agent/flow keys lifted from the W3C `baggage` and
+// TAS-Agent-* / `traceparent` headers, plus the AIQG token for the
+// principal tier. Additive and optional — nil when nothing resolved.
+// See docs/AIQG-AGENT-FLOW-ATTRIBUTION.md. The emitter promotes the
+// non-empty fields to top-level Loki labels so dashboards can group by
+// user_id / agent_id / flow_id without parsing the payload.
+type AgentContext struct {
+	AgentID        string `json:"agent_id,omitempty"`        // TAS-Agent-Id
+	AgentName      string `json:"agent_name,omitempty"`      // TAS-Agent-Name
+	AgentVersion   string `json:"agent_version,omitempty"`   // TAS-Agent-Version
+	UserID         string `json:"user_id,omitempty"`         // baggage user.id (pseudonymous)
+	ConversationID string `json:"conversation_id,omitempty"` // TAS-Conversation-Id or baggage session.id
+	FlowID         string `json:"flow_id,omitempty"`         // TAS-Flow-Id or traceparent trace-id
+	PrincipalID    string `json:"principal_id,omitempty"`    // AIQG token source_app / token id
+	IdentitySource string `json:"identity_source,omitempty"` // baggage|asserted|trace|principal|unattributed
 }
 
 // ResponseEvent mirrors aether-shared/data-models/aiqg/response-event.md §2.2.
@@ -175,6 +196,9 @@ type ResponseEvent struct {
 	// the bundle ID is empty and bundle name is "(default)", and the
 	// (Stage 4.1+) enforcement engine treats this as observe-only.
 	ResolvedPolicyBundle *ResolvedPolicyBundle `json:"resolved_policy_bundle,omitempty"`
+
+	// Identity attribution (additive) — see AgentContext.
+	AgentContext *AgentContext `json:"agent_context,omitempty"`
 }
 
 // ResolvedPolicyBundle mirrors the dashboard-be ResolveResponse shape.


### PR DESCRIPTION
Additive self-asserted identity attribution on every AIQG event (powers Traffic Explorer). Parses W3C `baggage` (user.id/session.id/account.id), `TAS-Agent-*`, `TAS-Flow-Id`, `TAS-Conversation-Id`, `traceparent`; resolves the ladder (baggage > asserted > trace > principal > unattributed; principal always present from the token); promotes the 8 fields onto the Loki line. `baggage`+TAS-Agent-* stripped before vendor; `traceparent` not (standard). No behavior change to existing flows — build (nohs) + full suite green. Deployed `aiqg-v5.23` to both gateway deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)