### PR TITLE
feat(aiqg): denormalize source_app + emit TAS-Response-Event-Id header

### DIFF
--- a/cmd/demo-traffic/gateway.go
+++ b/cmd/demo-traffic/gateway.go
@@ -143,6 +143,10 @@ func assurancePrompt() string {
 		strings.Join(docs, "\n\n")
 }
 
+// demoSourceApps populates the source_app dimension (TAS-Source-App header)
+// with believable calling-app names, sampled per flow.
+var demoSourceApps = []string{"checkout-svc", "search-svc", "support-portal", "batch-worker", "mobile-app"}
+
 func splitUsers(csv string) []string {
 	var out []string
 	for _, u := range strings.Split(csv, ",") {
@@ -170,6 +174,7 @@ func runGatewayPass(ctx context.Context, g rng, c *gatewayClient, users []string
 				"TAS-Agent-Name":    persona.Name,
 				"TAS-Agent-Version": persona.Version,
 				"TAS-Flow-Id":       g.uuid(),
+				"TAS-Source-App":    demoSourceApps[g.r.Intn(len(demoSourceApps))],
 				"baggage":           "user.id=" + user,
 			}
 			if persona.TurnsHi > 1 {

--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -214,6 +214,13 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 
 	sw := &statusCapturingResponseWriter{ResponseWriter: w}
 
+	// Pre-generate the response event id so we can advertise it as a
+	// response header BEFORE the downstream handler flushes the body
+	// (works for streaming too). Clients and the /feedback endpoint
+	// correlate feedback against this exact id. Build reuses it.
+	respEventID := events.NewEventID()
+	w.Header().Set("TAS-Response-Event-Id", respEventID)
+
 	emitter := cfg.Emitter
 	if emitter == nil {
 		emitter = events.NoopEmitter{}
@@ -225,9 +232,10 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// stamps made by the handler reach the event.
 	defer func() {
 		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
-			HTTPStatus:    sw.status(),
-			Region:        cfg.Region,
-			IPCaptureMode: cfg.IPCaptureMode,
+			HTTPStatus:      sw.status(),
+			Region:          cfg.Region,
+			IPCaptureMode:   cfg.IPCaptureMode,
+			ResponseEventID: respEventID,
 			ResolvedPolicyBundle: &events.ResolvedPolicyBundle{
 				BundleID:   bundleResolution.BundleID,
 				BundleName: bundleResolution.BundleName,

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -132,6 +132,12 @@ type BuildOptions struct {
 	IPCaptureMode string // off | minimized (default) | full — gates client IP
 	FinishReason  string
 
+	// ResponseEventID, when set, is used as the response event's id
+	// instead of minting a fresh one. The Path A middleware pre-generates
+	// it so it can set the TAS-Response-Event-Id response header before the
+	// body flushes (clients/feedback correlate against it). Empty = mint.
+	ResponseEventID string
+
 	// ResolvedPolicyBundle is the bundle aiqg-dashboard-be picked for
 	// this request (Phase 4.0). Always set in production — the
 	// middleware degrades to a Default() resolution when the resolver
@@ -247,7 +253,10 @@ func truncateIP(ip string) string {
 
 func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token TokenView, snap instrumentation.Snapshot, opts BuildOptions) (RequestEnvelope, ResponseEnvelope) {
 	reqID := newUUID()
-	respID := newUUID()
+	respID := opts.ResponseEventID
+	if respID == "" {
+		respID = newUUID()
+	}
 	now := time.Now().UTC()
 
 	receivedAt := now
@@ -381,6 +390,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		Vendor:               routing.Vendor,                                        // denormalized from routing decision (same as RequestEvent)
 		Model:                routing.Model,                                         // ditto — powers per-vendor/model dashboards off the response stream
 		Workflow:             preferredWorkflow(headers.Workflow, routing.Workflow), // ditto — carries the workflow_type dimension on the response stream
+		SourceApp:            sourceApp,                                             // ditto — carries the source_app dimension on the response stream
 		CompleteAt:           completeAt,
 		Status:               status,
 		HTTPStatus:           opts.HTTPStatus,
@@ -423,6 +433,11 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 // newUUID returns a v4-shaped 128-bit random ID, formatted as the
 // canonical 8-4-4-4-12 hex string. We don't pull in a UUID dep because
 // the format is mechanical and we don't need RFC-strict version bits.
+// NewEventID mints a fresh event id. Exported so the Path A middleware can
+// pre-generate a response_event_id (to set the TAS-Response-Event-Id header
+// before the body flushes) and pass it back via BuildOptions.ResponseEventID.
+func NewEventID() string { return newUUID() }
+
 func newUUID() string {
 	var b [16]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -149,9 +149,10 @@ type ResponseEvent struct {
 	// per-model cost/token dashboards read these directly off the
 	// response stream, and they survive a lost request event (see
 	// response-event.md KI-2). Same values as the paired RequestEvent.
-	Vendor   string `json:"vendor,omitempty"`
-	Model    string `json:"model,omitempty"`
-	Workflow string `json:"workflow,omitempty"` // CLEAR workflow_type — denormalized so the response stream carries the type dimension for per-type rollups (TimescaleDB)
+	Vendor    string `json:"vendor,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Workflow  string `json:"workflow,omitempty"`   // CLEAR workflow_type — denormalized so the response stream carries the type dimension for per-type rollups (TimescaleDB)
+	SourceApp string `json:"source_app,omitempty"` // calling app — denormalized like vendor/model/workflow so the response stream carries the source dimension
 
 	// Outcome
 	CompleteAt      time.Time `json:"complete_at"`


### PR DESCRIPTION
Two loose ends, gateway-side:
- **source_app** denormalized onto the ResponseEvent (like vendor/model/workflow) → flows Kafka→Spark→TS; `/events` and `/metrics/agents?by=source_app` now serve from TimescaleDB.
- **TAS-Response-Event-Id** response header — middleware pre-generates the response event id and sets it before the body flushes (streaming-safe) so apps/`/feedback` correlate exactly. Build reuses it via `BuildOptions.ResponseEventID`.
- demo-traffic gateway mode sends `TAS-Source-App` from an app pool for source_app variety.

Verified live on `aiqg-v5.26`: header present; source_app flows to TS. Tests `-tags nohs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)