### PR TITLE
feat(aiqg): linked-tier topology in the event builder (C2a)

### DIFF
--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -145,6 +145,10 @@ type BuildOptions struct {
 	// holds. Nil pointer → field omitted from the response event
 	// (covers pre-Phase-4.0 callers + non-AIQG middleware).
 	ResolvedPolicyBundle *ResolvedPolicyBundle
+
+	// Linkage is the resolved `linked`-tier flow/step topology for this
+	// request (the middleware resolves it via pkg/aiqg/linkage before Build).
+	Linkage Linkage
 }
 
 // Build constructs the paired (RequestEnvelope, ResponseEnvelope) from
@@ -178,23 +182,43 @@ type BuildOptions struct {
 // AIQG token supplies the always-present principal tier. identity_source
 // records the strongest tier that produced an identity. Returns nil only
 // when nothing at all resolved (no token, no headers).
-func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string) *AgentContext {
+// Linkage is the deterministic `linked`-tier result the middleware resolves
+// (via pkg/aiqg/linkage) before Build: this request's step id and, when it
+// echoed a tool_call_id we served, the parent step + flow it belongs to.
+// "asserted wins for WHO, linked wins for SHAPE" — StepID/ParentStepID are
+// always applied; LinkedFlowID only fills FlowID when no header/trace flow
+// was asserted.
+type Linkage struct {
+	StepID       string
+	ParentStepID string
+	LinkedFlowID string
+	FlowStepSeq  int
+}
+
+func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linkage) *AgentContext {
 	ac := &AgentContext{
 		AgentID:      h.AgentID,
 		AgentName:    h.AgentName,
 		AgentVersion: h.AgentVersion,
 		UserID:       h.BaggageUserID,
 		ClientIP:     clientIP,
+		StepID:       lk.StepID,
+		ParentStepID: lk.ParentStepID,
+		FlowStepSeq:  lk.FlowStepSeq,
 	}
 	// conversation: explicit header wins, else baggage session.id
 	ac.ConversationID = h.ConversationID
 	if ac.ConversationID == "" {
 		ac.ConversationID = h.BaggageSessionID
 	}
-	// flow: explicit header wins, else traceparent trace-id
+	// flow: explicit header wins, else traceparent trace-id, else the
+	// linked flow proven by a tool_call_id echo (shape, not naming).
 	ac.FlowID = h.FlowID
 	if ac.FlowID == "" {
 		ac.FlowID = h.TraceID
+	}
+	if ac.FlowID == "" {
+		ac.FlowID = lk.LinkedFlowID
 	}
 	// principal: token source_app, else token id (always present in AIQG mode)
 	ac.PrincipalID = t.SourceApp
@@ -209,6 +233,8 @@ func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string) *AgentCo
 		ac.IdentitySource = "asserted"
 	case h.TraceID != "":
 		ac.IdentitySource = "trace"
+	case lk.LinkedFlowID != "" || lk.ParentStepID != "":
+		ac.IdentitySource = "linked"
 	case ac.PrincipalID != "":
 		ac.IdentitySource = "principal"
 	case ac.ClientIP != "":
@@ -218,7 +244,8 @@ func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string) *AgentCo
 	}
 
 	if ac.AgentID == "" && ac.AgentName == "" && ac.UserID == "" &&
-		ac.ConversationID == "" && ac.FlowID == "" && ac.PrincipalID == "" && ac.ClientIP == "" {
+		ac.ConversationID == "" && ac.FlowID == "" && ac.PrincipalID == "" && ac.ClientIP == "" &&
+		ac.StepID == "" && ac.ParentStepID == "" {
 		return nil
 	}
 	return ac
@@ -290,7 +317,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 	clientIPVal := applyIPMode(clientIP(r), opts.IPCaptureMode)
 
 	// Self-asserted identity attribution (shared by both events).
-	agentCtx := buildAgentContext(headers, token, clientIPVal)
+	agentCtx := buildAgentContext(headers, token, clientIPVal, opts.Linkage)
 
 	reqEvent := RequestEvent{
 		RequestEventID:  reqID,

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -267,6 +267,15 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		if ac.IdentitySource != "" {
 			respFields["identity_source"] = ac.IdentitySource
 		}
+		if ac.StepID != "" {
+			respFields["step_id"] = ac.StepID
+		}
+		if ac.ParentStepID != "" {
+			respFields["parent_step_id"] = ac.ParentStepID
+		}
+		if ac.FlowStepSeq > 0 {
+			respFields["flow_step_seq"] = ac.FlowStepSeq
+		}
 	}
 	e.Logger.WithFields(respFields).Info("aiqg response event")
 	return nil

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -133,7 +133,16 @@ type AgentContext struct {
 	FlowID         string `json:"flow_id,omitempty"`         // TAS-Flow-Id or traceparent trace-id
 	PrincipalID    string `json:"principal_id,omitempty"`    // AIQG token source_app / token id
 	ClientIP       string `json:"client_ip,omitempty"`       // gated client IP (raw/truncated/off per ip_capture_mode)
-	IdentitySource string `json:"identity_source,omitempty"` // baggage|asserted|trace|principal|transport|unattributed
+	IdentitySource string `json:"identity_source,omitempty"` // baggage|asserted|trace|linked|principal|transport|unattributed
+
+	// Flow-step topology (the `linked` tier, docs/AIQG-AGENT-FLOW-ATTRIBUTION.md
+	// §A). StepID is this event's step (= response_event_id). ParentStepID and
+	// the linked FlowID are set when this request echoed a tool_call_id we
+	// served — proving it's the next step of that flow. FlowStepSeq is the
+	// 1-based order within the flow (0 = unknown).
+	StepID       string `json:"step_id,omitempty"`
+	ParentStepID string `json:"parent_step_id,omitempty"`
+	FlowStepSeq  int    `json:"flow_step_seq,omitempty"`
 }
 
 // ResponseEvent mirrors aether-shared/data-models/aiqg/response-event.md §2.2.

--- a/pkg/aiqg/events/linked_test.go
+++ b/pkg/aiqg/events/linked_test.go
@@ -1,0 +1,57 @@
+package events
+
+import "testing"
+
+// The `linked` tier: a tool_call_id echo proves flow/step topology even when
+// the caller sent no TAS-Flow-Id. "asserted wins for WHO, linked wins for
+// SHAPE" — step/parent are always applied; LinkedFlowID only fills an
+// otherwise-empty FlowID, and `linked` ranks below asserted/baggage/trace.
+func TestBuildAgentContext_Linked(t *testing.T) {
+	tok := TokenView{TASAuthTokenID: "tok-1"} // principal always present in AIQG mode
+
+	t.Run("untagged request linked by tool_call echo", func(t *testing.T) {
+		lk := Linkage{StepID: "resp-2", ParentStepID: "resp-1", LinkedFlowID: "flow-X"}
+		ac := buildAgentContext(AIQGHeadersView{}, tok, "", lk)
+		if ac == nil {
+			t.Fatal("nil agent context")
+		}
+		if ac.IdentitySource != "linked" {
+			t.Errorf("identity_source = %q, want linked", ac.IdentitySource)
+		}
+		if ac.FlowID != "flow-X" || ac.ParentStepID != "resp-1" || ac.StepID != "resp-2" {
+			t.Errorf("linkage not applied: %+v", ac)
+		}
+	})
+
+	t.Run("asserted agent keeps WHO, linkage supplies SHAPE", func(t *testing.T) {
+		// Agent named via header (asserted) but no TAS-Flow-Id; linkage fills the flow.
+		h := AIQGHeadersView{AgentID: "agent-7"}
+		lk := Linkage{StepID: "resp-9", ParentStepID: "resp-8", LinkedFlowID: "flow-Y"}
+		ac := buildAgentContext(h, tok, "", lk)
+		if ac.IdentitySource != "asserted" {
+			t.Errorf("identity_source = %q, want asserted (agent named wins WHO)", ac.IdentitySource)
+		}
+		if ac.FlowID != "flow-Y" || ac.ParentStepID != "resp-8" {
+			t.Errorf("linked shape not applied under asserted: %+v", ac)
+		}
+	})
+
+	t.Run("explicit TAS-Flow-Id wins over linked flow", func(t *testing.T) {
+		h := AIQGHeadersView{FlowID: "header-flow"}
+		lk := Linkage{StepID: "resp-3", LinkedFlowID: "flow-Z"}
+		ac := buildAgentContext(h, tok, "", lk)
+		if ac.FlowID != "header-flow" {
+			t.Errorf("FlowID = %q, want the asserted header flow", ac.FlowID)
+		}
+	})
+
+	t.Run("step id alone keeps principal tier", func(t *testing.T) {
+		ac := buildAgentContext(AIQGHeadersView{}, tok, "", Linkage{StepID: "resp-5"})
+		if ac.IdentitySource != "principal" {
+			t.Errorf("identity_source = %q, want principal (no link, token present)", ac.IdentitySource)
+		}
+		if ac.StepID != "resp-5" {
+			t.Errorf("step id not stamped: %+v", ac)
+		}
+	})
+}


### PR DESCRIPTION
C2a increment 2. Plumbs `linked` flow/step topology into the event builder + emitter (resolution I/O lands next in the middleware):
- `AgentContext` gains StepID/ParentStepID/FlowStepSeq; `BuildOptions.Linkage` carries the resolved link.
- `buildAgentContext`: step/parent always applied (shape); LinkedFlowID fills an empty FlowID; `identity_source` gains a `linked` rung (below asserted/baggage/trace) — *asserted wins WHO, linked wins SHAPE*.
- emitter promotes step_id/parent_step_id/flow_step_seq.

Inert until the middleware populates `BuildOptions.Linkage`. Unit-tested. `-tags nohs` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)