### PR TITLE
fix(anthropic): make tool calling work end-to-end

### DIFF
--- a/internal/providers/anthropic/provider.go
+++ b/internal/providers/anthropic/provider.go
@@ -2,6 +2,7 @@ package anthropic
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -464,24 +465,22 @@ func (p *AnthropicProvider) convertToAnthropicRequest(req *types.ChatRequest) (*
 		anthropicReq.StopSequences = stopSeqs
 	}
 
-	// Handle tools (Anthropic's function calling) - simplified for now
+	// Handle tools (OpenAI function-calling → Anthropic tool use). The
+	// JSON-Schema in tool.Function.Parameters maps directly onto Anthropic's
+	// input_schema — Anthropic REQUIRES a non-empty input_schema (it 400s
+	// with "tools.N.custom.input_schema: Field required" otherwise), so we
+	// translate properties/required across rather than sending an empty one.
 	if len(req.Tools) > 0 {
 		var tools []anthropic.ToolUnionParam
 		for _, tool := range req.Tools {
-			if tool.Type == "function" {
-				// Convert parameters schema if available
-				var inputSchema anthropic.ToolInputSchemaParam
-				if tool.Function.Parameters != nil {
-					// For now, use an empty schema as direct conversion is complex
-					inputSchema = anthropic.ToolInputSchemaParam{}
-				}
-
-				// Create tool using the union constructor
+			if tool.Type == "function" || tool.Type == "" {
 				anthropicTool := anthropic.ToolUnionParamOfTool(
-					inputSchema,
+					toAnthropicInputSchema(tool.Function.Parameters),
 					tool.Function.Name,
 				)
-
+				if tool.Function.Description != "" {
+					anthropicTool.OfTool.Description = anthropic.String(tool.Function.Description)
+				}
 				tools = append(tools, anthropicTool)
 			}
 		}
@@ -491,8 +490,70 @@ func (p *AnthropicProvider) convertToAnthropicRequest(req *types.ChatRequest) (*
 	return anthropicReq, nil
 }
 
-// convertMessage converts a unified message to Anthropic format
+// toAnthropicInputSchema translates an OpenAI tool's JSON-Schema parameters
+// (an interface{} that decodes to a map with "type"/"properties"/"required")
+// into Anthropic's ToolInputSchemaParam. Anthropic requires input_schema to be
+// present with type=object, so a tool with no/!object parameters still gets a
+// valid empty-object schema rather than an omitted field.
+func toAnthropicInputSchema(params interface{}) anthropic.ToolInputSchemaParam {
+	// Default: a valid `{"type":"object","properties":{}}` so the field is
+	// always present (Type marshals its zero value as "object").
+	schema := anthropic.ToolInputSchemaParam{Properties: map[string]interface{}{}}
+
+	m, ok := params.(map[string]interface{})
+	if !ok {
+		return schema
+	}
+	if props, ok := m["properties"]; ok && props != nil {
+		schema.Properties = props
+	}
+	if reqRaw, ok := m["required"].([]interface{}); ok {
+		required := make([]string, 0, len(reqRaw))
+		for _, r := range reqRaw {
+			if s, ok := r.(string); ok {
+				required = append(required, s)
+			}
+		}
+		if len(required) > 0 {
+			schema.Required = required
+		}
+	}
+	return schema
+}
+
+// convertMessage converts a unified (OpenAI-shaped) message to Anthropic
+// format, including the tool round-trip: a role=tool result becomes a
+// user-side tool_result block, and an assistant turn carrying tool_calls
+// becomes tool_use blocks. Without these a multi-turn tool loop breaks the
+// moment the caller sends results back.
 func (p *AnthropicProvider) convertMessage(msg types.Message) (anthropic.MessageParam, error) {
+	// Tool result (role=tool): Anthropic carries results in a USER message as
+	// tool_result blocks keyed by the originating tool_use id.
+	if msg.Role == "tool" {
+		return anthropic.NewUserMessage(
+			anthropic.NewToolResultBlock(msg.ToolCallID, messageContentString(msg.Content), false),
+		), nil
+	}
+
+	// Assistant turn that issued tool calls → tool_use blocks (+ any text).
+	if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
+		var blocks []anthropic.ContentBlockParamUnion
+		if s := messageContentString(msg.Content); s != "" {
+			blocks = append(blocks, anthropic.NewTextBlock(s))
+		}
+		for _, tc := range msg.ToolCalls {
+			var input any
+			if tc.Function.Arguments != "" {
+				_ = json.Unmarshal([]byte(tc.Function.Arguments), &input)
+			}
+			if input == nil {
+				input = map[string]any{}
+			}
+			blocks = append(blocks, anthropic.NewToolUseBlock(tc.ID, input, tc.Function.Name))
+		}
+		return anthropic.NewAssistantMessage(blocks...), nil
+	}
+
 	// Handle content based on type and create appropriate message
 	switch content := msg.Content.(type) {
 	case string:
@@ -530,30 +591,84 @@ func (p *AnthropicProvider) convertMessage(msg types.Message) (anthropic.Message
 	}
 }
 
+// messageContentString flattens a message's content (string or multimodal
+// parts) to plain text — used when emitting Anthropic tool_use / tool_result
+// blocks, which carry text only.
+func messageContentString(content interface{}) string {
+	switch c := content.(type) {
+	case string:
+		return c
+	case []types.ContentPart:
+		var sb strings.Builder
+		for _, p := range c {
+			if p.Type == "text" {
+				sb.WriteString(p.Text)
+			}
+		}
+		return sb.String()
+	default:
+		return ""
+	}
+}
+
 // convertFromAnthropicResponse converts Anthropic's response to our format
 func (p *AnthropicProvider) convertFromAnthropicResponse(resp *anthropic.Message, req *types.ChatRequest) *types.ChatResponse {
 	// Build choices from content blocks
 	var choices []types.Choice
 
+	// Normalize Anthropic's stop_reason to the OpenAI finish_reason vocabulary
+	// callers (and the linked-tier served-tool detection) expect:
+	// end_turn→stop, max_tokens→length, tool_use→tool_calls.
+	finishReason := string(resp.StopReason)
+	switch resp.StopReason {
+	case "end_turn", "stop_sequence":
+		finishReason = "stop"
+	case "max_tokens":
+		finishReason = "length"
+	case "tool_use":
+		finishReason = "tool_calls"
+	}
+
 	choice := types.Choice{
 		Index:        0,
-		FinishReason: string(resp.StopReason),
+		FinishReason: finishReason,
 		Message: types.Message{
 			Role:    "assistant",
 			Content: "", // Will be built from blocks
 		},
 	}
 
-	// Process content blocks - simple text extraction for now
+	// Process content blocks: concatenate text, and surface tool_use blocks
+	// as OpenAI-shaped tool_calls so the caller's agent loop sees them. The
+	// block's Input is already a JSON object → it becomes the tool_call's
+	// arguments string verbatim.
 	var textContent strings.Builder
+	var toolCalls []types.ToolCall
 
 	for _, block := range resp.Content {
-		if block.Type == "text" {
+		switch block.Type {
+		case "text":
 			textContent.WriteString(block.Text)
+		case "tool_use":
+			// ContentBlockUnion exposes the tool_use fields (ID/Name/Input)
+			// at the top level; Input is the args as a JSON object verbatim.
+			args := string(block.Input)
+			if args == "" {
+				args = "{}"
+			}
+			toolCalls = append(toolCalls, types.ToolCall{
+				ID:   block.ID,
+				Type: "function",
+				Function: types.Function{
+					Name:      block.Name,
+					Arguments: args,
+				},
+			})
 		}
 	}
 
 	choice.Message.Content = textContent.String()
+	choice.Message.ToolCalls = toolCalls
 	choices = append(choices, choice)
 
 	// Build usage information

--- a/internal/providers/anthropic/provider_test.go
+++ b/internal/providers/anthropic/provider_test.go
@@ -1,16 +1,19 @@
 package anthropic
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
 )
 
 func TestAnthropicProvider_GetProviderName(t *testing.T) {
 	provider := createTestProvider(t)
-	
+
 	name := provider.GetProviderName()
 	if name != "anthropic" {
 		t.Errorf("Expected provider name 'anthropic', got %s", name)
@@ -19,43 +22,43 @@ func TestAnthropicProvider_GetProviderName(t *testing.T) {
 
 func TestAnthropicProvider_GetCapabilities(t *testing.T) {
 	provider := createTestProvider(t)
-	
+
 	caps := provider.GetCapabilities()
-	
+
 	// Test basic capabilities
 	if caps.ProviderName != "anthropic" {
 		t.Errorf("Expected provider name 'anthropic', got %s", caps.ProviderName)
 	}
-	
+
 	if !caps.SupportsFunctions {
 		t.Error("Anthropic should support functions (tool use)")
 	}
-	
+
 	if caps.SupportsParallelFunctions {
 		t.Error("Anthropic should not support parallel functions")
 	}
-	
+
 	if !caps.SupportsVision {
 		t.Error("Anthropic should support vision")
 	}
-	
+
 	if !caps.SupportsStreaming {
 		t.Error("Anthropic should support streaming")
 	}
-	
+
 	if caps.SupportsStructuredOutput {
 		t.Error("Anthropic should not support structured output (no JSON schema mode)")
 	}
-	
+
 	if caps.AnthropicSpecific == nil {
 		t.Error("Anthropic specific capabilities should not be nil")
 	}
-	
+
 	// Test Anthropic-specific capabilities
 	if !caps.AnthropicSpecific.SupportsSystemMessages {
 		t.Error("Anthropic should support system messages")
 	}
-	
+
 	if !caps.AnthropicSpecific.SupportsToolUse {
 		t.Error("Anthropic should support tool use")
 	}
@@ -63,10 +66,10 @@ func TestAnthropicProvider_GetCapabilities(t *testing.T) {
 
 func TestAnthropicProvider_EstimateCost(t *testing.T) {
 	provider := createTestProvider(t)
-	
+
 	tests := []struct {
-		name           string
-		request        *types.ChatRequest
+		name            string
+		request         *types.ChatRequest
 		expectedMinCost float64
 	}{
 		{
@@ -93,22 +96,22 @@ func TestAnthropicProvider_EstimateCost(t *testing.T) {
 			expectedMinCost: 0.0,
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			estimate, err := provider.EstimateCost(tt.request)
 			if err != nil {
 				t.Fatalf("EstimateCost failed: %v", err)
 			}
-			
+
 			if estimate.TotalCost <= tt.expectedMinCost {
 				t.Errorf("Expected cost > %f, got %f", tt.expectedMinCost, estimate.TotalCost)
 			}
-			
+
 			if estimate.InputTokens <= 0 {
 				t.Error("Input tokens should be > 0")
 			}
-			
+
 			if estimate.OutputTokens != *tt.request.MaxTokens {
 				t.Errorf("Expected output tokens %d, got %d", *tt.request.MaxTokens, estimate.OutputTokens)
 			}
@@ -118,7 +121,7 @@ func TestAnthropicProvider_EstimateCost(t *testing.T) {
 
 func TestAnthropicProvider_ConvertRequest(t *testing.T) {
 	provider := createTestProvider(t)
-	
+
 	tests := []struct {
 		name    string
 		request *types.ChatRequest
@@ -181,7 +184,7 @@ func TestAnthropicProvider_ConvertRequest(t *testing.T) {
 			wantErr: true, // System messages must be text only
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req, err := provider.convertToAnthropicRequest(tt.request)
@@ -189,7 +192,7 @@ func TestAnthropicProvider_ConvertRequest(t *testing.T) {
 				t.Errorf("convertToAnthropicRequest() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			
+
 			if !tt.wantErr && req == nil {
 				t.Error("Expected non-nil request")
 			}
@@ -197,43 +200,185 @@ func TestAnthropicProvider_ConvertRequest(t *testing.T) {
 	}
 }
 
+// Regression: the OpenAI→Anthropic tool conversion used to send an empty
+// input_schema, which Anthropic rejects with
+// "tools.0.custom.input_schema: Field required". The schema's properties +
+// required must survive the translation.
+func TestAnthropicProvider_ToolInputSchemaCarriesThrough(t *testing.T) {
+	provider := createTestProvider(t)
+	req := &types.ChatRequest{
+		Model:    "claude-3-5-sonnet-20241022",
+		Messages: []types.Message{{Role: "user", Content: "What's the weather in SF?"}},
+		Tools: []types.Tool{{
+			Type: "function",
+			Function: types.Function{
+				Name:        "get_weather",
+				Description: "Get current weather",
+				Parameters: map[string]interface{}{
+					"type": "object",
+					"properties": map[string]interface{}{
+						"location": map[string]interface{}{"type": "string"},
+					},
+					"required": []interface{}{"location"},
+				},
+			},
+		}},
+	}
+
+	got, err := provider.convertToAnthropicRequest(req)
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest: %v", err)
+	}
+	if len(got.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(got.Tools))
+	}
+
+	// Marshal the tool the way the SDK sends it on the wire and assert the
+	// schema is present and populated (not the old empty {}).
+	b, err := json.Marshal(got.Tools[0])
+	if err != nil {
+		t.Fatalf("marshal tool: %v", err)
+	}
+	js := string(b)
+	for _, want := range []string{`"input_schema"`, `"type":"object"`, `"properties"`, `"location"`, `"required"`} {
+		if !strings.Contains(js, want) {
+			t.Errorf("tool JSON missing %s:\n%s", want, js)
+		}
+	}
+}
+
+// A tool with nil/empty parameters must still get a valid object schema so
+// input_schema is never omitted.
+func TestAnthropicProvider_ToolEmptyParamsStillValid(t *testing.T) {
+	schema := toAnthropicInputSchema(nil)
+	b, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	js := string(b)
+	if !strings.Contains(js, `"type":"object"`) || !strings.Contains(js, `"properties"`) {
+		t.Errorf("empty-params schema must still be a valid object: %s", js)
+	}
+}
+
+// The response converter must surface Anthropic tool_use blocks as OpenAI
+// tool_calls (with the input as the arguments JSON) and normalize
+// stop_reason=tool_use → finish_reason=tool_calls.
+func TestAnthropicProvider_ResponseToolUseExtraction(t *testing.T) {
+	provider := createTestProvider(t)
+	resp := &anthropic.Message{
+		ID:         "msg_1",
+		Model:      "claude-haiku-4-5-20251001",
+		StopReason: anthropic.StopReasonToolUse,
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "Let me check."},
+			{Type: "tool_use", ID: "toolu_42", Name: "get_weather", Input: json.RawMessage(`{"location":"SF"}`)},
+		},
+	}
+	got := provider.convertFromAnthropicResponse(resp, &types.ChatRequest{})
+	if len(got.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(got.Choices))
+	}
+	ch := got.Choices[0]
+	if ch.FinishReason != "tool_calls" {
+		t.Errorf("finish_reason = %q, want tool_calls", ch.FinishReason)
+	}
+	if len(ch.Message.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool_call, got %d", len(ch.Message.ToolCalls))
+	}
+	tc := ch.Message.ToolCalls[0]
+	if tc.ID != "toolu_42" || tc.Type != "function" || tc.Function.Name != "get_weather" {
+		t.Errorf("tool_call not mapped: %+v", tc)
+	}
+	if !strings.Contains(tc.Function.Arguments, `"location":"SF"`) {
+		t.Errorf("arguments not carried: %q", tc.Function.Arguments)
+	}
+	if ch.Message.Content != "Let me check." {
+		t.Errorf("text content lost: %q", ch.Message.Content)
+	}
+}
+
+func TestAnthropicProvider_FinishReasonNormalization(t *testing.T) {
+	provider := createTestProvider(t)
+	cases := map[anthropic.StopReason]string{
+		anthropic.StopReasonEndTurn:   "stop",
+		anthropic.StopReasonMaxTokens: "length",
+		anthropic.StopReasonToolUse:   "tool_calls",
+	}
+	for sr, want := range cases {
+		got := provider.convertFromAnthropicResponse(&anthropic.Message{StopReason: sr}, &types.ChatRequest{})
+		if got.Choices[0].FinishReason != want {
+			t.Errorf("stop_reason %q → %q, want %q", sr, got.Choices[0].FinishReason, want)
+		}
+	}
+}
+
+// A multi-turn tool loop (assistant tool_calls + role=tool result) must convert
+// without error — previously these collapsed to empty text and broke the loop.
+func TestAnthropicProvider_MultiTurnToolMessagesConvert(t *testing.T) {
+	provider := createTestProvider(t)
+	req := &types.ChatRequest{
+		Model: "claude-haiku-4-5-20251001",
+		Messages: []types.Message{
+			{Role: "user", Content: "Weather in SF?"},
+			{Role: "assistant", ToolCalls: []types.ToolCall{
+				{ID: "toolu_1", Type: "function", Function: types.Function{Name: "get_weather", Arguments: `{"location":"SF"}`}},
+			}},
+			{Role: "tool", ToolCallID: "toolu_1", Content: "62F and foggy"},
+			{Role: "user", Content: "Thanks."},
+		},
+	}
+	got, err := provider.convertToAnthropicRequest(req)
+	if err != nil {
+		t.Fatalf("convertToAnthropicRequest: %v", err)
+	}
+	// 4 messages in → 4 Anthropic messages out (none dropped).
+	if len(got.Messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(got.Messages))
+	}
+	// The whole thing must marshal (tool_use + tool_result blocks well-formed).
+	if _, err := json.Marshal(got.Messages); err != nil {
+		t.Errorf("messages do not marshal: %v", err)
+	}
+}
+
 func TestAnthropicProvider_Interfaces(t *testing.T) {
 	provider := createTestProvider(t)
-	
+
 	// Test FunctionCallingProvider interface
 	if !provider.SupportsFunctionCalling() {
 		t.Error("Anthropic should support function calling (tool use)")
 	}
-	
+
 	if provider.SupportsParallelFunctions() {
 		t.Error("Anthropic should not support parallel functions")
 	}
-	
+
 	// Test VisionProvider interface
 	if !provider.SupportsVision() {
 		t.Error("Anthropic should support vision")
 	}
-	
+
 	formats := provider.GetSupportedImageFormats()
 	expectedFormats := []string{"png", "jpeg", "webp", "gif"}
 	if len(formats) != len(expectedFormats) {
 		t.Errorf("Expected %d image formats, got %d", len(expectedFormats), len(formats))
 	}
-	
+
 	// Test StructuredOutputProvider interface
 	if provider.SupportsStructuredOutput() {
 		t.Error("Anthropic should not support structured output")
 	}
-	
+
 	if provider.SupportsStrictMode() {
 		t.Error("Anthropic should not support strict mode")
 	}
-	
+
 	// Test BatchProvider interface
 	if provider.SupportsBatch() {
 		t.Error("Anthropic should not support batch processing yet")
 	}
-	
+
 	// Test AssistantProvider interface
 	if provider.SupportsAssistants() {
 		t.Error("Anthropic should not support assistants API")
@@ -242,7 +387,7 @@ func TestAnthropicProvider_Interfaces(t *testing.T) {
 
 func TestAnthropicProvider_TokenEstimation(t *testing.T) {
 	provider := createTestProvider(t)
-	
+
 	tests := []struct {
 		name              string
 		request           *types.ChatRequest
@@ -282,7 +427,7 @@ func TestAnthropicProvider_TokenEstimation(t *testing.T) {
 			minExpectedTokens: 400, // Images add ~1500 chars = ~400+ tokens
 		},
 	}
-	
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tokens := provider.estimateTokens(tt.request)
@@ -297,30 +442,30 @@ func TestAnthropicProvider_TokenEstimation(t *testing.T) {
 func createTestProvider(t *testing.T) *AnthropicProvider {
 	logger := logrus.New()
 	logger.SetLevel(logrus.WarnLevel)
-	
+
 	config := &AnthropicConfig{
 		APIKey: "test-api-key",
 		Models: []types.ModelInfo{
 			{
-				Name:              "claude-3-haiku-20240307",
-				ProviderModelID:   "claude-3-haiku-20240307",
-				InputCostPer1K:    0.00025,
-				OutputCostPer1K:   0.00125,
-				MaxContextWindow:  200000,
-				MaxOutputTokens:   4096,
+				Name:             "claude-3-haiku-20240307",
+				ProviderModelID:  "claude-3-haiku-20240307",
+				InputCostPer1K:   0.00025,
+				OutputCostPer1K:  0.00125,
+				MaxContextWindow: 200000,
+				MaxOutputTokens:  4096,
 			},
 			{
-				Name:              "claude-3-5-sonnet-20241022",
-				ProviderModelID:   "claude-3-5-sonnet-20241022",
-				InputCostPer1K:    0.003,
-				OutputCostPer1K:   0.015,
-				MaxContextWindow:  200000,
-				MaxOutputTokens:   8192,
+				Name:             "claude-3-5-sonnet-20241022",
+				ProviderModelID:  "claude-3-5-sonnet-20241022",
+				InputCostPer1K:   0.003,
+				OutputCostPer1K:  0.015,
+				MaxContextWindow: 200000,
+				MaxOutputTokens:  8192,
 			},
 		},
 		Timeout: 30 * time.Second,
 	}
-	
+
 	return NewAnthropicProvider(config, logger)
 }
 
@@ -338,7 +483,7 @@ func BenchmarkAnthropicProvider_EstimateCost(b *testing.B) {
 		},
 		MaxTokens: intPtr(100),
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = provider.EstimateCost(req)
@@ -353,7 +498,7 @@ func BenchmarkAnthropicProvider_ConvertRequest(b *testing.B) {
 			{Role: "user", Content: "Hello"},
 		},
 	}
-	
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		_, _ = provider.convertToAnthropicRequest(req)


### PR DESCRIPTION
The OpenAI→Anthropic provider had a broken tool path on **every** side. Fixed all four:

1. **Request `input_schema` dropped** — the converter always sent an empty `anthropic.ToolInputSchemaParam{}`, so Anthropic 400'd with `tools.0.custom.input_schema: Field required`. Now `toAnthropicInputSchema` translates the JSON-Schema `properties`/`required` across (valid empty-object fallback so the field is never omitted).
2. **Response `tool_use` blocks dropped** — `convertFromAnthropicResponse` extracted only text blocks, so `finish_reason=tool_use` came back with **empty `tool_calls`**. Now maps `tool_use` → OpenAI `tool_calls` (id/name/arguments from the block's `Input`).
3. **`finish_reason` not normalized** — now `end_turn`→`stop`, `max_tokens`→`length`, `tool_use`→`tool_calls`, so OpenAI-compatible clients and the linked-tier served-tool detection work.
4. **Multi-turn loop broken** — `convertMessage` ignored assistant `tool_calls` and `role=tool` results (collapsed to empty text). Now emits Anthropic `tool_use` blocks (assistant) and user-side `tool_result` blocks (role=tool), so sending results back continues the loop.

### Verified live
claude-haiku-4-5, 2-step loop through the gateway:
- step1 → `finish_reason=tool_calls`, `get_weather(location="San Francisco")`
- step2 (tool result echoed) → `finish_reason=stop`, answer incorporating "62°F and foggy"

Unblocks linked-tier (C2a) verification on Anthropic models, which previously needed gpt-4o-mini as a workaround. New unit tests cover schema carry-through, empty-params validity, response tool_use extraction, finish_reason normalization, and multi-turn message conversion. Deployed `tas-llm-router:aiqg-v5.31`.

**Known remaining gap (separate follow-up):** streaming responses don't assemble `tool_use` deltas into `tool_calls` (non-streaming only) — mirrors the C2a served-tool capture limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)