### PR TITLE
feat(aiqg): prefix-chaining tier — thread tool-less conversations

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -297,6 +297,20 @@ func resolveLinkage(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *t
 		lk.Linked = true
 	}
 
+	// Prefix chaining (§A.2): a tool-less multi-turn thread re-sends a
+	// conversation state we served as the prefix of its next request. When the
+	// prefix hash matches an indexed state, this request is provably the next
+	// turn of that conversation. Independent of the flow/step tool-echo tier —
+	// it threads conversation_id, not flow topology.
+	if rs.PrefixHash != "" {
+		if convID, ok, err := cfg.Linkage.ResolvePrefix(ctx, tenantID, rs.PrefixHash); err != nil {
+			cfg.Logger.WithError(err).Warn("aiqg prefix-chain resolve failed")
+		} else if ok {
+			lk.ConversationID = convID
+			lk.Linked = true
+		}
+	}
+
 	// Root anchor: an untagged request that SERVES tool_calls starts a flow;
 	// anchor it on this step id so children group under it. Not "linked" —
 	// there's no echo evidence yet, only an outgoing tool call.
@@ -318,6 +332,23 @@ func resolveLinkage(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *t
 	if effFlow != "" && len(rs.ServedToolCallIDs) > 0 {
 		if err := cfg.Linkage.IndexToolCalls(ctx, tenantID, rs.ServedToolCallIDs, linkage.Link{FlowID: effFlow, StepID: respEventID}); err != nil {
 			cfg.Logger.WithError(err).Warn("aiqg linkage index failed")
+		}
+	}
+
+	// Index the conversation state this response leaves, so the next turn's
+	// prefix links back. The conversation id is the one we resolved (this turn
+	// continues an existing thread) or, for a thread head, this step's id —
+	// minted as a *candidate* in the index only. A head turn's own event is NOT
+	// stamped with a conversation_id (no evidence it'll be continued), so
+	// one-shot chats never flood the Conversations view; the id surfaces only
+	// once a real continuation resolves it. Mirrors the tool-echo root anchor.
+	if rs.StateHash != "" {
+		convID := lk.ConversationID
+		if convID == "" {
+			convID = respEventID
+		}
+		if err := cfg.Linkage.IndexPrefix(ctx, tenantID, rs.StateHash, convID); err != nil {
+			cfg.Logger.WithError(err).Warn("aiqg prefix-chain index failed")
 		}
 	}
 	return lk

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -73,6 +73,14 @@ type Routing struct {
 	// pkg/aiqg/linkage on response completion.
 	echoedToolCallIDs []string
 	servedToolCallIDs []string
+
+	// prefix-chaining tier (§A.2): canonical hash of the conversation state
+	// this request CONTINUES (its message prefix up to the last assistant
+	// turn = the resolve key) and the state serving this response LEAVES
+	// (request messages + our reply = the index key). Empty when not
+	// applicable (fresh thread / tool-call-only response).
+	prefixHash string
+	stateHash  string
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -138,6 +146,12 @@ type RoutingSnapshot struct {
 	// ids our served response minted. Nil when none.
 	EchoedToolCallIDs []string
 	ServedToolCallIDs []string
+
+	// prefix-chaining tier (§A.2): resolve key (prefix of the incoming
+	// request) and index key (state left by serving this response). Empty
+	// when not applicable.
+	PrefixHash string
+	StateHash  string
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -166,6 +180,8 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		TagFindings:       copyCounts(r.tagFindings),
 		EchoedToolCallIDs: append([]string(nil), r.echoedToolCallIDs...),
 		ServedToolCallIDs: append([]string(nil), r.servedToolCallIDs...),
+		PrefixHash:        r.prefixHash,
+		StateHash:         r.stateHash,
 	}
 }
 
@@ -198,6 +214,42 @@ func StampServedToolCalls(ctx context.Context, ids []string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.servedToolCallIDs = append(r.servedToolCallIDs, ids...)
+}
+
+// StampPrefixHash records the canonical hash of the conversation state this
+// request continues (its message prefix up to the last assistant turn) — the
+// prefix-chaining resolve key. First-write-wins; empty is a no-op.
+func StampPrefixHash(ctx context.Context, hash string) {
+	if hash == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.prefixHash == "" {
+		r.prefixHash = hash
+	}
+}
+
+// StampStateHash records the canonical hash of the conversation state serving
+// this response leaves behind (request messages + our reply) — the
+// prefix-chaining index key. First-write-wins; empty is a no-op.
+func StampStateHash(ctx context.Context, hash string) {
+	if hash == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stateHash == "" {
+		r.stateHash = hash
+	}
 }
 
 func copyCounts(in map[string]int) map[string]int {

--- a/internal/server/prefix_chain_test.go
+++ b/internal/server/prefix_chain_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+func userMsg(s string) types.Message      { return types.Message{Role: "user", Content: s} }
+func assistantMsg(s string) types.Message { return types.Message{Role: "assistant", Content: s} }
+
+func respWith(content string) *types.ChatResponse {
+	return &types.ChatResponse{Choices: []types.Choice{{Message: assistantMsg(content)}}}
+}
+
+// The load-bearing property of prefix chaining: the state hash we index after
+// serving turn N must equal the prefix hash the client produces on turn N+1
+// (which re-sends turn N's messages + our assistant reply + a new user turn).
+// If these don't match, conversations never thread.
+func TestPrefixChain_StateHashMatchesNextPrefix(t *testing.T) {
+	turn1Req := &types.ChatRequest{Messages: []types.Message{
+		{Role: "system", Content: "You are helpful."},
+		userMsg("What is the capital of France?"),
+	}}
+	answer := "The capital of France is Paris."
+	stateAfterTurn1 := conversationStateHash(turn1Req, respWith(answer))
+	if stateAfterTurn1 == "" {
+		t.Fatal("state hash should be non-empty for a text response")
+	}
+
+	// Turn 2: client re-sends everything verbatim + our reply + a follow-up.
+	turn2Req := &types.ChatRequest{Messages: []types.Message{
+		{Role: "system", Content: "You are helpful."},
+		userMsg("What is the capital of France?"),
+		assistantMsg(answer),
+		userMsg("And its population?"),
+	}}
+	prefixOfTurn2 := conversationPrefixHash(turn2Req)
+	if prefixOfTurn2 != stateAfterTurn1 {
+		t.Errorf("turn-2 prefix hash %q != turn-1 state hash %q — conversation would not thread",
+			prefixOfTurn2, stateAfterTurn1)
+	}
+}
+
+func TestPrefixChain_FirstTurnHasNoPrefix(t *testing.T) {
+	// A fresh thread (no assistant message) has nothing to chain back to.
+	req := &types.ChatRequest{Messages: []types.Message{userMsg("Hello")}}
+	if h := conversationPrefixHash(req); h != "" {
+		t.Errorf("first turn should have empty prefix hash, got %q", h)
+	}
+}
+
+func TestPrefixChain_ToolOnlyResponseHasNoStateHash(t *testing.T) {
+	// A response with no assistant text (tool-call-only) is handled by the
+	// tool_call_id echo tier, not prefix chaining — no state hash.
+	req := &types.ChatRequest{Messages: []types.Message{userMsg("Weather?")}}
+	toolResp := &types.ChatResponse{Choices: []types.Choice{{
+		Message: types.Message{Role: "assistant", ToolCalls: []types.ToolCall{{ID: "call_1"}}},
+	}}}
+	if h := conversationStateHash(req, toolResp); h != "" {
+		t.Errorf("tool-only response should have empty state hash, got %q", h)
+	}
+}
+
+func TestPrefixChain_DistinctConversationsDiffer(t *testing.T) {
+	a := conversationStateHash(
+		&types.ChatRequest{Messages: []types.Message{userMsg("A")}}, respWith("reply-A"))
+	b := conversationStateHash(
+		&types.ChatRequest{Messages: []types.Message{userMsg("B")}}, respWith("reply-B"))
+	if a == b || a == "" || b == "" {
+		t.Errorf("distinct conversations must hash differently: a=%q b=%q", a, b)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -510,6 +512,10 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// AIQG (linked tier): tool_call_ids this request echoes (role=tool) so
 	// the middleware can prove which flow/step it continues.
 	middleware.StampEchoedToolCalls(r.Context(), echoedToolCallIDs(&req))
+	// AIQG (prefix-chaining tier): hash of the conversation prefix this
+	// request continues, so the middleware can recognize a tool-less
+	// multi-turn thread it previously served.
+	middleware.StampPrefixHash(r.Context(), conversationPrefixHash(&req))
 
 	// Gatekeeper: check bypass token
 	scanBypassed := false
@@ -651,6 +657,10 @@ func (s *Server) handleNonStreamingCompletion(w http.ResponseWriter, r *http.Req
 		// AIQG (linked tier): tool_call_ids this response served, so a later
 		// request echoing them links back to this step.
 		middleware.StampServedToolCalls(r.Context(), servedToolCallIDs(resp))
+		// AIQG (prefix-chaining tier): hash of the conversation state this
+		// response leaves, so a later request re-sending it as prefix links
+		// to this turn's conversation.
+		middleware.StampStateHash(r.Context(), conversationStateHash(req, resp))
 	}
 	if metadata != nil {
 		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
@@ -808,6 +818,10 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 		// AIQG (linked tier): tool_call_ids this response served, so a later
 		// request echoing them links back to this step.
 		middleware.StampServedToolCalls(r.Context(), servedToolCallIDs(resp))
+		// AIQG (prefix-chaining tier): hash of the conversation state this
+		// response leaves, so a later request re-sending it as prefix links
+		// to this turn's conversation.
+		middleware.StampStateHash(r.Context(), conversationStateHash(req, resp))
 	}
 	if metadata != nil {
 		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
@@ -852,6 +866,69 @@ func servedToolCallIDs(resp *types.ChatResponse) []string {
 		}
 	}
 	return ids
+}
+
+// hashMessages returns a canonical SHA-256 over a message sequence, projecting
+// each message to (role, content, tool_call_id). json.Marshal sorts map keys,
+// so multimodal content (decoded as map[string]interface{}) hashes
+// deterministically, and extra fields on a client-echoed assistant message
+// (refusal, annotations, …) are ignored — so the hash of a state we serve
+// matches the prefix the client re-sends verbatim on the next turn.
+func hashMessages(msgs []types.Message) string {
+	type nm struct {
+		Role       string      `json:"r"`
+		Content    interface{} `json:"c,omitempty"`
+		ToolCallID string      `json:"t,omitempty"`
+	}
+	norm := make([]nm, 0, len(msgs))
+	for _, m := range msgs {
+		norm = append(norm, nm{Role: m.Role, Content: m.Content, ToolCallID: m.ToolCallID})
+	}
+	b, err := json.Marshal(norm)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// conversationPrefixHash hashes the conversation state this request CONTINUES:
+// all messages up to and including the last assistant message — the boundary
+// of the prior served turn. Empty when there's no assistant message (a fresh
+// thread: nothing to chain back to). Prefix-chaining resolve key (§A.2).
+func conversationPrefixHash(req *types.ChatRequest) string {
+	if req == nil {
+		return ""
+	}
+	last := -1
+	for i, m := range req.Messages {
+		if m.Role == "assistant" {
+			last = i
+		}
+	}
+	if last < 0 {
+		return ""
+	}
+	return hashMessages(req.Messages[:last+1])
+}
+
+// conversationStateHash hashes the conversation state serving this response
+// LEAVES behind: the request's messages plus the assistant turn we returned.
+// A later request whose prefix hash equals this is provably its next turn.
+// Empty for a tool-call-only response (no assistant text) — the tool_call_id
+// echo tier (§A.1) handles those. Prefix-chaining index key.
+func conversationStateHash(req *types.ChatRequest, resp *types.ChatResponse) string {
+	if req == nil || resp == nil {
+		return ""
+	}
+	content := extractResponseContent(resp)
+	if content == "" {
+		return ""
+	}
+	msgs := make([]types.Message, 0, len(req.Messages)+1)
+	msgs = append(msgs, req.Messages...)
+	msgs = append(msgs, types.Message{Role: "assistant", Content: content})
+	return hashMessages(msgs)
 }
 
 // extractResponseContent extracts text content from a ChatResponse.

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -196,10 +196,16 @@ type Linkage struct {
 	// child, or a minted anchor for a tool-serving root. Filling FlowID does
 	// NOT by itself mean "linked".
 	FlowID string
-	// Linked is true only when an echoed tool_call_id matched a served one
-	// (evidence) — that's what promotes identity_source to `linked`.
+	// Linked is true only when evidence matched — an echoed tool_call_id we
+	// served (§A.1) OR a message-prefix that matched a state we served
+	// (§A.2 prefix chaining). That's what promotes identity_source to `linked`.
 	Linked      bool
 	FlowStepSeq int
+	// ConversationID is the thread this request continues, proven by prefix
+	// chaining (the request's message prefix == a conversation state we
+	// previously served). Fills conversation_id only when no TAS-Conversation-Id
+	// header / baggage session.id was asserted. Empty for non-chained traffic.
+	ConversationID string
 }
 
 func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linkage) *AgentContext {
@@ -213,10 +219,15 @@ func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linka
 		ParentStepID: lk.ParentStepID,
 		FlowStepSeq:  lk.FlowStepSeq,
 	}
-	// conversation: explicit header wins, else baggage session.id
+	// conversation: explicit header wins, else baggage session.id, else the
+	// thread proven by prefix chaining (a served-state echo). Naming, like
+	// FlowID — header always wins to preserve customer intent.
 	ac.ConversationID = h.ConversationID
 	if ac.ConversationID == "" {
 		ac.ConversationID = h.BaggageSessionID
+	}
+	if ac.ConversationID == "" {
+		ac.ConversationID = lk.ConversationID
 	}
 	// flow: explicit header wins, else traceparent trace-id, else the
 	// linked flow proven by a tool_call_id echo (shape, not naming).

--- a/pkg/aiqg/linkage/store.go
+++ b/pkg/aiqg/linkage/store.go
@@ -32,13 +32,23 @@ type Link struct {
 }
 
 // Store indexes served tool_call_ids and resolves echoed ones back to their
-// originating (flow, step). Implementations are safe for concurrent use.
+// originating (flow, step). It also indexes conversation-state hashes for the
+// prefix-chaining tier (§A.2). Implementations are safe for concurrent use.
 type Store interface {
 	// IndexToolCalls records that this (flow, step) served these tool_call_ids.
 	IndexToolCalls(ctx context.Context, tenantID string, toolCallIDs []string, link Link) error
 	// ResolveToolCalls returns the linked (flow, step) for the first of these
 	// echoed tool_call_ids that we previously served, or ok=false if none match.
 	ResolveToolCalls(ctx context.Context, tenantID string, toolCallIDs []string) (link Link, ok bool, err error)
+
+	// IndexPrefix records that serving this request left the conversation in a
+	// state whose canonical hash is stateHash, belonging to conversationID. A
+	// later request whose message-prefix hashes to stateHash is the next turn
+	// of that conversation. Tool-less multi-turn threading, zero cooperation.
+	IndexPrefix(ctx context.Context, tenantID, stateHash, conversationID string) error
+	// ResolvePrefix returns the conversationID a request continues when its
+	// message-prefix hash matches a state we previously served, or ok=false.
+	ResolvePrefix(ctx context.Context, tenantID, prefixHash string) (conversationID string, ok bool, err error)
 }
 
 // DefaultTTL bounds how long a served tool_call_id stays linkable. A tool
@@ -47,6 +57,10 @@ type Store interface {
 const DefaultTTL = time.Hour
 
 func redisKey(tenantID, id string) string { return "aiqg:tcid:" + tenantID + ":" + id }
+
+// prefixKey namespaces the prefix-chaining index separately from tool_call_ids
+// so the two tiers never collide. Value is the conversation_id.
+func prefixKey(tenantID, hash string) string { return "aiqg:pfx:" + tenantID + ":" + hash }
 
 // RedisStore is the production Store. Keys are short-TTL so the index
 // self-prunes; tenant_id is part of the key so flows never cross tenants.
@@ -105,17 +119,44 @@ func (s *RedisStore) ResolveToolCalls(ctx context.Context, tenantID string, tool
 	return Link{}, false, nil
 }
 
+func (s *RedisStore) IndexPrefix(ctx context.Context, tenantID, stateHash, conversationID string) error {
+	if s == nil || s.R == nil || stateHash == "" || conversationID == "" {
+		return nil
+	}
+	return s.R.Set(ctx, prefixKey(tenantID, stateHash), conversationID, s.TTL).Err()
+}
+
+func (s *RedisStore) ResolvePrefix(ctx context.Context, tenantID, prefixHash string) (string, bool, error) {
+	if s == nil || s.R == nil || prefixHash == "" {
+		return "", false, nil
+	}
+	v, err := s.R.Get(ctx, prefixKey(tenantID, prefixHash)).Result()
+	if err == redis.Nil {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, err
+	}
+	if v == "" {
+		return "", false, nil
+	}
+	return v, true, nil
+}
+
 // MemoryStore is an in-process Store for tests and as a Redis-less fallback
 // (linkage degrades to single-process when Redis isn't configured). Unlike
 // RedisStore it doesn't TTL-evict; callers that need bounded memory in a
 // long-lived process should prefer RedisStore.
 type MemoryStore struct {
-	mu sync.Mutex
-	m  map[string]Link
+	mu  sync.Mutex
+	m   map[string]Link
+	pfx map[string]string
 }
 
 // NewMemoryStore returns an empty in-process store.
-func NewMemoryStore() *MemoryStore { return &MemoryStore{m: make(map[string]Link)} }
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{m: make(map[string]Link), pfx: make(map[string]string)}
+}
 
 func (s *MemoryStore) IndexToolCalls(_ context.Context, tenantID string, toolCallIDs []string, link Link) error {
 	s.mu.Lock()
@@ -140,6 +181,28 @@ func (s *MemoryStore) ResolveToolCalls(_ context.Context, tenantID string, toolC
 		}
 	}
 	return Link{}, false, nil
+}
+
+func (s *MemoryStore) IndexPrefix(_ context.Context, tenantID, stateHash, conversationID string) error {
+	if stateHash == "" || conversationID == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.pfx[prefixKey(tenantID, stateHash)] = conversationID
+	return nil
+}
+
+func (s *MemoryStore) ResolvePrefix(_ context.Context, tenantID, prefixHash string) (string, bool, error) {
+	if prefixHash == "" {
+		return "", false, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if c, ok := s.pfx[prefixKey(tenantID, prefixHash)]; ok && c != "" {
+		return c, true, nil
+	}
+	return "", false, nil
 }
 
 // Ensure both satisfy Store.

--- a/pkg/aiqg/linkage/store_test.go
+++ b/pkg/aiqg/linkage/store_test.go
@@ -65,4 +65,55 @@ func TestRedisStore_NilSafe(t *testing.T) {
 	if _, ok, err := s.ResolveToolCalls(context.Background(), "t", []string{"a"}); ok || err != nil {
 		t.Errorf("nil resolve should be (false,nil), got ok=%v err=%v", ok, err)
 	}
+	// Prefix-chaining methods are nil-safe too.
+	if err := s.IndexPrefix(context.Background(), "t", "h", "c"); err != nil {
+		t.Errorf("nil prefix index should be a no-op, got %v", err)
+	}
+	if _, ok, err := s.ResolvePrefix(context.Background(), "t", "h"); ok || err != nil {
+		t.Errorf("nil prefix resolve should be (false,nil), got ok=%v err=%v", ok, err)
+	}
+}
+
+func TestMemoryStore_PrefixIndexThenResolve(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+
+	// Serving turn 1 leaves the conversation in state hash "state-1",
+	// belonging to conversation "conv-1".
+	if err := s.IndexPrefix(ctx, "t1", "state-1", "conv-1"); err != nil {
+		t.Fatalf("index prefix: %v", err)
+	}
+	// Turn 2's message prefix hashes to that same state → same conversation.
+	got, ok, err := s.ResolvePrefix(ctx, "t1", "state-1")
+	if err != nil || !ok {
+		t.Fatalf("resolve prefix: ok=%v err=%v", ok, err)
+	}
+	if got != "conv-1" {
+		t.Errorf("resolved conversation %q, want conv-1", got)
+	}
+}
+
+func TestMemoryStore_PrefixMissTenantAndNamespace(t *testing.T) {
+	ctx := context.Background()
+	s := NewMemoryStore()
+	_ = s.IndexPrefix(ctx, "t1", "state-x", "conv-x")
+
+	// Unknown prefix hash → miss.
+	if _, ok, _ := s.ResolvePrefix(ctx, "t1", "state-nope"); ok {
+		t.Error("unknown prefix should not resolve")
+	}
+	// Same hash, different tenant → miss (conversations never cross tenants).
+	if _, ok, _ := s.ResolvePrefix(ctx, "t2", "state-x"); ok {
+		t.Error("prefix must not resolve across tenants")
+	}
+	// Empty hash → miss, no panic.
+	if _, ok, _ := s.ResolvePrefix(ctx, "t1", ""); ok {
+		t.Error("empty prefix should not resolve")
+	}
+	// The prefix namespace must not collide with the tool_call_id namespace:
+	// a tool_call_id equal to a state hash string must not cross-resolve.
+	_ = s.IndexToolCalls(ctx, "t1", []string{"state-x"}, Link{FlowID: "f", StepID: "s"})
+	if c, ok, _ := s.ResolvePrefix(ctx, "t1", "state-x"); !ok || c != "conv-x" {
+		t.Errorf("prefix namespace collided with tool_call index: ok=%v c=%q", ok, c)
+	}
 }


### PR DESCRIPTION
Adds the second deterministic `linked`-tier signal from the attribution doc (§A.2): **prefix chaining** for plain multi-turn chat that carries no `tool_call_id`s.

### Why it works
Chat completions are stateless — the client re-sends the whole history each turn — so every response we serve reappears verbatim as a prefix of the next request. We hash the state a response *leaves* (request messages + our assistant reply) → `conversation_id`; the next request's message-prefix hash matches, proving it's the next turn. Zero headers, zero client cooperation. Prior art: prompt/prefix caching (Anthropic/OpenAI/vLLM) keys on exactly this.

### Mechanics
- `linkage.Store` gains `IndexPrefix`/`ResolvePrefix` (Redis ns `aiqg:pfx:`, short-TTL, tenant-scoped; `MemoryStore` mirror; nil-safe).
- Routing sidecar stamps `PrefixHash` (request parse) + `StateHash` (non-streaming response). Canonical SHA-256 over `(role, content, tool_call_id)` projections — robust to extra fields on a client-echoed assistant message and to multimodal content.
- `resolveLinkage` resolves prefix→`conversation_id` (→ `identity_source=linked`) and indexes the served state. A thread **head** mints only a candidate id in the index; its own event carries no `conversation_id`, so one-shot chats never flood the Conversations view — the id surfaces only once a real continuation resolves it (mirrors the tool-echo root anchor).
- `events.Linkage` gains `ConversationID`; `buildAgentContext` fills `conversation_id` when no header/baggage asserted one.

### Verified live
gpt-4o-mini, no tools, no headers:
| turn | identity_source | conversation_id |
|---|---|---|
| 1 (head) | principal | ∅ |
| 2 | **linked** | turn1.response_event_id |

Landed in TimescaleDB. New unit tests: prefix index/resolve + tenant/namespace isolation (linkage pkg), and the load-bearing `stateHash(N) == prefixHash(N+1)` threading property + head/tool-only/distinct cases (server pkg). `go build`/`vet`/tests green with `-tags nohs`. Deployed `tas-llm-router:aiqg-v5.28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)