### PR TITLE
feat(experiments): Phase D 2a — gateway resolver, assignment, event stamping

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -34,12 +34,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/tributary-ai/llm-router-waf/internal/instrumentation"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/experiments"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/linkage"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
@@ -92,6 +95,12 @@ type AIQGConfig struct {
 	// index, docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §A). Nil disables linkage —
 	// events emit without step/parent topology, same as pre-C2a behavior.
 	Linkage linkage.Store
+
+	// Experiments resolves the experiment + variant that claims a request
+	// (Phase D, docs/AIQG-EXPERIMENTS-RUNNER.md). Nil disables experiments —
+	// no assignment, no stamping. dry_run/running experiments get stamped on
+	// the event; the routing override (running) is applied separately.
+	Experiments *experiments.Resolver
 }
 
 // NewAIQG returns the middleware constructor. The returned handler is a
@@ -245,6 +254,13 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 		// the request context may already be cancelled in this deferred path.
 		lk := resolveLinkage(cfg, parsed, routing, resolvedToken, respEventID)
 
+		// Experiment attribution (Phase D): assign this request to a variant if
+		// an experiment's cohort claims it, and stamp experiment_id/variant on
+		// the event. dry_run assigns + stamps only; running's override is
+		// applied at routing time (Phase 2b) — this deferred resolution is
+		// deterministic, so it matches the request-time decision.
+		expDecision := resolveExperiment(cfg, parsed, routing, resolvedToken, r, respEventID)
+
 		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
 			HTTPStatus:      sw.status(),
 			Region:          cfg.Region,
@@ -256,6 +272,8 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 				BundleName: bundleResolution.BundleName,
 				Source:     bundleResolution.Source,
 			},
+			ExperimentID:      expDecision.ExperimentID,
+			ExperimentVariant: expDecision.Variant,
 		})
 		if err := emitter.Emit(ctx, reqEnv, respEnv); err != nil {
 			cfg.Logger.WithError(err).Warn("AIQG event emission failed")
@@ -357,6 +375,71 @@ func resolveLinkage(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *t
 		}
 	}
 	return lk
+}
+
+// resolveExperiment assigns the request to an experiment variant if one's
+// cohort claims it (Phase D). Returns a zero Decision when experiments are
+// disabled or none claim the request — the event then carries no
+// experiment_id/variant. The sticky key is built from the same identity ladder
+// the attribution tiers use, so a user stays in one variant across a flow.
+// Best-effort: never fails the request.
+func resolveExperiment(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *tokens.Token, r *http.Request, respEventID string) experiments.Decision {
+	if cfg.Experiments == nil || tok == nil || routing == nil {
+		return experiments.Decision{}
+	}
+	rs := routing.Snapshot()
+	principal := tok.SourceApp
+	if principal == "" {
+		principal = tok.TokenID
+	}
+	flowID := parsed.FlowID
+	if flowID == "" {
+		flowID = parsed.TraceID
+	}
+	convID := parsed.ConversationID
+	if convID == "" {
+		convID = parsed.Baggage["session.id"]
+	}
+	id := experiments.Identity{
+		UserID:         parsed.Baggage["user.id"],
+		ConversationID: convID,
+		FlowID:         flowID,
+		PrincipalID:    principal,
+		ClientIP:       experimentClientIP(r),
+		RequestID:      respEventID, // always present — the random sticky-key fallback
+	}
+	sourceApp := parsed.SourceApp
+	if sourceApp == "" {
+		sourceApp = tok.SourceApp
+	}
+	attrs := experiments.ReqAttrs{
+		SourceApp:    sourceApp,
+		Model:        rs.Model,
+		WorkflowType: rs.Workflow,
+		Path:         r.URL.Path,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if d := cfg.Experiments.Resolve(ctx, tok.TenantID, id, attrs); d != nil {
+		return *d
+	}
+	return experiments.Decision{}
+}
+
+// experimentClientIP extracts a stable client IP for the assignment key —
+// first X-Forwarded-For hop, else RemoteAddr host. Hashing input only; not
+// stored.
+func experimentClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		if i := strings.IndexByte(xff, ','); i >= 0 {
+			return strings.TrimSpace(xff[:i])
+		}
+		return strings.TrimSpace(xff)
+	}
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }
 
 // headersView projects an AIQGHeaders into the read-only view the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/types"
 	"github.com/tributary-ai/llm-router-waf/internal/workflow"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/experiments"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/linkage"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
@@ -285,6 +286,18 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			}
 		}
 
+		// Experiments runner resolver (Phase D). Reuses the dashboard URL +
+		// internal auth token; loads each tenant's active (dry_run+running)
+		// experiments on a TTL cache and assigns requests to variants. Nil
+		// when the dashboard isn't configured — no assignment, no stamping.
+		var experimentResolver *experiments.Resolver
+		if config.AIQG.DashboardURL != "" && config.AIQG.DashboardInternalAuthToken != "" {
+			loader := experiments.NewHTTPLoader(config.AIQG.DashboardURL, config.AIQG.DashboardInternalAuthToken)
+			experimentResolver = experiments.NewResolver(loader, 0) // 0 = 30s TTL default
+			logger.WithField("dashboard_url", config.AIQG.DashboardURL).
+				Info("AIQG experiments resolver enabled (Phase D)")
+		}
+
 		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{
 			Strict:         config.AIQG.Strict,
 			Logger:         logger,
@@ -294,6 +307,7 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			Resolver:       resolver,
 			PolicyResolver: policyResolver,
 			Linkage:        linkageStore,
+			Experiments:    experimentResolver,
 		})
 		logger.WithFields(logrus.Fields{
 			"strict":           config.AIQG.Strict,

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -150,6 +150,11 @@ type BuildOptions struct {
 	// Linkage is the resolved `linked`-tier flow/step topology for this
 	// request (the middleware resolves it via pkg/aiqg/linkage before Build).
 	Linkage Linkage
+
+	// ExperimentID + ExperimentVariant stamp the experiment that claimed this
+	// request (Phase D). Empty for untouched traffic.
+	ExperimentID      string
+	ExperimentVariant string
 }
 
 // Build constructs the paired (RequestEnvelope, ResponseEnvelope) from
@@ -477,6 +482,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		Model:                routing.Model,                                         // ditto — powers per-vendor/model dashboards off the response stream
 		Workflow:             preferredWorkflow(headers.Workflow, routing.Workflow), // ditto — carries the workflow_type dimension on the response stream
 		SourceApp:            sourceApp,                                             // ditto — carries the source_app dimension on the response stream
+		ExperimentID:         opts.ExperimentID,                                     // Phase D — experiment that claimed this request (per-variant rollup key)
+		ExperimentVariant:    opts.ExperimentVariant,
 		CompleteAt:           completeAt,
 		Status:               status,
 		HTTPStatus:           opts.HTTPStatus,

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -144,6 +144,12 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		"model":   resp.Data.Model,
 		"payload": string(respJSON),
 	}
+	// Experiment attribution (Phase D) — promote so dashboards/Loki can slice
+	// per-variant directly; empty (omitted) for traffic no experiment claimed.
+	if resp.Data.ExperimentID != "" {
+		respFields["experiment_id"] = resp.Data.ExperimentID
+		respFields["experiment_variant"] = resp.Data.ExperimentVariant
+	}
 	// Token accounting — nil-safe; either fully populated or omitted.
 	if ta := resp.Data.TokenAccounting; ta != nil {
 		respFields["prompt_tokens"] = ta.PromptTokens

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -174,6 +174,12 @@ type ResponseEvent struct {
 	Workflow  string `json:"workflow,omitempty"`   // CLEAR workflow_type — denormalized so the response stream carries the type dimension for per-type rollups (TimescaleDB)
 	SourceApp string `json:"source_app,omitempty"` // calling app — denormalized like vendor/model/workflow so the response stream carries the source dimension
 
+	// Experiment attribution (Phase D). Set when an experiment claimed this
+	// request (dry_run or running); the Spark scope_type='experiment_variant'
+	// rollup keys per-variant metrics off these. Empty for untouched traffic.
+	ExperimentID      string `json:"experiment_id,omitempty"`
+	ExperimentVariant string `json:"experiment_variant,omitempty"`
+
 	// Outcome
 	CompleteAt      time.Time `json:"complete_at"`
 	Status          string    `json:"status"` // success | vendor_error | gateway_error | policy_blocked | client_disconnect | timeout

--- a/pkg/aiqg/experiments/experiments.go
+++ b/pkg/aiqg/experiments/experiments.go
@@ -1,0 +1,332 @@
+// Package experiments implements the gateway side of the AIQG Experiments
+// runner (docs/AIQG-EXPERIMENTS-RUNNER.md): it loads a tenant's active
+// experiments from aiqg-dashboard-be, matches a request against each cohort,
+// and deterministically assigns it to a variant. Assignment is sticky (same
+// identity → same variant) and respects max_traffic_pct.
+//
+// dry_run experiments only get ASSIGNED + stamped on the event (no routing
+// change); running experiments additionally carry an Override the router
+// applies (Phase 2b). Resolution never fails a request — any error degrades to
+// "no assignment" (route normally), mirroring the policy resolver.
+package experiments
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Lifecycle states the gateway acts on. Others are never returned by the
+// cache-load endpoint.
+const (
+	StatusDryRun  = "dry_run"
+	StatusRunning = "running"
+)
+
+// Variant is one arm. key="control" is the baseline (empty Override).
+type Variant struct {
+	Key      string          `json:"key"`
+	Weight   int             `json:"weight"`
+	Override json.RawMessage `json:"override,omitempty"`
+}
+
+// Cohort is the eligibility matcher. Empty fields match anything; non-empty
+// lists are OR-within / AND-across (a request must satisfy every set field).
+type Cohort struct {
+	URLPath      string   `json:"url_path,omitempty"`
+	SourceApp    []string `json:"source_app,omitempty"`
+	Model        []string `json:"model,omitempty"`
+	WorkflowType []string `json:"workflow_type,omitempty"`
+}
+
+// Assignment controls the sticky key + decorrelation salt.
+type Assignment struct {
+	KeySource string `json:"key_source,omitempty"` // conversation|user|flow|principal|ip|request
+	Salt      string `json:"salt,omitempty"`
+}
+
+// Guardrails — only the fields the gateway enforces inline. max_traffic_pct
+// caps the eligible share; the rest of a matched cohort is left untouched.
+type Guardrails struct {
+	MaxTrafficPct *int `json:"max_traffic_pct,omitempty"`
+}
+
+// Experiment mirrors the aiqg-dashboard-be /internal/experiments payload. The
+// JSONB config blocks deserialize straight into the typed sub-structs.
+type Experiment struct {
+	ID         string     `json:"id"`
+	TenantID   string     `json:"tenant_id"`
+	Status     string     `json:"status"`
+	Cohort     Cohort     `json:"cohort"`
+	Assignment Assignment `json:"assignment"`
+	Guardrails Guardrails `json:"guardrails"`
+	Variants   []Variant  `json:"variants"`
+	StartsAt   *time.Time `json:"starts_at,omitempty"`
+	EndsAt     *time.Time `json:"ends_at,omitempty"`
+}
+
+// Identity is the sticky-key ladder for a request. RequestID is the always-
+// present random fallback (so an un-instrumented caller still gets a clean,
+// if non-sticky, split).
+type Identity struct {
+	UserID         string
+	ConversationID string
+	FlowID         string
+	PrincipalID    string
+	ClientIP       string
+	RequestID      string
+}
+
+// ReqAttrs are the request attributes a cohort matches on.
+type ReqAttrs struct {
+	SourceApp    string
+	Model        string
+	WorkflowType string
+	Path         string
+}
+
+// Decision is the assignment outcome. Apply is true only for running
+// experiments (dry_run assigns + stamps but the router ignores Override).
+type Decision struct {
+	ExperimentID string
+	Variant      string
+	Override     json.RawMessage
+	Apply        bool
+}
+
+// key picks the sticky key per Assignment.KeySource, falling down the ladder to
+// RequestID when the chosen source is empty.
+func (a Assignment) key(id Identity) string {
+	ladder := []string{id.ConversationID, id.UserID, id.FlowID, id.PrincipalID, id.ClientIP, id.RequestID}
+	switch a.KeySource {
+	case "user":
+		ladder = []string{id.UserID, id.ConversationID, id.FlowID, id.PrincipalID, id.ClientIP, id.RequestID}
+	case "flow":
+		ladder = []string{id.FlowID, id.ConversationID, id.UserID, id.PrincipalID, id.ClientIP, id.RequestID}
+	case "principal":
+		ladder = []string{id.PrincipalID, id.ClientIP, id.RequestID}
+	case "ip":
+		ladder = []string{id.ClientIP, id.RequestID}
+	case "request":
+		ladder = []string{id.RequestID}
+	}
+	for _, k := range ladder {
+		if k != "" {
+			return k
+		}
+	}
+	return id.RequestID
+}
+
+// bucket maps (experiment, salt, key) to a stable 0..9999 bucket.
+func bucket(expID, salt, key string) int {
+	h := crc32.ChecksumIEEE([]byte(expID + ":" + salt + ":" + key))
+	return int(h % 10000)
+}
+
+func containsFold(list []string, v string) bool {
+	for _, x := range list {
+		if strings.EqualFold(x, v) {
+			return true
+		}
+	}
+	return false
+}
+
+// matches reports cohort eligibility. URLPath uses substring containment (a
+// conservative stand-in for the route-rule regex; over-matches rather than
+// under-matches, consistent with the collision-detection bias).
+func (c Cohort) matches(a ReqAttrs) bool {
+	if len(c.SourceApp) > 0 && !containsFold(c.SourceApp, a.SourceApp) {
+		return false
+	}
+	if len(c.Model) > 0 && !containsFold(c.Model, a.Model) {
+		return false
+	}
+	if len(c.WorkflowType) > 0 && !containsFold(c.WorkflowType, a.WorkflowType) {
+		return false
+	}
+	if c.URLPath != "" && !strings.Contains(a.Path, c.URLPath) {
+		return false
+	}
+	return true
+}
+
+// withinSchedule reports whether now is inside [StartsAt, EndsAt] (open ends
+// when unset).
+func (e Experiment) withinSchedule(now time.Time) bool {
+	if e.StartsAt != nil && now.Before(*e.StartsAt) {
+		return false
+	}
+	if e.EndsAt != nil && now.After(*e.EndsAt) {
+		return false
+	}
+	return true
+}
+
+// assign deterministically maps an identity to a variant within the eligible
+// band, or returns nil when the bucket falls outside max_traffic_pct
+// ("untouched" — route normally, no stamping). Weights split the eligible band
+// (so a 50/50 capped at 10% = 5% control-arm / 5% variant / 90% untouched).
+func (e Experiment) assign(id Identity) *Decision {
+	if len(e.Variants) == 0 {
+		return nil
+	}
+	maxPct := 100
+	if e.Guardrails.MaxTrafficPct != nil {
+		maxPct = *e.Guardrails.MaxTrafficPct
+	}
+	if maxPct <= 0 {
+		return nil
+	}
+	if maxPct > 100 {
+		maxPct = 100
+	}
+	b := bucket(e.ID, e.Assignment.Salt, e.Assignment.key(id))
+	band := maxPct * 100 // eligible bucket count out of 10000
+	if b >= band {
+		return nil // untouched
+	}
+	pos := b * 10000 / band // rescale into 0..9999 across the eligible band
+	cum := 0
+	for _, v := range e.Variants {
+		cum += v.Weight * 100
+		if pos < cum {
+			return &Decision{ExperimentID: e.ID, Variant: v.Key, Override: v.Override}
+		}
+	}
+	last := e.Variants[len(e.Variants)-1]
+	return &Decision{ExperimentID: e.ID, Variant: last.Key, Override: last.Override}
+}
+
+// Loader fetches a tenant's active (dry_run+running) experiments. The HTTP
+// implementation hits aiqg-dashboard-be; tests inject a fake.
+type Loader interface {
+	ActiveForTenant(ctx context.Context, tenantID string) ([]Experiment, error)
+}
+
+// Resolver caches each tenant's active experiments (TTL) and assigns requests.
+// Cache bounds dashboard load + worst-case staleness on edits.
+type Resolver struct {
+	loader Loader
+	ttl    time.Duration
+	mu     sync.Mutex
+	cache  map[string]cacheEntry
+	now    func() time.Time // injectable for tests
+}
+
+type cacheEntry struct {
+	experiments []Experiment
+	expiresAt   time.Time
+}
+
+// NewResolver wraps a Loader with a TTL cache. ttl<=0 defaults to 30s (the
+// kill-switch propagation target in §7).
+func NewResolver(loader Loader, ttl time.Duration) *Resolver {
+	if ttl <= 0 {
+		ttl = 30 * time.Second
+	}
+	return &Resolver{loader: loader, ttl: ttl, cache: map[string]cacheEntry{}, now: time.Now}
+}
+
+func (r *Resolver) active(ctx context.Context, tenantID string) []Experiment {
+	now := r.now()
+	r.mu.Lock()
+	if e, ok := r.cache[tenantID]; ok && now.Before(e.expiresAt) {
+		exps := e.experiments
+		r.mu.Unlock()
+		return exps
+	}
+	r.mu.Unlock()
+
+	exps, err := r.loader.ActiveForTenant(ctx, tenantID)
+	if err != nil {
+		// Degrade: serve any stale cache, else no experiments. Never fail.
+		r.mu.Lock()
+		stale := r.cache[tenantID].experiments
+		r.mu.Unlock()
+		return stale
+	}
+	r.mu.Lock()
+	r.cache[tenantID] = cacheEntry{experiments: exps, expiresAt: now.Add(r.ttl)}
+	r.mu.Unlock()
+	return exps
+}
+
+// Resolve returns the variant decision for a request, or nil when no
+// experiment claims it. v1 collision rule: the first matching cohort (by
+// dashboard order = created_at) claims the request and it participates in that
+// one only — claim-on-match, so a matched-but-untouched bucket still leaves
+// other experiments' pools (returns nil = route normally).
+func (r *Resolver) Resolve(ctx context.Context, tenantID string, id Identity, attrs ReqAttrs) *Decision {
+	if r == nil {
+		return nil
+	}
+	now := r.now()
+	for _, e := range r.active(ctx, tenantID) {
+		if e.Status != StatusDryRun && e.Status != StatusRunning {
+			continue
+		}
+		if !e.withinSchedule(now) {
+			continue
+		}
+		if !e.Cohort.matches(attrs) {
+			continue
+		}
+		// Cohort matched — this experiment claims the request.
+		d := e.assign(id)
+		if d == nil {
+			return nil // claimed but in the untouched band
+		}
+		d.Apply = e.Status == StatusRunning
+		return d
+	}
+	return nil
+}
+
+// HTTPLoader loads experiments from aiqg-dashboard-be's internal cache endpoint.
+type HTTPLoader struct {
+	HTTP              *http.Client
+	BaseURL           string
+	InternalAuthToken string
+}
+
+// NewHTTPLoader builds a loader against the dashboard. Reuses the same base URL
+// + Internal-Auth token as the policy resolver.
+func NewHTTPLoader(baseURL, internalAuthToken string) *HTTPLoader {
+	return &HTTPLoader{
+		HTTP:              &http.Client{Timeout: 2 * time.Second},
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		InternalAuthToken: internalAuthToken,
+	}
+}
+
+func (l *HTTPLoader) ActiveForTenant(ctx context.Context, tenantID string) ([]Experiment, error) {
+	url := l.BaseURL + "/internal/experiments?tenant=" + tenantID
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Internal-Auth", l.InternalAuthToken)
+	resp, err := l.HTTP.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("experiments load: status %d", resp.StatusCode)
+	}
+	var body struct {
+		Experiments []Experiment `json:"experiments"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return nil, err
+	}
+	return body.Experiments, nil
+}

--- a/pkg/aiqg/experiments/experiments_test.go
+++ b/pkg/aiqg/experiments/experiments_test.go
@@ -1,0 +1,188 @@
+package experiments
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func ptr(i int) *int { return &i }
+
+func twoArm(maxPct int) Experiment {
+	e := Experiment{
+		ID:       "exp-1",
+		Status:   StatusRunning,
+		Variants: []Variant{{Key: "control", Weight: 50}, {Key: "b", Weight: 50, Override: json.RawMessage(`{"model":"gpt-4o-mini"}`)}},
+	}
+	if maxPct > 0 {
+		e.Guardrails.MaxTrafficPct = ptr(maxPct)
+	}
+	return e
+}
+
+func TestAssign_DeterministicAndSticky(t *testing.T) {
+	e := twoArm(100)
+	id := Identity{ConversationID: "conv-42"}
+	d1 := e.assign(id)
+	d2 := e.assign(id)
+	if d1 == nil || d2 == nil {
+		t.Fatal("expected assignment at 100% traffic")
+	}
+	if d1.Variant != d2.Variant {
+		t.Errorf("same identity must be sticky: %s vs %s", d1.Variant, d2.Variant)
+	}
+	if d1.ExperimentID != "exp-1" {
+		t.Errorf("experiment id not set: %+v", d1)
+	}
+}
+
+func TestAssign_SplitIsRoughly5050(t *testing.T) {
+	e := twoArm(100)
+	control, variant := 0, 0
+	for i := 0; i < 10000; i++ {
+		d := e.assign(Identity{ConversationID: "user-" + itoa(i)})
+		if d == nil {
+			t.Fatal("no assignment at 100%")
+		}
+		if d.Variant == "control" {
+			control++
+		} else {
+			variant++
+		}
+	}
+	// Allow generous slack; just prove it's a real split, not all-one-arm.
+	if control < 4000 || control > 6000 {
+		t.Errorf("control share off: control=%d variant=%d", control, variant)
+	}
+}
+
+func TestAssign_MaxTrafficPctUntouched(t *testing.T) {
+	e := twoArm(10) // 10% eligible
+	touched := 0
+	for i := 0; i < 10000; i++ {
+		if d := e.assign(Identity{ConversationID: "u-" + itoa(i)}); d != nil {
+			touched++
+		}
+	}
+	// ~10% eligible (allow slack); the rest untouched (nil).
+	if touched < 700 || touched > 1300 {
+		t.Errorf("eligible share off: touched=%d (want ~1000)", touched)
+	}
+}
+
+func TestAssign_ZeroPctNeverAssigns(t *testing.T) {
+	e := twoArm(100)
+	e.Guardrails.MaxTrafficPct = ptr(0)
+	if d := e.assign(Identity{ConversationID: "x"}); d != nil {
+		t.Errorf("0%% traffic must never assign, got %+v", d)
+	}
+}
+
+func TestAssignmentKey_LadderFallback(t *testing.T) {
+	a := Assignment{} // default = conversation-first
+	if got := a.key(Identity{ConversationID: "c", UserID: "u"}); got != "c" {
+		t.Errorf("default key = %q, want conversation", got)
+	}
+	if got := a.key(Identity{UserID: "u", RequestID: "r"}); got != "u" {
+		t.Errorf("ladder fallback to user = %q", got)
+	}
+	if got := a.key(Identity{RequestID: "r"}); got != "r" {
+		t.Errorf("final fallback to request = %q", got)
+	}
+	au := Assignment{KeySource: "user"}
+	if got := au.key(Identity{ConversationID: "c", UserID: "u"}); got != "u" {
+		t.Errorf("key_source=user = %q, want u", got)
+	}
+}
+
+func TestCohortMatches(t *testing.T) {
+	c := Cohort{SourceApp: []string{"checkout"}, WorkflowType: []string{"rag"}}
+	if !c.matches(ReqAttrs{SourceApp: "checkout", WorkflowType: "rag"}) {
+		t.Error("should match")
+	}
+	if c.matches(ReqAttrs{SourceApp: "other", WorkflowType: "rag"}) {
+		t.Error("source_app mismatch should fail")
+	}
+	if c.matches(ReqAttrs{SourceApp: "checkout", WorkflowType: "code_generation"}) {
+		t.Error("workflow mismatch should fail")
+	}
+	// Empty cohort matches anything.
+	if !(Cohort{}).matches(ReqAttrs{SourceApp: "anything"}) {
+		t.Error("empty cohort must match all")
+	}
+}
+
+// fakeLoader returns a fixed list (and counts loads to prove caching).
+type fakeLoader struct {
+	exps  []Experiment
+	loads int
+}
+
+func (f *fakeLoader) ActiveForTenant(_ context.Context, _ string) ([]Experiment, error) {
+	f.loads++
+	return f.exps, nil
+}
+
+func TestResolver_ClaimFirstMatchAndCache(t *testing.T) {
+	// Two overlapping experiments; the first (by list order) claims.
+	expA := twoArm(100)
+	expA.ID = "A"
+	expB := twoArm(100)
+	expB.ID = "B"
+	fl := &fakeLoader{exps: []Experiment{expA, expB}}
+	r := NewResolver(fl, time.Minute)
+
+	d := r.Resolve(context.Background(), "t1", Identity{ConversationID: "c1"}, ReqAttrs{})
+	if d == nil || d.ExperimentID != "A" {
+		t.Fatalf("first experiment should claim, got %+v", d)
+	}
+	if !d.Apply {
+		t.Error("running experiment should have Apply=true")
+	}
+	// Second resolve hits cache (no extra load).
+	r.Resolve(context.Background(), "t1", Identity{ConversationID: "c2"}, ReqAttrs{})
+	if fl.loads != 1 {
+		t.Errorf("expected 1 load (cached), got %d", fl.loads)
+	}
+}
+
+func TestResolver_DryRunNoApply(t *testing.T) {
+	e := twoArm(100)
+	e.Status = StatusDryRun
+	r := NewResolver(&fakeLoader{exps: []Experiment{e}}, time.Minute)
+	d := r.Resolve(context.Background(), "t1", Identity{ConversationID: "c"}, ReqAttrs{})
+	if d == nil {
+		t.Fatal("dry_run should still assign + stamp")
+	}
+	if d.Apply {
+		t.Error("dry_run must NOT apply the override")
+	}
+}
+
+func TestResolver_NilSafe(t *testing.T) {
+	var r *Resolver
+	if d := r.Resolve(context.Background(), "t", Identity{}, ReqAttrs{}); d != nil {
+		t.Error("nil resolver must return nil")
+	}
+}
+
+// tiny int→string to avoid strconv import churn in the table tests
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}


### PR DESCRIPTION
The gateway side of the Experiments runner, in **dry_run posture**: assign a request to a variant and stamp `experiment_id`/`variant` on the event, with **no routing change**. The override application (running) is Phase 2b — and because assignment is deterministic, the request-time decision there matches this one.

### What's here
- **`pkg/aiqg/experiments`** — typed `Experiment`/`Cohort`/`Assignment`/`Guardrails`/`Variant` mirroring the dashboard payload; deterministic **sticky assignment** (crc32 over `experiment+salt+key`; identity-ladder key, conversation default + fallback to a per-request id); **`max_traffic_pct`** band (eligible share split by weight, rest untouched); cohort match on `source_app`/`model`/`workflow_type`/`url_path`; schedule window; `Resolver` with a per-tenant **TTL cache** (30s; serves stale on loader error — never fails a request) + `HTTPLoader` against `/internal/experiments`. v1 **collision rule**: first matching cohort claims.
- **events** — `ResponseEvent.ExperimentID/Variant` + `BuildOptions`; emitter promotes `experiment_id`/`experiment_variant` to the Loki line (and they ride the Kafka envelope for the 2b Spark rollup).
- **middleware** — `AIQGConfig.Experiments` + `resolveExperiment` in the deferred path (identity ladder from baggage/headers/token, ReqAttrs from the routing snapshot). Best-effort, nil-safe.
- **server** — builds the Resolver from the existing dashboard URL + internal auth token (no new config); nil when unset.

### Verified live (aiqg-v5.32)
A dry_run 50/50 experiment (empty cohort) claimed 4 conversation-keyed requests and split them deterministically:
```
conv-aaa → mini      conv-bbb → control
conv-ccc → control   conv-ddd → control
```
`experiment_id` stamped through gateway→Kafka→TS; dry_run left routing unchanged (all still gpt-4o-mini). Unit tests cover assignment determinism/stickiness, the traffic-cap band, 0%/cohort matching, first-match claim + caching, dry_run no-apply, nil-safe. build/vet/tests green `-tags nohs`.

Pairs with aiqg-dashboard-be #51 (CRUD + `/internal/experiments`). Next: Phase 2b (Route() override + guardrails + auto-stop + Spark `scope_type='experiment_variant'` rollup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)