### PR TITLE
feat(demo-traffic): gateway target (real attributed traffic → TS rollups)

### DIFF
--- a/cmd/demo-traffic/README.md
+++ b/cmd/demo-traffic/README.md
@@ -1,10 +1,35 @@
 # demo-traffic — AIQG demo data generator
 
-Generates synthetic **AIQG response-event** log lines for a set of agent
-traffic types and pushes them to Loki so the AIQG dashboard's CLEAR,
-cost, latency, tag, and avoidable-cost panels light up with believable
-multi-agent traffic — and reports the **potential savings** AIQG would
-surface.
+Generates believable multi-agent AIQG traffic. **Two targets:**
+
+- **`--target=loki`** (default) — synthesizes **AIQG response-event** log
+  lines and pushes them straight to Loki so the dashboard's CLEAR, cost,
+  latency, tag, and avoidable-cost panels light up. Does **not** call any
+  vendor LLM; scores/costs come from the real `pkg/clear` scorer. Fast,
+  free, deterministic — but **Loki-only**: it never reaches Kafka, so the
+  TimescaleDB rollups behind `/metrics/agents` + `/flows` stay empty.
+- **`--target=gateway`** — sends **real** chat-completion requests through
+  the AIQG strict gateway (`llm-router-aiqg`) with the same per-agent
+  attribution headers (`TAS-Agent-*`, `TAS-Flow-Id`/`TAS-Conversation-Id`,
+  `baggage user.id`). The gateway emits genuine events down the full
+  **Kafka→Spark→TimescaleDB** path (and Loki), so the per-agent / per-flow
+  TS rollups populate with attributed traffic. Makes tiny real upstream
+  calls (small `--max-tokens`), so it costs a few cents.
+
+```bash
+# Loki target (default)
+go run ./cmd/demo-traffic                       # one pass
+go run ./cmd/demo-traffic --interval 30s        # loop
+
+# Gateway target — populates the TimescaleDB rollups
+export AIQG_TAS_AUTH_TOKEN=tas_qg_live_...       # aether-secrets/apps/tas-llm-router/aiqg-tokens.env
+go run ./cmd/demo-traffic --target=gateway \
+  --gateway-url https://gateway.aiqg.tas.scharber.com --insecure --flows-per-agent 2
+go run ./cmd/demo-traffic --target=gateway --dry-run   # preview requests, no token / no calls
+```
+
+The Loki-target details below also describe the agent personas and flow
+shapes the gateway target reuses.
 
 It does **not** call any vendor LLM. Per-step inputs are sampled from
 eight workflow profiles and scored by the **real** `pkg/clear` scorer

--- a/cmd/demo-traffic/gateway.go
+++ b/cmd/demo-traffic/gateway.go
@@ -1,0 +1,204 @@
+// Gateway target for the demo-traffic generator.
+//
+// Unlike the default Loki target (which synthesizes response-event log
+// lines and pushes them straight to Loki), the gateway target sends real
+// chat-completion requests through the AIQG strict gateway
+// (llm-router-aiqg). The gateway then emits genuine response events down
+// the full Kafka→Spark→TimescaleDB path (and Loki), so the per-agent /
+// per-flow TimescaleDB rollups behind /metrics/agents and /flows light up
+// with attributed traffic — which the Loki-synthesis path can't do (it
+// never touches Kafka).
+//
+// Attribution headers (TAS-Agent-*, TAS-Flow-Id / TAS-Conversation-Id,
+// baggage user.id) are derived from the same agent personas the synth
+// path uses, so the two targets tell the same demo story.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// gatewayClient posts chat completions to {URL}/v1/chat/completions.
+type gatewayClient struct {
+	URL       string
+	Token     string // TAS-Auth gateway token (tas_qg_live_...)
+	Model     string
+	MaxTokens int
+	HTTP      *http.Client
+}
+
+func newGatewayClient(url, token, model string, maxTokens int, insecure bool) *gatewayClient {
+	hc := &http.Client{Timeout: 60 * time.Second}
+	if insecure {
+		hc.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	}
+	return &gatewayClient{URL: strings.TrimRight(url, "/"), Token: token, Model: model, MaxTokens: maxTokens, HTTP: hc}
+}
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatRequest struct {
+	Model     string        `json:"model"`
+	Messages  []chatMessage `json:"messages"`
+	MaxTokens int           `json:"max_tokens"`
+}
+
+// send posts one chat completion with the given attribution headers and
+// returns the HTTP status code (0 on transport error). The response body
+// is drained and discarded — we only care that the gateway emitted an event.
+func (c *gatewayClient) send(ctx context.Context, headers map[string]string, prompt string) (int, error) {
+	body, err := json.Marshal(chatRequest{
+		Model:     c.Model,
+		Messages:  []chatMessage{{Role: "user", Content: prompt}},
+		MaxTokens: c.MaxTokens,
+	})
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.URL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("TAS-Auth", c.Token)
+	// Path A (strict) requires an Authorization header to be present; the
+	// gateway uses its own server-side upstream creds, so the dummy
+	// upstream key still yields a real (tiny) vendor call.
+	req.Header.Set("Authorization", "Bearer demo-traffic")
+	req.Header.Set("TAS-Upstream-Authorization", "Bearer demo-traffic")
+	for k, v := range headers {
+		if v != "" {
+			req.Header.Set(k, v)
+		}
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, nil
+}
+
+// prompts per CLEAR workflow type. Kept short (max-tokens is tiny) — the
+// point is attribution + workflow classification, not content.
+var workflowPrompts = map[string][]string{
+	"single_turn_qa":            {"What is the capital of France?", "Define idempotency in one line.", "What is a vector database?"},
+	"rag":                       {"Using the docs, what is TAS?", "Summarize the retrieved context.", "Cite a source for that claim."},
+	"agentic":                   {"Plan the steps to refactor this module.", "Decide which tool to call next.", "Orchestrate retrieval then summarize."},
+	"summarization":             {"Summarize: the quick brown fox jumps over the lazy dog.", "Give a one-line TL;DR of this paragraph."},
+	"code_generation":           {"Write a Go function to reverse a string.", "Fix this off-by-one loop.", "Generate a SQL query for the top 5 users."},
+	"classification_extraction": {"Classify the sentiment of 'I love this'.", "Extract the date from 'meet on 2026-06-13'.", "Label this ticket's intent."},
+}
+
+// compliancePrompts carry fake PII so the gateway's inbound scanners fire,
+// giving the Findings panel real flagged traffic.
+var compliancePrompts = []string{
+	"My email is jane@example.com and my SSN is 123-45-6789 — summarize my account.",
+	"Call me at 555-867-5309 about the overdue invoice for card 4111 1111 1111 1111.",
+}
+
+func pickPrompt(g rng, workflow string, complianceRate float64) string {
+	if g.chance(complianceRate) {
+		return compliancePrompts[g.r.Intn(len(compliancePrompts))]
+	}
+	ps := workflowPrompts[workflow]
+	if len(ps) == 0 {
+		ps = workflowPrompts["single_turn_qa"]
+	}
+	return ps[g.r.Intn(len(ps))]
+}
+
+func splitUsers(csv string) []string {
+	var out []string
+	for _, u := range strings.Split(csv, ",") {
+		if u = strings.TrimSpace(u); u != "" {
+			out = append(out, u)
+		}
+	}
+	if len(out) == 0 {
+		out = []string{"u_demo"}
+	}
+	return out
+}
+
+// runGatewayPass walks every persona's flows and sends one request per
+// step with attribution headers derived from the persona. Multi-turn
+// personas share a conversation_id; every flow shares a flow_id.
+func runGatewayPass(ctx context.Context, g rng, c *gatewayClient, users []string, flowsPerAgent int, complianceRate float64, dryRun bool) (sent, failed int) {
+	for _, persona := range personas {
+		agentID := agentIDFor(persona.Name)
+		for f := 0; f < flowsPerAgent; f++ {
+			user := users[g.r.Intn(len(users))]
+			headers := map[string]string{
+				"TAS-Agent-Id":      agentID,
+				"TAS-Agent-Name":    persona.Name,
+				"TAS-Agent-Version": persona.Version,
+				"TAS-Flow-Id":       g.uuid(),
+				"baggage":           "user.id=" + user,
+			}
+			if persona.TurnsHi > 1 {
+				headers["TAS-Conversation-Id"] = g.uuid()
+			}
+			for _, s := range persona.BuildFlow(g) {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				prompt := pickPrompt(g, profileByKey[s.Profile].Workflow, complianceRate)
+				if dryRun {
+					fmt.Printf("POST %s/v1/chat/completions  agent=%q user=%s flow=%s prompt=%q\n",
+						c.URL, persona.Name, user, headers["TAS-Flow-Id"], prompt)
+					sent++
+					continue
+				}
+				code, err := c.send(ctx, headers, prompt)
+				if err != nil || code < 200 || code >= 300 {
+					failed++
+				} else {
+					sent++
+				}
+			}
+		}
+	}
+	return sent, failed
+}
+
+// runGatewayTarget handles the gateway target end-to-end: single pass, or
+// loop on --interval.
+func runGatewayTarget(ctx context.Context, g rng, r rates, gc *gatewayClient, users []string, flowsPerAgent int, interval time.Duration, dryRun bool) {
+	fmt.Printf("demo-traffic: target=gateway url=%s model=%s agents=%d flows-per-agent=%d users=%v dry-run=%v\n",
+		gc.URL, gc.Model, len(personas), flowsPerAgent, users, dryRun)
+	pass := func() {
+		sent, failed := runGatewayPass(ctx, g, gc, users, flowsPerAgent, r.Compliance, dryRun)
+		fmt.Printf("gateway pass: sent=%d failed=%d\n", sent, failed)
+	}
+	pass()
+	if interval <= 0 {
+		return
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\nstopped.")
+			return
+		case <-ticker.C:
+			pass()
+		}
+	}
+}

--- a/cmd/demo-traffic/main.go
+++ b/cmd/demo-traffic/main.go
@@ -29,6 +29,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -56,6 +57,13 @@ func main() {
 		orgID      = flag.String("org-id", "", "optional X-Scope-OrgID header for multi-tenant Loki")
 		spreadSec  = flag.Int("spread", 90, "seconds to spread a pass's events over, ending at now")
 		insecure   = flag.Bool("insecure", true, "skip TLS verification (TAS Loki uses the internal tas-ca-issuer CA)")
+
+		target     = flag.String("target", "loki", "loki: synthesize response-event log lines + push to Loki | gateway: send real attributed chat requests through llm-router-aiqg (populates Kafka→Spark→TimescaleDB)")
+		gatewayURL = flag.String("gateway-url", "http://localhost:8086", "gateway base URL for --target=gateway (chat at /v1/chat/completions)")
+		token      = flag.String("token", os.Getenv("AIQG_TAS_AUTH_TOKEN"), "TAS-Auth gateway token for --target=gateway (or env AIQG_TAS_AUTH_TOKEN)")
+		model      = flag.String("model", "claude-haiku-4-5-20251001", "model for --target=gateway requests")
+		maxTokens  = flag.Int("max-tokens", 8, "max_tokens for --target=gateway requests (keep small — attribution, not content, is the point)")
+		usersCSV   = flag.String("users", "u_alice,u_bob,u_carol,u_dave", "baggage user.id pool sampled per flow (--target=gateway)")
 
 		complianceRate = flag.Float64("compliance-rate", 0.08, "fraction of events carrying a compliance (PII/cred/injection/safety) finding")
 		vagueRate      = flag.Float64("vague-rate", 0.12, "fraction of events carrying a vague-input finding")
@@ -86,6 +94,19 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	// Gateway target: send real attributed requests through llm-router-aiqg
+	// so the full Kafka→Spark→TimescaleDB attribution path populates (the
+	// Loki-synthesis path below never reaches Kafka).
+	if *target == "gateway" {
+		if strings.TrimSpace(*token) == "" && !*dryRun {
+			fmt.Fprintln(os.Stderr, "error: --target=gateway needs --token or AIQG_TAS_AUTH_TOKEN (set --dry-run to preview without a token)")
+			os.Exit(2)
+		}
+		gc := newGatewayClient(*gatewayURL, *token, *model, *maxTokens, *insecure)
+		runGatewayTarget(ctx, g, r, gc, splitUsers(*usersCSV), *flowsPer, *interval, *dryRun)
+		return
+	}
 
 	fmt.Printf("demo-traffic: tenant=%s account=%s agents=%d flows-per-agent=%d inferred-flows=%d seed=%d dry-run=%v\n",
 		*tenantID, *accountID, len(personas), *flowsPer, *inferredFl, s, *dryRun)


### PR DESCRIPTION
Adds `--target=gateway` to the demo-traffic generator so it can produce **real attributed traffic** that populates the C3 TimescaleDB rollups — not just Loki log lines.

**Why:** the default `--target=loki` synthesizes response-event lines straight to Loki. Great for the Loki-backed panels, but it never touches Kafka, so the per-agent / per-flow rollups behind `/metrics/agents` + `/flows` (served from TimescaleDB) stay empty. Gateway mode closes that gap.

**What it does:** for each of the existing agent personas, sends real `/v1/chat/completions` requests through `llm-router-aiqg` with attribution headers derived from the persona — `TAS-Agent-Id`/`Name`/`Version`, a per-flow `TAS-Flow-Id` (+ `TAS-Conversation-Id` for multi-turn personas), and `baggage user.id` sampled from `--users`. The gateway emits genuine events down Kafka→Spark→TimescaleDB (and Loki), so the rollups populate with real agents/flows. A couple of PII prompts (`--compliance-rate`) exercise the Findings panel.

**Flags:** `--target=loki|gateway`, `--gateway-url`, `--token` (or `AIQG_TAS_AUTH_TOKEN`), `--model`, `--max-tokens`, `--users`. Honors `--dry-run` (preview, no token/calls) and `--interval` (loop).

**Verified:** `go build`/`vet` clean, dry-run output correct, and a real 15-request pass through the gateway ingress (`sent=15 failed=0`) — confirmed the events land in `event_metrics` with identity columns and the rollup queries return the agents/flows.

Reuses `personas` / `BuildFlow` / `agentIDFor` from the existing synth path; no change to the loki target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)