### PR TITLE
AIQG IP transport tier: gated client_ip on events

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,10 +38,16 @@ type Config struct {
 // to a backend-client Resolver against aiqg-dashboard-be once that
 // service ships.
 type AIQGConfig struct {
-	Enabled bool                  `yaml:"enabled"`
-	Strict  bool                  `yaml:"strict"`
-	Region  string                `yaml:"region"`
-	Tokens  []AIQGTokenConfig     `yaml:"tokens"`
+	Enabled bool   `yaml:"enabled"`
+	Strict  bool   `yaml:"strict"`
+	Region  string `yaml:"region"`
+	// IPCaptureMode gates how the client IP is recorded on AIQG events:
+	// "off" (none), "minimized" (truncated /24·/48 prefix; the default
+	// when empty), "full" (raw). Set "full" on internal/self-hosted
+	// deployments; leave default for the privacy-minimized product.
+	// Env: AIQG_IP_CAPTURE_MODE.
+	IPCaptureMode string            `yaml:"ip_capture_mode"`
+	Tokens        []AIQGTokenConfig `yaml:"tokens"`
 
 	// EmitterType selects the AIQG event sink: "log" (default,
 	// Loki via logrus), "kafka", or "both". Env override:
@@ -432,6 +438,9 @@ func (c *Config) loadFromEnv() {
 	if region := os.Getenv("AIQG_REGION"); region != "" {
 		c.AIQG.Region = region
 	}
+	if mode := os.Getenv("AIQG_IP_CAPTURE_MODE"); mode != "" {
+		c.AIQG.IPCaptureMode = mode
+	}
 	if et := os.Getenv("AIQG_EMITTER_TYPE"); et != "" {
 		c.AIQG.EmitterType = et
 	}
@@ -622,6 +631,7 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 		Enabled:                    c.AIQG.Enabled,
 		Strict:                     c.AIQG.Strict,
 		Region:                     c.AIQG.Region,
+		IPCaptureMode:              c.AIQG.IPCaptureMode,
 		EmitterType:                c.AIQG.EmitterType,
 		DashboardURL:               c.AIQG.DashboardURL,
 		DashboardInternalAuthToken: c.AIQG.DashboardInternalAuthToken,

--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -65,6 +65,10 @@ type AIQGConfig struct {
 	// during local dev and is omitted from the event JSON.
 	Region string
 
+	// IPCaptureMode gates client-IP recording on events: "off",
+	// "minimized" (truncated prefix; default when empty), "full" (raw).
+	IPCaptureMode string
+
 	// Resolver turns the TAS-Auth bearer into a tenant_id / account_id
 	// for event attribution. Nil is allowed during incremental rollout:
 	// the middleware skips resolution, every request is treated as
@@ -221,8 +225,9 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// stamps made by the handler reach the event.
 	defer func() {
 		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
-			HTTPStatus: sw.status(),
-			Region:     cfg.Region,
+			HTTPStatus:    sw.status(),
+			Region:        cfg.Region,
+			IPCaptureMode: cfg.IPCaptureMode,
 			ResolvedPolicyBundle: &events.ResolvedPolicyBundle{
 				BundleID:   bundleResolution.BundleID,
 				BundleName: bundleResolution.BundleName,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,10 +14,10 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/gatekeeper"
 	"github.com/tributary-ai/llm-router-waf/internal/middleware"
 	"github.com/tributary-ai/llm-router-waf/internal/providers"
-	"github.com/tributary-ai/llm-router-waf/internal/workflow"
 	"github.com/tributary-ai/llm-router-waf/internal/routing"
 	"github.com/tributary-ai/llm-router-waf/internal/security"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/internal/workflow"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
@@ -72,9 +72,11 @@ func (aiqgMetricsAdapter) RecordEvent(resp events.ResponseEnvelope) {
 }
 
 // buildAIQGEmitter constructs the Emitter per the configured type.
-//   "" or "log" → LogEmitter (default; no infra required)
-//   "kafka"     → KafkaEmitter only
-//   "both"      → MultiEmitter fanning to log + kafka
+//
+//	"" or "log" → LogEmitter (default; no infra required)
+//	"kafka"     → KafkaEmitter only
+//	"both"      → MultiEmitter fanning to log + kafka
+//
 // Unknown values fall back to log with a warning so a typo doesn't
 // crash the deployment.
 func buildAIQGEmitter(cfg *AIQGServerConfig, logger *logrus.Logger) (events.Emitter, error) {
@@ -128,6 +130,10 @@ type AIQGServerConfig struct {
 	Enabled bool   `yaml:"enabled"`
 	Strict  bool   `yaml:"strict"`
 	Region  string `yaml:"region"`
+
+	// IPCaptureMode gates client-IP recording on events: "off",
+	// "minimized" (truncated prefix; default when empty), "full" (raw).
+	IPCaptureMode string `yaml:"ip_capture_mode"`
 
 	// Tokens is the MVP in-memory token store. Used as a fallback
 	// when DashboardURL is unset OR when the dashboard-be is
@@ -262,6 +268,7 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			Logger:         logger,
 			Emitter:        server.aiqgEmitter,
 			Region:         config.AIQG.Region,
+			IPCaptureMode:  config.AIQG.IPCaptureMode,
 			Resolver:       resolver,
 			PolicyResolver: policyResolver,
 		})

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -126,10 +126,11 @@ var ScoringVersion = clear.Version
 // aren't on the request context (HTTP status, response status string,
 // region). Fields default to sensible MVP values when zero.
 type BuildOptions struct {
-	HTTPStatus   int    // 0 if no response was written (gateway blocked)
-	Status       string // explicit status; if empty, derived from HTTPStatus
-	Region       string // deployment region; if empty, omitted from event
-	FinishReason string
+	HTTPStatus    int    // 0 if no response was written (gateway blocked)
+	Status        string // explicit status; if empty, derived from HTTPStatus
+	Region        string // deployment region; if empty, omitted from event
+	IPCaptureMode string // off | minimized (default) | full — gates client IP
+	FinishReason  string
 
 	// ResolvedPolicyBundle is the bundle aiqg-dashboard-be picked for
 	// this request (Phase 4.0). Always set in production — the
@@ -171,12 +172,13 @@ type BuildOptions struct {
 // AIQG token supplies the always-present principal tier. identity_source
 // records the strongest tier that produced an identity. Returns nil only
 // when nothing at all resolved (no token, no headers).
-func buildAgentContext(h AIQGHeadersView, t TokenView) *AgentContext {
+func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string) *AgentContext {
 	ac := &AgentContext{
 		AgentID:      h.AgentID,
 		AgentName:    h.AgentName,
 		AgentVersion: h.AgentVersion,
 		UserID:       h.BaggageUserID,
+		ClientIP:     clientIP,
 	}
 	// conversation: explicit header wins, else baggage session.id
 	ac.ConversationID = h.ConversationID
@@ -203,15 +205,44 @@ func buildAgentContext(h AIQGHeadersView, t TokenView) *AgentContext {
 		ac.IdentitySource = "trace"
 	case ac.PrincipalID != "":
 		ac.IdentitySource = "principal"
+	case ac.ClientIP != "":
+		ac.IdentitySource = "transport"
 	default:
 		ac.IdentitySource = "unattributed"
 	}
 
 	if ac.AgentID == "" && ac.AgentName == "" && ac.UserID == "" &&
-		ac.ConversationID == "" && ac.FlowID == "" && ac.PrincipalID == "" {
+		ac.ConversationID == "" && ac.FlowID == "" && ac.PrincipalID == "" && ac.ClientIP == "" {
 		return nil
 	}
 	return ac
+}
+
+// applyIPMode gates a raw client IP per the deployment's capture mode:
+// "off" drops it, "full" keeps it raw, anything else (incl. empty)
+// minimizes to a /24 (IPv4) or /48 (IPv6) prefix.
+func applyIPMode(ip, mode string) string {
+	switch mode {
+	case "off":
+		return ""
+	case "full":
+		return ip
+	default:
+		return truncateIP(ip)
+	}
+}
+
+// truncateIP reduces an IP to its /24 (IPv4) or /48 (IPv6) network
+// prefix. Returns "" for an empty or unparseable address.
+func truncateIP(ip string) string {
+	parsed := net.ParseIP(ip)
+	if parsed == nil {
+		return ""
+	}
+	if v4 := parsed.To4(); v4 != nil {
+		return v4.Mask(net.CIDRMask(24, 32)).String() + "/24"
+	}
+	return parsed.Mask(net.CIDRMask(48, 128)).String() + "/48"
 }
 
 func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token TokenView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
@@ -246,8 +277,11 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		sourceApp = token.SourceApp
 	}
 
+	// Client IP, gated by the deployment's IP-capture mode.
+	clientIPVal := applyIPMode(clientIP(r), opts.IPCaptureMode)
+
 	// Self-asserted identity attribution (shared by both events).
-	agentCtx := buildAgentContext(headers, token)
+	agentCtx := buildAgentContext(headers, token, clientIPVal)
 
 	reqEvent := RequestEvent{
 		RequestEventID:  reqID,

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -261,6 +261,9 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		if ac.PrincipalID != "" {
 			respFields["principal_id"] = ac.PrincipalID
 		}
+		if ac.ClientIP != "" {
+			respFields["client_ip"] = ac.ClientIP
+		}
 		if ac.IdentitySource != "" {
 			respFields["identity_source"] = ac.IdentitySource
 		}

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -132,7 +132,8 @@ type AgentContext struct {
 	ConversationID string `json:"conversation_id,omitempty"` // TAS-Conversation-Id or baggage session.id
 	FlowID         string `json:"flow_id,omitempty"`         // TAS-Flow-Id or traceparent trace-id
 	PrincipalID    string `json:"principal_id,omitempty"`    // AIQG token source_app / token id
-	IdentitySource string `json:"identity_source,omitempty"` // baggage|asserted|trace|principal|unattributed
+	ClientIP       string `json:"client_ip,omitempty"`       // gated client IP (raw/truncated/off per ip_capture_mode)
+	IdentitySource string `json:"identity_source,omitempty"` // baggage|asserted|trace|principal|transport|unattributed
 }
 
 // ResponseEvent mirrors aether-shared/data-models/aiqg/response-event.md §2.2.

--- a/pkg/aiqg/events/ip_test.go
+++ b/pkg/aiqg/events/ip_test.go
@@ -1,0 +1,35 @@
+package events
+
+import "testing"
+
+func TestTruncateIP(t *testing.T) {
+	cases := map[string]string{
+		"192.168.68.74":        "192.168.68.0/24",
+		"10.0.0.5":             "10.0.0.0/24",
+		"203.0.113.42":         "203.0.113.0/24",
+		"":                     "",
+		"not-an-ip":            "",
+		"2001:db8:1:2:3:4:5:6": "2001:db8:1::/48",
+	}
+	for in, want := range cases {
+		if got := truncateIP(in); got != want {
+			t.Errorf("truncateIP(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestApplyIPMode(t *testing.T) {
+	const raw = "192.168.68.74"
+	if got := applyIPMode(raw, "off"); got != "" {
+		t.Errorf("off = %q, want empty", got)
+	}
+	if got := applyIPMode(raw, "full"); got != raw {
+		t.Errorf("full = %q, want raw", got)
+	}
+	if got := applyIPMode(raw, "minimized"); got != "192.168.68.0/24" {
+		t.Errorf("minimized = %q, want /24", got)
+	}
+	if got := applyIPMode(raw, ""); got != "192.168.68.0/24" {
+		t.Errorf("default (empty mode) = %q, want /24 minimized", got)
+	}
+}


### PR DESCRIPTION
Adds the transport tier of the identity ladder. `ip_capture_mode` config (off|minimized|full; default minimized) gates the client IP: minimized truncates to /24·/48 (privacy-safe default), full keeps raw, off drops it. Promoted to Loki as `client_ip`; adds a `transport` rung to identity_source (below principal). Existing `source_ip` unchanged (non-breaking). Build + full suite green. Deployed `aiqg-v5.24`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)