### PR TITLE
feat(aiqg): fingerprinted tier — infer agent identity from request shape

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -285,6 +285,11 @@ func resolveLinkage(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *t
 	rs := routing.Snapshot()
 	tenantID := tok.TenantID
 
+	// Fingerprinted tier (§B): pass the request's structural signature to the
+	// builder, which scopes it per (tenant, principal) into an AgentSurrogateID.
+	// Independent of the deterministic store lookups below.
+	lk.Fingerprint = rs.Fingerprint
+
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -81,6 +81,12 @@ type Routing struct {
 	// applicable (fresh thread / tool-call-only response).
 	prefixHash string
 	stateHash  string
+
+	// fingerprinted tier (§B): the request's structural signature (sorted
+	// tool names + param schemas + config tuple). Empty when the request
+	// carries nothing fingerprintable. Combined with (tenant, principal) by
+	// the events builder to mint the AgentSurrogateID.
+	fingerprint string
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -152,6 +158,10 @@ type RoutingSnapshot struct {
 	// when not applicable.
 	PrefixHash string
 	StateHash  string
+
+	// fingerprinted tier (§B): the request's structural signature. Empty
+	// when nothing fingerprintable.
+	Fingerprint string
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -182,6 +192,7 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		ServedToolCallIDs: append([]string(nil), r.servedToolCallIDs...),
 		PrefixHash:        r.prefixHash,
 		StateHash:         r.stateHash,
+		Fingerprint:       r.fingerprint,
 	}
 }
 
@@ -249,6 +260,23 @@ func StampStateHash(ctx context.Context, hash string) {
 	defer r.mu.Unlock()
 	if r.stateHash == "" {
 		r.stateHash = hash
+	}
+}
+
+// StampFingerprint records the request's structural signature for the
+// fingerprinted tier (§B). First-write-wins; empty is a no-op.
+func StampFingerprint(ctx context.Context, fp string) {
+	if fp == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.fingerprint == "" {
+		r.fingerprint = fp
 	}
 }
 

--- a/internal/server/prefix_chain_test.go
+++ b/internal/server/prefix_chain_test.go
@@ -62,6 +62,51 @@ func TestPrefixChain_ToolOnlyResponseHasNoStateHash(t *testing.T) {
 	}
 }
 
+func tool(name string) types.Tool {
+	return types.Tool{Type: "function", Function: types.Function{Name: name}}
+}
+
+func TestAgentFingerprint_GateAndStability(t *testing.T) {
+	// A bare chat (no tools / response_format / stop) is not fingerprintable.
+	bare := &types.ChatRequest{Model: "gpt-4o-mini", Messages: []types.Message{userMsg("hi")}}
+	if h := agentFingerprint(bare); h != "" {
+		t.Errorf("bare chat should not be fingerprinted, got %q", h)
+	}
+
+	// A request declaring tools fingerprints, and tool-array order doesn't matter.
+	a := &types.ChatRequest{Model: "gpt-4o-mini", Tools: []types.Tool{tool("get_weather"), tool("search")}}
+	b := &types.ChatRequest{Model: "gpt-4o-mini", Tools: []types.Tool{tool("search"), tool("get_weather")}}
+	fa, fb := agentFingerprint(a), agentFingerprint(b)
+	if fa == "" {
+		t.Fatal("tool-bearing request should fingerprint")
+	}
+	if fa != fb {
+		t.Error("tool ordering must not change the fingerprint")
+	}
+
+	// A different toolset → different fingerprint.
+	c := &types.ChatRequest{Model: "gpt-4o-mini", Tools: []types.Tool{tool("get_weather")}}
+	if agentFingerprint(c) == fa {
+		t.Error("a different toolset must change the fingerprint")
+	}
+
+	// Same toolset, different model → different fingerprint (config tie-breaker).
+	d := &types.ChatRequest{Model: "gpt-4o", Tools: []types.Tool{tool("get_weather"), tool("search")}}
+	if agentFingerprint(d) == fa {
+		t.Error("model is part of the config signature")
+	}
+}
+
+func TestAgentFingerprint_MaxTokensIgnored(t *testing.T) {
+	mt1, mt2 := 8, 4096
+	base := func(mt int) *types.ChatRequest {
+		return &types.ChatRequest{Model: "gpt-4o-mini", MaxTokens: &mt, Tools: []types.Tool{tool("search")}}
+	}
+	if agentFingerprint(base(mt1)) != agentFingerprint(base(mt2)) {
+		t.Error("max_tokens must NOT split one agent's fingerprint")
+	}
+}
+
 func TestPrefixChain_DistinctConversationsDiffer(t *testing.T) {
 	a := conversationStateHash(
 		&types.ChatRequest{Messages: []types.Message{userMsg("A")}}, respWith("reply-A"))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -516,6 +517,9 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// request continues, so the middleware can recognize a tool-less
 	// multi-turn thread it previously served.
 	middleware.StampPrefixHash(r.Context(), conversationPrefixHash(&req))
+	// AIQG (fingerprinted tier): structural signature (toolset + config) so
+	// untagged programmatic traffic resolves to an inferred agent surrogate.
+	middleware.StampFingerprint(r.Context(), agentFingerprint(&req))
 
 	// Gatekeeper: check bypass token
 	scanBypassed := false
@@ -929,6 +933,75 @@ func conversationStateHash(req *types.ChatRequest, resp *types.ChatResponse) str
 	msgs = append(msgs, req.Messages...)
 	msgs = append(msgs, types.Message{Role: "assistant", Content: content})
 	return hashMessages(msgs)
+}
+
+// agentFingerprint computes the request's structural signature for the
+// fingerprinted tier (§B): the toolset (sorted tool/function names + their
+// param schemas) plus the config shape (model, sampling params, stop,
+// response_format). Programmatic agents pin these per code path and rarely
+// randomize them, so the same signature recurring is strong evidence of the
+// same agent type — even with zero identifying headers.
+//
+// Returns "" for a request with no fingerprintable structure (no tools /
+// functions / response_format / stop): a bare chat (model + free-text
+// messages) is too generic to attribute, and fingerprinting it would collapse
+// every ad-hoc call into one phantom agent. max_tokens and seed are
+// deliberately excluded — they're the config fields most likely to vary
+// per-call, which would wrongly split one agent into many.
+func agentFingerprint(req *types.ChatRequest) string {
+	if req == nil {
+		return ""
+	}
+	if len(req.Tools) == 0 && len(req.Functions) == 0 && req.ResponseFormat == nil && len(req.Stop) == 0 {
+		return ""
+	}
+	type toolSig struct {
+		Name   string      `json:"n"`
+		Params interface{} `json:"p,omitempty"`
+	}
+	var tools []toolSig
+	for _, t := range req.Tools {
+		tools = append(tools, toolSig{Name: t.Function.Name, Params: t.Function.Parameters})
+	}
+	for _, f := range req.Functions {
+		tools = append(tools, toolSig{Name: f.Name, Params: f.Parameters})
+	}
+	// Sort so tool-array reordering doesn't change the identity.
+	sort.Slice(tools, func(i, j int) bool { return tools[i].Name < tools[j].Name })
+
+	stop := append([]string(nil), req.Stop...)
+	sort.Strings(stop)
+
+	var rf interface{}
+	if req.ResponseFormat != nil {
+		rf = req.ResponseFormat
+	}
+
+	sig := struct {
+		Tools          []toolSig   `json:"tools,omitempty"`
+		Model          string      `json:"model,omitempty"`
+		Temperature    *float32    `json:"temp,omitempty"`
+		TopP           *float32    `json:"top_p,omitempty"`
+		FreqPenalty    *float32    `json:"freq_pen,omitempty"`
+		PresPenalty    *float32    `json:"pres_pen,omitempty"`
+		Stop           []string    `json:"stop,omitempty"`
+		ResponseFormat interface{} `json:"rf,omitempty"`
+	}{
+		Tools:          tools,
+		Model:          req.Model,
+		Temperature:    req.Temperature,
+		TopP:           req.TopP,
+		FreqPenalty:    req.FrequencyPenalty,
+		PresPenalty:    req.PresencePenalty,
+		Stop:           stop,
+		ResponseFormat: rf,
+	}
+	b, err := json.Marshal(sig)
+	if err != nil {
+		return ""
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }
 
 // extractResponseContent extracts text content from a ChatResponse.

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"net"
 	"net/http"
@@ -206,6 +207,12 @@ type Linkage struct {
 	// previously served). Fills conversation_id only when no TAS-Conversation-Id
 	// header / baggage session.id was asserted. Empty for non-chained traffic.
 	ConversationID string
+	// Fingerprint is the request's structural signature — a hash of its
+	// sorted tool names + param schemas + config tuple (model, sampling, stop,
+	// response_format). Empty unless the request carries a fingerprintable
+	// structure. Combined with (tenant, principal) in buildAgentContext to mint
+	// the per-customer AgentSurrogateID for the `fingerprinted` tier (§B).
+	Fingerprint string
 }
 
 func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linkage) *AgentContext {
@@ -261,12 +268,46 @@ func buildAgentContext(h AIQGHeadersView, t TokenView, clientIP string, lk Linka
 		ac.IdentitySource = "unattributed"
 	}
 
+	// Fingerprinted tier (§B): when the request leaks a structural signature
+	// (tools / response_format / stop), mint a per-(tenant, principal)
+	// surrogate id. Always recorded for the asserted-vs-inferred cross-check
+	// (§E). It only PROMOTES identity when nothing stronger than the principal
+	// tier resolved — a fingerprint is weaker evidence than baggage / asserted
+	// / trace / linked, but stronger than "just a token + IP". The (tenant,
+	// principal) scoping means two customers running the same OSS agent never
+	// collide into one surrogate.
+	if lk.Fingerprint != "" {
+		ac.AgentSurrogateID = agentSurrogateID(t.TenantID, ac.PrincipalID, lk.Fingerprint)
+		switch ac.IdentitySource {
+		case "principal", "transport", "unattributed":
+			if ac.AgentID == "" {
+				ac.AgentID = ac.AgentSurrogateID
+			}
+			ac.IdentitySource = "fingerprinted"
+		}
+	}
+
 	if ac.AgentID == "" && ac.AgentName == "" && ac.UserID == "" &&
 		ac.ConversationID == "" && ac.FlowID == "" && ac.PrincipalID == "" && ac.ClientIP == "" &&
 		ac.StepID == "" && ac.ParentStepID == "" {
 		return nil
 	}
 	return ac
+}
+
+// agentSurrogateID mints the fingerprinted-tier identity: a short, stable id
+// scoped to (tenant, principal) so the same structural signature recurs as one
+// inferred agent for a customer, and never collides across customers. The
+// "fp_" prefix marks it as inferred (vs an asserted TAS-Agent-Id) wherever it
+// surfaces in agent_id.
+func agentSurrogateID(tenantID, principalID, fingerprint string) string {
+	h := sha256.New()
+	h.Write([]byte(tenantID))
+	h.Write([]byte{0})
+	h.Write([]byte(principalID))
+	h.Write([]byte{0})
+	h.Write([]byte(fingerprint))
+	return "fp_" + hex.EncodeToString(h.Sum(nil))[:16]
 }
 
 // applyIPMode gates a raw client IP per the deployment's capture mode:

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -143,6 +143,17 @@ type AgentContext struct {
 	StepID       string `json:"step_id,omitempty"`
 	ParentStepID string `json:"parent_step_id,omitempty"`
 	FlowStepSeq  int    `json:"flow_step_seq,omitempty"`
+
+	// AgentSurrogateID is the inferred agent-type fingerprint (the
+	// `fingerprinted` tier, docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §B): a
+	// per-(tenant, principal) hash of the request's toolset + config tuple.
+	// Programmatic callers leak a stable identity through the tools they
+	// declare and the sampling config they pin, even with zero headers.
+	// Always set when the request carries a fingerprintable structure
+	// (tools / response_format / stop), so an asserted-vs-inferred mismatch
+	// can be surfaced (§E). When no stronger tier resolved, it also fills
+	// AgentID and IdentitySource becomes "fingerprinted".
+	AgentSurrogateID string `json:"agent_surrogate_id,omitempty"`
 }
 
 // ResponseEvent mirrors aether-shared/data-models/aiqg/response-event.md §2.2.

--- a/pkg/aiqg/events/fingerprint_test.go
+++ b/pkg/aiqg/events/fingerprint_test.go
@@ -1,0 +1,80 @@
+package events
+
+import "testing"
+
+// The `fingerprinted` tier (§B): a per-(tenant, principal) surrogate minted
+// from the request's structural signature. It promotes identity only when
+// nothing stronger resolved, is always recorded for the asserted-vs-inferred
+// cross-check, and never collides across tenants/principals.
+func TestBuildAgentContext_Fingerprinted(t *testing.T) {
+	tok := TokenView{TenantID: "t1", TASAuthTokenID: "tok-1"} // principal present
+	const fp = "sig-abc"
+
+	t.Run("untagged request with a fingerprint becomes fingerprinted", func(t *testing.T) {
+		ac := buildAgentContext(AIQGHeadersView{}, tok, "", Linkage{StepID: "r1", Fingerprint: fp})
+		if ac == nil {
+			t.Fatal("nil agent context")
+		}
+		if ac.IdentitySource != "fingerprinted" {
+			t.Errorf("identity_source = %q, want fingerprinted", ac.IdentitySource)
+		}
+		if ac.AgentSurrogateID == "" || ac.AgentID != ac.AgentSurrogateID {
+			t.Errorf("surrogate should fill agent_id: %+v", ac)
+		}
+	})
+
+	t.Run("surrogate is stable per signature and scoped per principal", func(t *testing.T) {
+		a := buildAgentContext(AIQGHeadersView{}, tok, "", Linkage{Fingerprint: fp})
+		b := buildAgentContext(AIQGHeadersView{}, tok, "", Linkage{Fingerprint: fp})
+		if a.AgentSurrogateID != b.AgentSurrogateID {
+			t.Error("same (tenant, principal, signature) must yield the same surrogate")
+		}
+		// Different principal → different surrogate (no cross-customer collision).
+		other := buildAgentContext(AIQGHeadersView{}, TokenView{TenantID: "t1", TASAuthTokenID: "tok-2"}, "", Linkage{Fingerprint: fp})
+		if other.AgentSurrogateID == a.AgentSurrogateID {
+			t.Error("different principal must yield a different surrogate")
+		}
+		// Different tenant → different surrogate.
+		otherT := buildAgentContext(AIQGHeadersView{}, TokenView{TenantID: "t2", TASAuthTokenID: "tok-1"}, "", Linkage{Fingerprint: fp})
+		if otherT.AgentSurrogateID == a.AgentSurrogateID {
+			t.Error("different tenant must yield a different surrogate")
+		}
+	})
+
+	t.Run("stronger tier wins WHO but surrogate is still recorded for cross-check", func(t *testing.T) {
+		// Baggage user wins identity_source, but a fingerprint present must
+		// still be stamped so an impersonation mismatch can be surfaced (§E).
+		h := AIQGHeadersView{BaggageUserID: "u_alice"}
+		ac := buildAgentContext(h, tok, "", Linkage{Fingerprint: fp})
+		if ac.IdentitySource != "baggage" {
+			t.Errorf("identity_source = %q, want baggage", ac.IdentitySource)
+		}
+		if ac.AgentSurrogateID == "" {
+			t.Error("surrogate should be recorded even under a stronger tier")
+		}
+		if ac.AgentID != "" {
+			t.Errorf("surrogate must NOT overwrite agent_id under a stronger tier: %+v", ac)
+		}
+	})
+
+	t.Run("asserted agent keeps its id; surrogate recorded alongside", func(t *testing.T) {
+		h := AIQGHeadersView{AgentID: "agent-real"}
+		ac := buildAgentContext(h, tok, "", Linkage{Fingerprint: fp})
+		if ac.IdentitySource != "asserted" || ac.AgentID != "agent-real" {
+			t.Errorf("asserted agent must be preserved: %+v", ac)
+		}
+		if ac.AgentSurrogateID == "" {
+			t.Error("surrogate should still be computed for the cross-check")
+		}
+	})
+
+	t.Run("no fingerprint leaves principal tier untouched", func(t *testing.T) {
+		ac := buildAgentContext(AIQGHeadersView{}, tok, "", Linkage{StepID: "r1"})
+		if ac.IdentitySource != "principal" {
+			t.Errorf("identity_source = %q, want principal", ac.IdentitySource)
+		}
+		if ac.AgentSurrogateID != "" || ac.AgentID != "" {
+			t.Errorf("no surrogate without a fingerprint: %+v", ac)
+		}
+	})
+}


### PR DESCRIPTION
Adds the probabilistic **agent-type fingerprinting** tier (attribution doc §B) on top of the deterministic §A linkage (tool-echo + prefix chaining). Programmatic callers leak a stable identity through what they *don't* randomize — the tools they declare and the config they pin. When a request carries that structure but no identifying headers, we mint a per-(tenant, principal) surrogate, so untagged traffic still groups into inferred agents ("14 distinct agents detected") with zero client cooperation.

### MVP signals (doc order #1 + #8)
- **Toolset hash** — sorted tool/function names + param schemas (the most stable proxy; survives prompt rewrites).
- **Config tuple** — model, temperature, top_p, freq/presence penalty, stop, response_format (the code-path tie-breaker).

Deferred: Drain template mining, step-archetype sequencing, CDC content-propagation, version lineage, registry UI.

### Mechanics
- `agentFingerprint(req)`: canonical SHA-256 over toolset + config shape. Returns `""` for a bare chat (no tools/response_format/stop) — too generic to attribute. Tool order normalized; `max_tokens`/`seed` excluded (most volatile → would split one agent into many).
- Routing sidecar stamps it at request parse; `resolveLinkage` threads it into `events.Linkage.Fingerprint`.
- `buildAgentContext` mints `AgentSurrogateID = "fp_"+hash(tenant|principal|fingerprint)`. **Always recorded** (powers the asserted-vs-inferred impersonation cross-check, §E); it only PROMOTES identity to `fingerprinted` and fills `agent_id` when nothing stronger than the principal tier resolved. Per-(tenant, principal) scope → no cross-customer collision on shared OSS agents.
- `AgentContext` gains `agent_surrogate_id` (emitted in event JSON). Reusing `agent_id` for the surrogate means inferred agents flow into the existing `/metrics/agents` rollup **with no TS/Spark schema change**.

### Verified live
gpt-4o-mini, no headers, two independent requests with the same toolset+config:
```
a218a39c… | fingerprinted | fp_eac35d9fc3ff1c1f
78743144… | fingerprinted | fp_eac35d9fc3ff1c1f
```
Same inferred agent in TimescaleDB. Unit tests: surrogate stability + tenant/principal scoping + tier precedence (events pkg), fingerprint gate + tool-order/model sensitivity + max_tokens-ignored (server pkg). build/vet/tests green `-tags nohs`. Deployed `tas-llm-router:aiqg-v5.29`.

Completes the C2b MVP and the full attribution ladder: baggage › asserted › trace › **linked** (tool-echo + prefix) › **fingerprinted** › principal › transport › unattributed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)