### PR TITLE
docs(aiqg): add investor + patent positioning analyses

### DIFF
--- a/docs/AIQG-INVESTOR-ANALYSIS.md
+++ b/docs/AIQG-INVESTOR-ANALYSIS.md
@@ -1,0 +1,94 @@
+# AIQG — Investor Positioning Analysis
+
+**Status:** Working analysis — 2026-06-12.
+**Inputs:** [`AIQG-EXTENSION.md`](./AIQG-EXTENSION.md),
+[`AIQG-AGENT-FLOW-ATTRIBUTION.md`](./AIQG-AGENT-FLOW-ATTRIBUTION.md),
+[`AIQG-AGENT-IDENTITY-RESEARCH.md`](./AIQG-AGENT-IDENTITY-RESEARCH.md),
+[`AIQG-EXPERIMENTS-RUNNER.md`](./AIQG-EXPERIMENTS-RUNNER.md).
+**Companion:** [`AIQG-PATENT-ANALYSIS.md`](./AIQG-PATENT-ANALYSIS.md)
+
+## Summary
+
+The pitch is not any one feature — it's that the four pieces (extension /
+attribution / identity / experiments) close a loop nobody else closes:
+**attribute → score → experiment → optimize, all at the gateway, with zero
+client code changes.**
+
+## The wedge: agentless attribution in an instrumented market
+
+The LLM gateway/observability category is crowded (Helicone, Langfuse,
+LangSmith, Portkey, Kong/Cloudflare AI gateways) — but every competitor shares
+one assumption AIQG breaks: **the customer must instrument their code**
+(headers, SDKs, trace context). The prior-art research confirms this is
+universal ("today's attribution is self-asserted everywhere").
+
+AIQG's inferred tier means a customer points DNS at the gateway and gets
+per-agent cost/quality attribution on day one with zero code changes. This is
+the agentless-vs-agent-based monitoring story replayed for AI — and
+historically the agentless entrant wins the land-grab because it removes the
+adoption tax.
+
+## Three investor-legible storylines
+
+### 1. FinOps for AI agents
+
+Per-agent and per-flow cost rollup, plus the avoidable-cost decomposition
+(direct / induced / genuine waste) from the CLEAR extension. *"Which of our 40
+agents is burning the budget, and how much of that spend is avoidable"* is a
+CFO question nobody can currently answer without an instrumentation project.
+
+The agent registry ("14 distinct agents detected, 11 unnamed") doubles as
+**shadow-AI discovery**, which sells to the CISO in the same meeting — and the
+asserted-vs-inferred impersonation cross-check gives security a reason to keep
+the product after the cost story lands it.
+
+### 2. The closed loop (measurement → action)
+
+Competitors stop at dashboards. The Experiments Runner makes the measurement
+actionable: detect that a workflow is over-provisioned on gpt-4o → run a
+guardrailed, sticky, non-inferiority A/B against 4o-mini → quantified verdict.
+That's Statsig/LaunchDarkly-for-LLM-routing, executed at the gateway so it
+again needs no app changes.
+
+The **Gatekeeper-impact experiment** is a unique proof-point: we can *show
+customers data* that the security layer doesn't degrade answer quality — a
+claim every competing AI firewall asserts and none can demonstrate.
+
+### 3. Positioned for the authenticated-agent-identity wave
+
+The schema ships self-asserted (matching the whole market) but reserves
+`agent_identity_verified` + credential refs so AIP/IBCT, Google A2A, or
+token-bound identity slots in without migration. Agent identity is an emerging
+2026 standards fight; being the gateway that already records graded identity
+confidence is a cheap option on that future. OTel `gen_ai.*` alignment also
+de-risks the "proprietary schema lock-in" objection.
+
+## Moat shape
+
+- **Data network effect**: the fingerprint registry compounds — every labeled
+  cluster and every framework signature (CrewAI / LangChain / AutoGen idioms)
+  improves inference for all tenants; competitors can't shortcut it.
+- **Deterministic floor**: the token-echo and prefix-chain tiers are
+  proof-not-probability, so the headline capability holds even if fingerprint
+  clustering underperforms.
+- **IP option**: a provisional on the inference tier (see
+  `AIQG-PATENT-ANALYSIS.md`) turns the wedge into a defensibility story beyond
+  "we built a nice proxy."
+
+## Risks an investor will probe (be ready)
+
+| Risk | Honest counter |
+|---|---|
+| FTO overhang on metering/billing (4 located USPTO patents, claims unread) | Scoped: gates billing use only, not observability; FTO pass is planned and cheap relative to the raise |
+| Inference precision/recall unproven | The validation harness with known ground truth (`cmd/demo-traffic --untagged`) is already built; deterministic tiers set a high floor |
+| OTel GenAI conventions are experimental | Names pinned; additive schema means renames are migrations, not breakage |
+| Hyperscalers bundle basic gateway attribution | They'll ship header-based (self-asserted) attribution; the inferred tier + registry is the differentiated layer |
+| Crowded category | The wedge is adoption cost, not feature count — zero-code-change attribution is structurally hard for SDK-first incumbents to retrofit |
+
+## Concrete next steps
+
+1. **Run the untagged validation** and publish precision/recall per inference
+   tier internally — the single best artifact for the pitch deck.
+2. **FTO claim-read** before diligence surfaces it for us.
+3. Keep the inferred-attribution design non-public until the
+   provisional-vs-defensive-publication decision is made.

--- a/docs/AIQG-PATENT-ANALYSIS.md
+++ b/docs/AIQG-PATENT-ANALYSIS.md
@@ -1,0 +1,108 @@
+# AIQG — Patent Position Analysis
+
+**Status:** Working analysis — 2026-06-12. Technical/strategic assessment, **not
+legal advice**; patentability and FTO calls require a patent attorney.
+**Inputs:** [`AIQG-EXTENSION.md`](./AIQG-EXTENSION.md),
+[`AIQG-AGENT-FLOW-ATTRIBUTION.md`](./AIQG-AGENT-FLOW-ATTRIBUTION.md),
+[`AIQG-AGENT-IDENTITY-RESEARCH.md`](./AIQG-AGENT-IDENTITY-RESEARCH.md),
+[`AIQG-EXPERIMENTS-RUNNER.md`](./AIQG-EXPERIMENTS-RUNNER.md).
+**Companion:** [`AIQG-INVESTOR-ANALYSIS.md`](./AIQG-INVESTOR-ANALYSIS.md)
+
+## Summary
+
+The genuinely novel asset is the **zero-cooperation inferred attribution
+layer** — the gateway recognizing its own served output echoing back in later
+requests to reconstruct agent flows deterministically, plus the
+fingerprint-ensemble agent registry built on top of it. The prior-art research
+(21 verified claims, 22 sources; see `AIQG-AGENT-IDENTITY-RESEARCH.md`) found
+nobody doing this. The CLEAR scoring, header taxonomy, and experiments work is
+well-executed but has visible neighbors in the market.
+
+## Patent candidates, in order of strength
+
+### 1. Content-propagation graph (attribution doc §A.3) — file on this
+
+Rabin-fingerprint chunking of served responses into a TTL'd index, then
+matching incoming request content against it to build data-flow edges between
+flows — catching planner→worker handoffs across *different processes, models,
+and toolsets* where no header scheme can propagate anything.
+
+- The WAN-dedupe analogy (Bluecoat/Riverbed byte caching) is prior art in a
+  different field; applying it to *agent attribution in an LLM gateway*, with
+  IDF suppression of boilerplate, is a new use.
+- The non-obvious insight: the stateless chat-completions protocol
+  **guarantees** the echo rather than making it statistically likely.
+- Absent from all surveyed prior art (OTel GenAI, LangSmith, Langfuse,
+  Helicone, AIP/A2A).
+
+### 2. Deterministic flow linkage via vendor-minted token echo (§A.1)
+
+Indexing every served `tool_call_id` and treating its reappearance as proof of
+flow parentage — "the client cannot fake having received `call_abc123` from
+us" — yields full ReAct-loop reconstruction with zero cooperation. Simple once
+stated (cuts both ways for obviousness), but no surveyed tool does it.
+
+### 3. The graded identity ladder as a system claim
+
+Not the individual tiers (self-asserted headers are Helicone; principal/IP are
+routine) but the **combination**:
+
+- 8-tier resolution ladder stamping `identity_source` + `identity_confidence`
+  per event;
+- the split-trust rule — asserted wins for *who*, linked wins for *shape*;
+- **asserted-vs-inferred mismatch as an agent-impersonation signal** (§E).
+  The inference tier auditing the cooperative tier is a genuinely novel
+  security mechanism — nobody else can detect a client lying about which agent
+  it is.
+
+### 4. Fingerprint ensemble + version lineage + registry (§B–D)
+
+The 13-signal catalog individually borrows known techniques (Drain template
+mining, MinHash, process mining), but the composition has no surveyed
+precedent:
+
+- ensemble clustering scoped per `(tenant, principal)`;
+- version lineage (MinHash Jaccard) so identity survives prompt iteration —
+  the failure mode of naive prompt-hashing;
+- semi-supervised calibration where cooperatively tagged traffic teaches the
+  inferrer;
+- humans label *clusters*, not flows ("14 agents detected, 3 named").
+
+### 5. Identity-ladder-keyed sticky experimentation
+
+Gateway-native A/B on live LLM traffic where assignment stickiness rides the
+*inferred* identity ladder (so even un-instrumented callers get coherent
+splits), with claim-on-match mutual exclusion and non-inferiority verdicts.
+A/B testing is ancient; doing it at an LLM gateway keyed on inferred identity
+— including the Gatekeeper-impact design (shadow-eval pairwise to prove the
+security layer's rewrites don't degrade answers) — is a differentiated
+combination.
+
+## What weakens or gates the position
+
+- **FTO is unresolved and already flagged**: US 12,483,411 / 12,547,677 /
+  10,924,326 / 11,785,115 were located but never claim-read
+  (`AIQG-AGENT-IDENTITY-RESEARCH.md` coverage gaps). Both design docs
+  correctly gate billing-grade metering on this. Do the FTO claim-read before
+  fundraising diligence surfaces it.
+- **Prefix chaining (§A.2) is the weakest claim** — the attribution doc itself
+  cites Anthropic/OpenAI prompt caching and vLLM prefix caching as prior art
+  that prefix identity ≡ conversation identity. The *application* to
+  attribution is new; the core mechanism isn't.
+- **Timing.** Identity plumbing shipped 2026-06-11 (`aiqg-v5.24`); the
+  inferred-attribution section is design-only. If the docs and shipped
+  behavior stay non-public, no statutory bar has started — but a provisional
+  on the inference cluster (candidates 1–4) is cheap and starts priority
+  before anyone publishes the same idea.
+
+## Recommended next steps
+
+1. **Provisional filing** on the inference cluster (candidates 1–4) before any
+   public disclosure. Lean provisional over defensive publication for the
+   moat-bearing pieces; defensive publication only for what we decide not to
+   claim.
+2. **FTO claim-read** on the four located USPTO patents and neighbors —
+   required before billing use of per-agent metering, and before diligence.
+3. **Run the untagged validation** (`cmd/demo-traffic --untagged`) to get
+   precision/recall per inference tier — the single best artifact for both a
+   patent filing (reduction to practice) and investor diligence.


### PR DESCRIPTION
Adds two working strategic analysis docs (2026-06-12) that reference the existing AIQG design docs:
- `AIQG-INVESTOR-ANALYSIS.md` — investor positioning
- `AIQG-PATENT-ANALYSIS.md` — patentability / FTO assessment (not legal advice)

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)