### PR TITLE
feat(aiqg): wire the linked tier into the request path (C2a)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,6 +70,12 @@ type AIQGConfig struct {
 	//   AIQG_DASHBOARD_INTERNAL_AUTH_TOKEN
 	DashboardURL               string `yaml:"dashboard_url"`
 	DashboardInternalAuthToken string `yaml:"dashboard_internal_auth_token"`
+
+	// LinkageRedisURL enables the deterministic `linked`-tier attribution
+	// (docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §A): a Redis (redis://…) URL for
+	// the tool_call_id echo index. Empty = linkage disabled (events emit
+	// without step/parent topology). Env: AIQG_LINKAGE_REDIS_URL.
+	LinkageRedisURL string `yaml:"linkage_redis_url"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Defined here (not in
@@ -451,6 +457,9 @@ func (c *Config) loadFromEnv() {
 	if topic := os.Getenv("AIQG_KAFKA_TOPIC"); topic != "" {
 		c.AIQG.Kafka.Topic = topic
 	}
+	if u := os.Getenv("AIQG_LINKAGE_REDIS_URL"); u != "" {
+		c.AIQG.LinkageRedisURL = u
+	}
 	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
 		c.AIQG.DashboardURL = u
 	}
@@ -635,6 +644,7 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 		EmitterType:                c.AIQG.EmitterType,
 		DashboardURL:               c.AIQG.DashboardURL,
 		DashboardInternalAuthToken: c.AIQG.DashboardInternalAuthToken,
+		LinkageRedisURL:            c.AIQG.LinkageRedisURL,
 		Kafka: server.AIQGKafkaConfig{
 			Brokers: c.AIQG.Kafka.Brokers,
 			Topic:   c.AIQG.Kafka.Topic,

--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -31,13 +31,16 @@
 package middleware
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/linkage"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
@@ -84,6 +87,11 @@ type AIQGConfig struct {
 	// the middleware falls back to policy.Default() so the event
 	// always has a resolution (the "every request resolves" gate).
 	PolicyResolver policy.Resolver
+
+	// Linkage is the deterministic `linked`-tier store (tool_call_id echo
+	// index, docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §A). Nil disables linkage —
+	// events emit without step/parent topology, same as pre-C2a behavior.
+	Linkage linkage.Store
 }
 
 // NewAIQG returns the middleware constructor. The returned handler is a
@@ -231,11 +239,18 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// routing sidecar is read at the same moment, so any vendor/model
 	// stamps made by the handler reach the event.
 	defer func() {
+		// Linked tier: resolve the flow/step this request continues (it
+		// echoed a tool_call_id we served) and index the ids this response
+		// served (so the next step links back here). Uses a fresh context —
+		// the request context may already be cancelled in this deferred path.
+		lk := resolveLinkage(cfg, parsed, routing, resolvedToken, respEventID)
+
 		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
 			HTTPStatus:      sw.status(),
 			Region:          cfg.Region,
 			IPCaptureMode:   cfg.IPCaptureMode,
 			ResponseEventID: respEventID,
+			Linkage:         lk,
 			ResolvedPolicyBundle: &events.ResolvedPolicyBundle{
 				BundleID:   bundleResolution.BundleID,
 				BundleName: bundleResolution.BundleName,
@@ -249,6 +264,63 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	defer instrumentation.StampComplete(ctx)
 
 	next.ServeHTTP(sw, r.WithContext(ctx))
+}
+
+// resolveLinkage runs the deterministic `linked`-tier resolution + indexing
+// (docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §A) for one request/response:
+//   - resolve the tool_call_ids this request echoed → the (flow, step) we
+//     served them from = the parent step + the flow this request continues;
+//   - index the tool_call_ids this response served under the effective flow
+//     so the NEXT request echoing them links back to this step.
+//
+// Uses a fresh context — the request context may already be cancelled in the
+// deferred path this runs from. Best-effort: any store error is logged and
+// degrades to no linkage rather than failing the (already-served) request.
+func resolveLinkage(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *tokens.Token, respEventID string) events.Linkage {
+	lk := events.Linkage{StepID: respEventID}
+	if cfg.Linkage == nil || tok == nil || routing == nil {
+		return lk
+	}
+	hv := headersView(parsed)
+	rs := routing.Snapshot()
+	tenantID := tok.TenantID
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	// Resolve: did this request echo a tool_call we served? (evidence)
+	if link, ok, err := cfg.Linkage.ResolveToolCalls(ctx, tenantID, rs.EchoedToolCallIDs); err != nil {
+		cfg.Logger.WithError(err).Warn("aiqg linkage resolve failed")
+	} else if ok {
+		lk.ParentStepID = link.StepID
+		lk.FlowID = link.FlowID
+		lk.Linked = true
+	}
+
+	// Root anchor: an untagged request that SERVES tool_calls starts a flow;
+	// anchor it on this step id so children group under it. Not "linked" —
+	// there's no echo evidence yet, only an outgoing tool call.
+	if lk.FlowID == "" && hv.FlowID == "" && hv.TraceID == "" && len(rs.ServedToolCallIDs) > 0 {
+		lk.FlowID = respEventID
+	}
+
+	// Effective flow the event will carry (mirrors the builder precedence:
+	// asserted header > traceparent > linked/anchor).
+	effFlow := hv.FlowID
+	if effFlow == "" {
+		effFlow = hv.TraceID
+	}
+	if effFlow == "" {
+		effFlow = lk.FlowID
+	}
+
+	// Index served ids under (effFlow, respEventID) so a later echo links here.
+	if effFlow != "" && len(rs.ServedToolCallIDs) > 0 {
+		if err := cfg.Linkage.IndexToolCalls(ctx, tenantID, rs.ServedToolCallIDs, linkage.Link{FlowID: effFlow, StepID: respEventID}); err != nil {
+			cfg.Logger.WithError(err).Warn("aiqg linkage index failed")
+		}
+	}
+	return lk
 }
 
 // headersView projects an AIQGHeaders into the read-only view the

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -65,6 +65,14 @@ type Routing struct {
 	// /api/v1/metrics/tags endpoint (which shows "what matchers are
 	// firing most often for this tenant"). Direction-agnostic.
 	tagFindings map[string]int
+
+	// linked tier (docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §A): tool_call_ids
+	// this request echoed back in role=tool messages (the resolve key) and
+	// the ids our served response minted (the index key). The middleware
+	// resolves echoed→(flow,step) and indexes served→(flow,step) via
+	// pkg/aiqg/linkage on response completion.
+	echoedToolCallIDs []string
+	servedToolCallIDs []string
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -125,6 +133,11 @@ type RoutingSnapshot struct {
 	// Gatekeeper pattern_id → count for this request. Nil when no
 	// findings. Drives /api/v1/metrics/tags.
 	TagFindings map[string]int
+
+	// linked tier: tool_call_ids this request echoed (role=tool) and the
+	// ids our served response minted. Nil when none.
+	EchoedToolCallIDs []string
+	ServedToolCallIDs []string
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -134,24 +147,57 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return RoutingSnapshot{
-		Vendor:           r.vendor,
-		Model:            r.model,
-		Streaming:        r.streaming,
-		StreamingSet:     r.streamSet,
-		PromptTokens:     r.promptTokens,
-		CompletionTokens: r.completionTokens,
-		UsageSet:         r.usageSet,
-		InboundFindings:  copyCounts(r.inboundFindings),
-		OutboundFindings: copyCounts(r.outboundFindings),
-		ScanRan:          r.scanRan,
-		FinishReason:     r.finishReason,
-		AttemptCount:     r.attemptCount,
-		FallbackUsed:     r.fallbackUsed,
-		RetrySet:         r.retrySet,
-		Workflow:         r.workflow,
-		NISTFindings:     copyCounts(r.nistFindings),
-		TagFindings:      copyCounts(r.tagFindings),
+		Vendor:            r.vendor,
+		Model:             r.model,
+		Streaming:         r.streaming,
+		StreamingSet:      r.streamSet,
+		PromptTokens:      r.promptTokens,
+		CompletionTokens:  r.completionTokens,
+		UsageSet:          r.usageSet,
+		InboundFindings:   copyCounts(r.inboundFindings),
+		OutboundFindings:  copyCounts(r.outboundFindings),
+		ScanRan:           r.scanRan,
+		FinishReason:      r.finishReason,
+		AttemptCount:      r.attemptCount,
+		FallbackUsed:      r.fallbackUsed,
+		RetrySet:          r.retrySet,
+		Workflow:          r.workflow,
+		NISTFindings:      copyCounts(r.nistFindings),
+		TagFindings:       copyCounts(r.tagFindings),
+		EchoedToolCallIDs: append([]string(nil), r.echoedToolCallIDs...),
+		ServedToolCallIDs: append([]string(nil), r.servedToolCallIDs...),
 	}
+}
+
+// StampEchoedToolCalls records the tool_call_ids this request echoed back in
+// role=tool messages — the linked-tier resolve key. Append semantics (a
+// request can carry several tool results).
+func StampEchoedToolCalls(ctx context.Context, ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.echoedToolCallIDs = append(r.echoedToolCallIDs, ids...)
+}
+
+// StampServedToolCalls records the tool_call_ids our response minted — the
+// linked-tier index key (a future request echoing them links to this step).
+func StampServedToolCalls(ctx context.Context, ids []string) {
+	if len(ids) == 0 {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.servedToolCallIDs = append(r.servedToolCallIDs, ids...)
 }
 
 func copyCounts(in map[string]int) map[string]int {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/sirupsen/logrus"
 
+	"github.com/redis/go-redis/v9"
 	"github.com/tributary-ai/llm-router-waf/internal/gatekeeper"
 	"github.com/tributary-ai/llm-router-waf/internal/middleware"
 	"github.com/tributary-ai/llm-router-waf/internal/providers"
@@ -19,6 +20,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/types"
 	"github.com/tributary-ai/llm-router-waf/internal/workflow"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/linkage"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
@@ -151,6 +153,10 @@ type AIQGServerConfig struct {
 	DashboardURL               string `yaml:"dashboard_url"`
 	DashboardInternalAuthToken string `yaml:"dashboard_internal_auth_token"`
 
+	// LinkageRedisURL enables the deterministic `linked`-tier attribution
+	// (tool_call_id echo index). Empty = linkage disabled.
+	LinkageRedisURL string `yaml:"linkage_redis_url"`
+
 	// EmitterType selects how AIQG events are published:
 	//   "log"   — logrus → Loki (default; works without infra)
 	//   "kafka" — sarama SyncProducer → Kafka topic (durable, partitioned)
@@ -263,6 +269,19 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			logger.Info("AIQG policy resolver: none — events emit without resolved_policy_bundle")
 		}
 
+		// Deterministic `linked`-tier store (tool_call_id echo index).
+		// Redis-backed when AIQG_LINKAGE_REDIS_URL is set; nil otherwise
+		// (linkage disabled — events emit without step/parent topology).
+		var linkageStore linkage.Store
+		if config.AIQG.LinkageRedisURL != "" {
+			if opt, err := redis.ParseURL(config.AIQG.LinkageRedisURL); err != nil {
+				logger.WithError(err).Warn("AIQG linkage: invalid AIQG_LINKAGE_REDIS_URL; linkage disabled")
+			} else {
+				linkageStore = linkage.NewRedisStore(redis.NewClient(opt), 0)
+				logger.WithField("redis_addr", opt.Addr).Info("AIQG linkage: tool_call_id echo index enabled (linked tier)")
+			}
+		}
+
 		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{
 			Strict:         config.AIQG.Strict,
 			Logger:         logger,
@@ -271,6 +290,7 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			IPCaptureMode:  config.AIQG.IPCaptureMode,
 			Resolver:       resolver,
 			PolicyResolver: policyResolver,
+			Linkage:        linkageStore,
 		})
 		logger.WithFields(logrus.Fields{
 			"strict":           config.AIQG.Strict,
@@ -487,6 +507,9 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// the CLEAR latency scorer uses a sensible SLA when the caller
 	// didn't send a TAS-Workflow header. Empty result is a no-op.
 	middleware.StampWorkflow(r.Context(), workflow.Classify(&req))
+	// AIQG (linked tier): tool_call_ids this request echoes (role=tool) so
+	// the middleware can prove which flow/step it continues.
+	middleware.StampEchoedToolCalls(r.Context(), echoedToolCallIDs(&req))
 
 	// Gatekeeper: check bypass token
 	scanBypassed := false
@@ -625,6 +648,9 @@ func (s *Server) handleNonStreamingCompletion(w http.ResponseWriter, r *http.Req
 	}
 	if len(resp.Choices) > 0 {
 		middleware.StampFinishReason(r.Context(), resp.Choices[0].FinishReason)
+		// AIQG (linked tier): tool_call_ids this response served, so a later
+		// request echoing them links back to this step.
+		middleware.StampServedToolCalls(r.Context(), servedToolCallIDs(resp))
 	}
 	if metadata != nil {
 		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
@@ -779,6 +805,9 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 	}
 	if len(resp.Choices) > 0 {
 		middleware.StampFinishReason(r.Context(), resp.Choices[0].FinishReason)
+		// AIQG (linked tier): tool_call_ids this response served, so a later
+		// request echoing them links back to this step.
+		middleware.StampServedToolCalls(r.Context(), servedToolCallIDs(resp))
 	}
 	if metadata != nil {
 		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
@@ -790,6 +819,39 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(resp)
+}
+
+// echoedToolCallIDs returns the tool_call_ids this request echoes back in
+// role=tool messages — the linked-tier resolve key (the request is provably
+// the next step of the flow whose response served those ids).
+func echoedToolCallIDs(req *types.ChatRequest) []string {
+	if req == nil {
+		return nil
+	}
+	var ids []string
+	for _, m := range req.Messages {
+		if m.ToolCallID != "" {
+			ids = append(ids, m.ToolCallID)
+		}
+	}
+	return ids
+}
+
+// servedToolCallIDs returns the tool_call_ids our response minted — the
+// linked-tier index key (a later request echoing them links to this step).
+func servedToolCallIDs(resp *types.ChatResponse) []string {
+	if resp == nil {
+		return nil
+	}
+	var ids []string
+	for _, ch := range resp.Choices {
+		for _, tc := range ch.Message.ToolCalls {
+			if tc.ID != "" {
+				ids = append(ids, tc.ID)
+			}
+		}
+	}
+	return ids
 }
 
 // extractResponseContent extracts text content from a ChatResponse.

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -191,8 +191,15 @@ type BuildOptions struct {
 type Linkage struct {
 	StepID       string
 	ParentStepID string
-	LinkedFlowID string
-	FlowStepSeq  int
+	// FlowID is the effective flow anchor to stamp when no TAS-Flow-Id /
+	// traceparent flow was asserted: the resolved link's flow for an echoing
+	// child, or a minted anchor for a tool-serving root. Filling FlowID does
+	// NOT by itself mean "linked".
+	FlowID string
+	// Linked is true only when an echoed tool_call_id matched a served one
+	// (evidence) — that's what promotes identity_source to `linked`.
+	Linked      bool
+	FlowStepSeq int
 }
 
 func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linkage) *AgentContext {
@@ -218,7 +225,7 @@ func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linka
 		ac.FlowID = h.TraceID
 	}
 	if ac.FlowID == "" {
-		ac.FlowID = lk.LinkedFlowID
+		ac.FlowID = lk.FlowID
 	}
 	// principal: token source_app, else token id (always present in AIQG mode)
 	ac.PrincipalID = t.SourceApp
@@ -233,7 +240,7 @@ func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linka
 		ac.IdentitySource = "asserted"
 	case h.TraceID != "":
 		ac.IdentitySource = "trace"
-	case lk.LinkedFlowID != "" || lk.ParentStepID != "":
+	case lk.Linked:
 		ac.IdentitySource = "linked"
 	case ac.PrincipalID != "":
 		ac.IdentitySource = "principal"

--- a/pkg/aiqg/events/linked_test.go
+++ b/pkg/aiqg/events/linked_test.go
@@ -10,7 +10,7 @@ func TestBuildAgentContext_Linked(t *testing.T) {
 	tok := TokenView{TASAuthTokenID: "tok-1"} // principal always present in AIQG mode
 
 	t.Run("untagged request linked by tool_call echo", func(t *testing.T) {
-		lk := Linkage{StepID: "resp-2", ParentStepID: "resp-1", LinkedFlowID: "flow-X"}
+		lk := Linkage{StepID: "resp-2", ParentStepID: "resp-1", FlowID: "flow-X", Linked: true}
 		ac := buildAgentContext(AIQGHeadersView{}, tok, "", lk)
 		if ac == nil {
 			t.Fatal("nil agent context")
@@ -26,7 +26,7 @@ func TestBuildAgentContext_Linked(t *testing.T) {
 	t.Run("asserted agent keeps WHO, linkage supplies SHAPE", func(t *testing.T) {
 		// Agent named via header (asserted) but no TAS-Flow-Id; linkage fills the flow.
 		h := AIQGHeadersView{AgentID: "agent-7"}
-		lk := Linkage{StepID: "resp-9", ParentStepID: "resp-8", LinkedFlowID: "flow-Y"}
+		lk := Linkage{StepID: "resp-9", ParentStepID: "resp-8", FlowID: "flow-Y", Linked: true}
 		ac := buildAgentContext(h, tok, "", lk)
 		if ac.IdentitySource != "asserted" {
 			t.Errorf("identity_source = %q, want asserted (agent named wins WHO)", ac.IdentitySource)
@@ -38,7 +38,7 @@ func TestBuildAgentContext_Linked(t *testing.T) {
 
 	t.Run("explicit TAS-Flow-Id wins over linked flow", func(t *testing.T) {
 		h := AIQGHeadersView{FlowID: "header-flow"}
-		lk := Linkage{StepID: "resp-3", LinkedFlowID: "flow-Z"}
+		lk := Linkage{StepID: "resp-3", FlowID: "flow-Z", Linked: true}
 		ac := buildAgentContext(h, tok, "", lk)
 		if ac.FlowID != "header-flow" {
 			t.Errorf("FlowID = %q, want the asserted header flow", ac.FlowID)


### PR DESCRIPTION
Activates deterministic `tool_call_id`-echo attribution (C2a) end to end. The gateway reconstructs flow/step topology with **zero client cooperation**.

- Routing sidecar carries echoed (role=tool) + served (response tool_calls) ids; `server.go` stamps them at the request/response parse sites (non-streaming for MVP).
- `aiqg.go` `resolveLinkage` (deferred path, fresh ctx): resolves echoed ids → parent step + flow; anchors a flow for a tool-serving root; indexes served ids for the next echo. Best-effort (store errors degrade to no-linkage).
- `events.Linkage` = {StepID, ParentStepID, FlowID, Linked}; `identity_source=linked` only on echo evidence — *asserted wins WHO, linked wins SHAPE*.
- `AIQG_LINKAGE_REDIS_URL` config/env → RedisStore (nil = disabled, zero behavior change). Flow anchoring only on tool-call evidence so the Flows report isn't flooded.

**Verified live** on `aiqg-v5.27`: a 2-step tool-call loop (no flow/agent headers) → step 2 carries `identity_source=linked`, `parent_step_id`=step 1, and the same `flow_id` as step 1. Builds + tests green.

Follow-on: Spark step_id/parent_step_id columns for the TS trace-waterfall (flow grouping already works via shared flow_id); streaming served-tool capture; FlowStepSeq counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)