### PR TITLE
fix(aiqg): denormalize workflow onto the ResponseEvent

### DIFF
--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -376,10 +376,11 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	respEvent := ResponseEvent{
 		ResponseEventID:      respID,
 		RequestEventID:       reqID,
-		TenantID:             token.TenantID,      // denormalized per response-event.md §"Denormalization rationale"
-		AIQGAccountID:        token.AIQGAccountID, // ditto
-		Vendor:               routing.Vendor,      // denormalized from routing decision (same as RequestEvent)
-		Model:                routing.Model,       // ditto — powers per-vendor/model dashboards off the response stream
+		TenantID:             token.TenantID,                                        // denormalized per response-event.md §"Denormalization rationale"
+		AIQGAccountID:        token.AIQGAccountID,                                   // ditto
+		Vendor:               routing.Vendor,                                        // denormalized from routing decision (same as RequestEvent)
+		Model:                routing.Model,                                         // ditto — powers per-vendor/model dashboards off the response stream
+		Workflow:             preferredWorkflow(headers.Workflow, routing.Workflow), // ditto — carries the workflow_type dimension on the response stream
 		CompleteAt:           completeAt,
 		Status:               status,
 		HTTPStatus:           opts.HTTPStatus,

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -149,8 +149,9 @@ type ResponseEvent struct {
 	// per-model cost/token dashboards read these directly off the
 	// response stream, and they survive a lost request event (see
 	// response-event.md KI-2). Same values as the paired RequestEvent.
-	Vendor string `json:"vendor,omitempty"`
-	Model  string `json:"model,omitempty"`
+	Vendor   string `json:"vendor,omitempty"`
+	Model    string `json:"model,omitempty"`
+	Workflow string `json:"workflow,omitempty"` // CLEAR workflow_type — denormalized so the response stream carries the type dimension for per-type rollups (TimescaleDB)
 
 	// Outcome
 	CompleteAt      time.Time `json:"complete_at"`


### PR DESCRIPTION
`vendor`/`model` were already copied from the routing decision onto the **response** event, but `workflow_type` wasn't — it lived only on the RequestEvent. Since the Kafka→Spark→TimescaleDB path consumes the response event, `event_metrics.workflow` came out NULL for all gateway traffic, blanking the type dimension (Explorer Hierarchy "by type", the Type column, per-workflow rollups).

Adds `ResponseEvent.Workflow`, populated with the same `preferredWorkflow(header, classified)` the RequestEvent uses. The Spark schema already has the field and the `event_metrics.workflow` column exists, so **no aggregator/migration change** — the value now flows through.

**Verified end-to-end** on `aiqg-v5.25` (both gateways): a fresh attributed pass produced 27/27 TS rows with `workflow` populated (was 0/66), breakdown `classification_extraction`/`summarization`/`single_turn_qa`/`code_generation`.

`gofmt`/`build`/`vet`/`test -tags nohs` green on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)