### PR TITLE
feat(experiments): Phase D 2b — apply the variant override (the reroute)

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -238,6 +238,20 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	respEventID := events.NewEventID()
 	w.Header().Set("TAS-Response-Event-Id", respEventID)
 
+	// Experiments (Phase D): stash the resolver + this request's sticky
+	// identity on ctx so the completion handler can resolve the variant at
+	// ROUTING time (when model + workflow are known) — applying a running
+	// experiment's override before Router.Route, and stamping
+	// experiment_id/variant on the routing sidecar for the event.
+	if cfg.Experiments != nil && resolvedToken != nil {
+		ctx = withExperimentResolveCtx(ctx, &experimentResolveCtx{
+			resolver:  cfg.Experiments,
+			tenantID:  resolvedToken.TenantID,
+			id:        experimentIdentity(parsed, resolvedToken, r, respEventID),
+			sourceApp: experimentSourceApp(parsed, resolvedToken),
+		})
+	}
+
 	emitter := cfg.Emitter
 	if emitter == nil {
 		emitter = events.NoopEmitter{}
@@ -254,12 +268,10 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 		// the request context may already be cancelled in this deferred path.
 		lk := resolveLinkage(cfg, parsed, routing, resolvedToken, respEventID)
 
-		// Experiment attribution (Phase D): assign this request to a variant if
-		// an experiment's cohort claims it, and stamp experiment_id/variant on
-		// the event. dry_run assigns + stamps only; running's override is
-		// applied at routing time (Phase 2b) — this deferred resolution is
-		// deterministic, so it matches the request-time decision.
-		expDecision := resolveExperiment(cfg, parsed, routing, resolvedToken, r, respEventID)
+		// Experiment attribution (Phase D): read the variant the completion
+		// handler resolved + stamped at routing time. dry_run stamps only;
+		// running additionally applied the override before Router.Route.
+		expSnap := routing.Snapshot()
 
 		reqEnv, respEnv := events.Build(r, headersView(parsed), routingView(routing), tokenView(resolvedToken), collector.Snapshot(), events.BuildOptions{
 			HTTPStatus:      sw.status(),
@@ -272,8 +284,8 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 				BundleName: bundleResolution.BundleName,
 				Source:     bundleResolution.Source,
 			},
-			ExperimentID:      expDecision.ExperimentID,
-			ExperimentVariant: expDecision.Variant,
+			ExperimentID:      expSnap.ExperimentID,
+			ExperimentVariant: expSnap.ExperimentVariant,
 		})
 		if err := emitter.Emit(ctx, reqEnv, respEnv); err != nil {
 			cfg.Logger.WithError(err).Warn("AIQG event emission failed")
@@ -377,17 +389,51 @@ func resolveLinkage(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *t
 	return lk
 }
 
-// resolveExperiment assigns the request to an experiment variant if one's
-// cohort claims it (Phase D). Returns a zero Decision when experiments are
-// disabled or none claim the request — the event then carries no
-// experiment_id/variant. The sticky key is built from the same identity ladder
-// the attribution tiers use, so a user stays in one variant across a flow.
-// Best-effort: never fails the request.
-func resolveExperiment(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok *tokens.Token, r *http.Request, respEventID string) experiments.Decision {
-	if cfg.Experiments == nil || tok == nil || routing == nil {
-		return experiments.Decision{}
+// experimentResolveCtx carries everything the completion handler needs to
+// resolve the experiment variant at routing time. Stashed on the request
+// context by handleAIQG.
+type experimentResolveCtx struct {
+	resolver  *experiments.Resolver
+	tenantID  string
+	id        experiments.Identity
+	sourceApp string
+}
+
+type experimentCtxKey struct{}
+
+func withExperimentResolveCtx(ctx context.Context, ec *experimentResolveCtx) context.Context {
+	return context.WithValue(ctx, experimentCtxKey{}, ec)
+}
+
+// ResolveExperimentForRouting is called by the chat-completion handler once the
+// model + workflow are known. It resolves the variant claiming this request,
+// stamps experiment_id/variant on the routing sidecar (so the event carries
+// them), and returns the Decision — Apply=true means the caller should apply
+// the variant's override before Router.Route. Returns nil when no experiment
+// is configured/claims the request. Best-effort: never fails the request.
+func ResolveExperimentForRouting(ctx context.Context, model, workflowType, path string) *experiments.Decision {
+	ec, _ := ctx.Value(experimentCtxKey{}).(*experimentResolveCtx)
+	if ec == nil || ec.resolver == nil {
+		return nil
 	}
-	rs := routing.Snapshot()
+	attrs := experiments.ReqAttrs{
+		SourceApp:    ec.sourceApp,
+		Model:        model,
+		WorkflowType: workflowType,
+		Path:         path,
+	}
+	rctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	d := ec.resolver.Resolve(rctx, ec.tenantID, ec.id, attrs)
+	if d != nil {
+		StampExperiment(ctx, d.ExperimentID, d.Variant)
+	}
+	return d
+}
+
+// experimentIdentity builds the sticky-key ladder from the request's parsed
+// headers + token, ending at respEventID (the always-present random fallback).
+func experimentIdentity(parsed AIQGHeaders, tok *tokens.Token, r *http.Request, respEventID string) experiments.Identity {
 	principal := tok.SourceApp
 	if principal == "" {
 		principal = tok.TokenID
@@ -400,30 +446,21 @@ func resolveExperiment(cfg AIQGConfig, parsed AIQGHeaders, routing *Routing, tok
 	if convID == "" {
 		convID = parsed.Baggage["session.id"]
 	}
-	id := experiments.Identity{
+	return experiments.Identity{
 		UserID:         parsed.Baggage["user.id"],
 		ConversationID: convID,
 		FlowID:         flowID,
 		PrincipalID:    principal,
 		ClientIP:       experimentClientIP(r),
-		RequestID:      respEventID, // always present — the random sticky-key fallback
+		RequestID:      respEventID,
 	}
-	sourceApp := parsed.SourceApp
-	if sourceApp == "" {
-		sourceApp = tok.SourceApp
+}
+
+func experimentSourceApp(parsed AIQGHeaders, tok *tokens.Token) string {
+	if parsed.SourceApp != "" {
+		return parsed.SourceApp
 	}
-	attrs := experiments.ReqAttrs{
-		SourceApp:    sourceApp,
-		Model:        rs.Model,
-		WorkflowType: rs.Workflow,
-		Path:         r.URL.Path,
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	if d := cfg.Experiments.Resolve(ctx, tok.TenantID, id, attrs); d != nil {
-		return *d
-	}
-	return experiments.Decision{}
+	return tok.SourceApp
 }
 
 // experimentClientIP extracts a stable client IP for the assignment key —

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -87,6 +87,12 @@ type Routing struct {
 	// carries nothing fingerprintable. Combined with (tenant, principal) by
 	// the events builder to mint the AgentSurrogateID.
 	fingerprint string
+
+	// experiments (Phase D): the experiment + variant that claimed this
+	// request. Stamped at request time (so the routing override + the event
+	// stamp use one decision). Empty when no experiment claimed it.
+	experimentID      string
+	experimentVariant string
 }
 
 // NewRouting returns an empty Routing. Attach to ctx via WithRouting.
@@ -162,6 +168,10 @@ type RoutingSnapshot struct {
 	// fingerprinted tier (§B): the request's structural signature. Empty
 	// when nothing fingerprintable.
 	Fingerprint string
+
+	// experiments (Phase D): claiming experiment + variant. Empty when none.
+	ExperimentID      string
+	ExperimentVariant string
 }
 
 // Snapshot returns a read-only view of the current routing state.
@@ -193,6 +203,8 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		PrefixHash:        r.prefixHash,
 		StateHash:         r.stateHash,
 		Fingerprint:       r.fingerprint,
+		ExperimentID:      r.experimentID,
+		ExperimentVariant: r.experimentVariant,
 	}
 }
 
@@ -260,6 +272,24 @@ func StampStateHash(ctx context.Context, hash string) {
 	defer r.mu.Unlock()
 	if r.stateHash == "" {
 		r.stateHash = hash
+	}
+}
+
+// StampExperiment records the experiment + variant that claimed this request
+// (Phase D). First-write-wins; empty experiment id is a no-op.
+func StampExperiment(ctx context.Context, experimentID, variant string) {
+	if experimentID == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.experimentID == "" {
+		r.experimentID = experimentID
+		r.experimentVariant = variant
 	}
 }
 

--- a/internal/server/prefix_chain_test.go
+++ b/internal/server/prefix_chain_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/tributary-ai/llm-router-waf/internal/types"
@@ -104,6 +105,36 @@ func TestAgentFingerprint_MaxTokensIgnored(t *testing.T) {
 	}
 	if agentFingerprint(base(mt1)) != agentFingerprint(base(mt2)) {
 		t.Error("max_tokens must NOT split one agent's fingerprint")
+	}
+}
+
+func TestApplyExperimentOverride(t *testing.T) {
+	// Model-swap override reroutes by changing req.Model.
+	req := &types.ChatRequest{Model: "gpt-4o"}
+	applyExperimentOverride(req, json.RawMessage(`{"model":"gpt-4o-mini"}`))
+	if req.Model != "gpt-4o-mini" {
+		t.Errorf("model override not applied: %q", req.Model)
+	}
+
+	// Param-sweep override.
+	req2 := &types.ChatRequest{Model: "gpt-4o"}
+	applyExperimentOverride(req2, json.RawMessage(`{"params":{"temperature":0.2,"max_tokens":256}}`))
+	if req2.Temperature == nil || *req2.Temperature != 0.2 {
+		t.Errorf("temperature override not applied: %v", req2.Temperature)
+	}
+	if req2.MaxTokens == nil || *req2.MaxTokens != 256 {
+		t.Errorf("max_tokens override not applied: %v", req2.MaxTokens)
+	}
+	if req2.Model != "gpt-4o" {
+		t.Errorf("model should be untouched when override has no model: %q", req2.Model)
+	}
+
+	// Empty / control override is a no-op.
+	req3 := &types.ChatRequest{Model: "gpt-4o"}
+	applyExperimentOverride(req3, nil)
+	applyExperimentOverride(req3, json.RawMessage(`{}`))
+	if req3.Model != "gpt-4o" {
+		t.Errorf("empty override must not change the request: %q", req3.Model)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -516,14 +516,23 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	}
 	req.Timestamp = time.Now()
 
-	// AIQG: stamp the requested model + streaming flag onto the routing
-	// sidecar so the response event carries them. No-op outside AIQG mode.
-	middleware.StampModel(r.Context(), req.Model)
-	middleware.StampStreaming(r.Context(), req.Stream)
 	// AIQG: heuristically classify the workflow from request shape so
 	// the CLEAR latency scorer uses a sensible SLA when the caller
 	// didn't send a TAS-Workflow header. Empty result is a no-op.
-	middleware.StampWorkflow(r.Context(), workflow.Classify(&req))
+	wf := workflow.Classify(&req)
+	// AIQG experiments (Phase D): resolve the variant claiming this request on
+	// the REQUESTED model + workflow (the cohort matches what the caller
+	// asked), then — for a running experiment — apply the variant's override
+	// (model swap / param sweep) BEFORE routing + stamping, so the event
+	// reflects the SERVED config. dry_run returns Apply=false (stamped only).
+	if d := middleware.ResolveExperimentForRouting(r.Context(), req.Model, wf, r.URL.Path); d != nil && d.Apply {
+		applyExperimentOverride(&req, d.Override)
+	}
+	// AIQG: stamp the (possibly overridden) model + streaming flag onto the
+	// routing sidecar so the response event carries them. No-op outside AIQG.
+	middleware.StampModel(r.Context(), req.Model)
+	middleware.StampStreaming(r.Context(), req.Stream)
+	middleware.StampWorkflow(r.Context(), wf)
 	// AIQG (linked tier): tool_call_ids this request echoes (role=tool) so
 	// the middleware can prove which flow/step it continues.
 	middleware.StampEchoedToolCalls(r.Context(), echoedToolCallIDs(&req))
@@ -1016,6 +1025,40 @@ func agentFingerprint(req *types.ChatRequest) string {
 	}
 	sum := sha256.Sum256(b)
 	return hex.EncodeToString(sum[:])
+}
+
+// applyExperimentOverride mutates the request per a running experiment's
+// variant override (Phase D). Supports the model-swap (the canonical case —
+// req.Model change reroutes via the model→provider mapping) and param-sweep
+// axes. A vendor-only override (no model) is not applied here — that needs a
+// forced-provider Route() arg; logged as a no-op by the caller if needed.
+func applyExperimentOverride(req *types.ChatRequest, override json.RawMessage) {
+	if len(override) == 0 {
+		return
+	}
+	var o struct {
+		Model  string `json:"model"`
+		Params struct {
+			Temperature *float32 `json:"temperature"`
+			TopP        *float32 `json:"top_p"`
+			MaxTokens   *int     `json:"max_tokens"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(override, &o); err != nil {
+		return
+	}
+	if o.Model != "" {
+		req.Model = o.Model
+	}
+	if o.Params.Temperature != nil {
+		req.Temperature = o.Params.Temperature
+	}
+	if o.Params.TopP != nil {
+		req.TopP = o.Params.TopP
+	}
+	if o.Params.MaxTokens != nil {
+		req.MaxTokens = o.Params.MaxTokens
+	}
 }
 
 // extractResponseContent extracts text content from a ChatResponse.


### PR DESCRIPTION
Makes a **running** experiment actually change the served model/params — the gated step. It reroutes real customer traffic, but only when an operator transitions an experiment to `running` (audited, UI-guarded) and only within `max_traffic_pct`.

### Resolution moves to routing time (was deferred/stamp-only in 2a)
- `handleAIQG` stashes the resolver + the request's sticky identity on ctx before the handler runs.
- The chat-completion handler calls `ResolveExperimentForRouting` once model + workflow are known, on the **requested** model (cohort matches what the caller asked); for `Apply=true` (running) it applies the variant override via `applyExperimentOverride` **before `Router.Route`** — model swap (`req.Model` → reroutes through the model→provider map) + param sweep (temperature/top_p/max_tokens). dry_run → `Apply=false` (stamp only).
- The decision is stamped on the routing sidecar (`StampExperiment`); the deferred event-build reads the snapshot instead of re-resolving, so the override and the event stamp share **one** decision. Stamps reflect the **served** config (model stamped after the override).

Fail-safe unchanged: nil resolver / no claim / error → no override, route normally. Vendor-only override (no model) isn't applied yet (needs a forced-provider Route arg) — noted.

### Verified live (aiqg-v5.33)
A running experiment (cohort `model=[gpt-4o-mini]`, 100% → swap override `model=gpt-4o`) rerouted a `gpt-4o-mini` request to **`gpt-4o-2024-08-06`**; the TS event stamped `experiment_id` + `variant=swap` + served `model=gpt-4o`. Archived after; no active experiments remain. Unit test covers `applyExperimentOverride` (model swap / param sweep / empty no-op). build/vet/tests green `-tags nohs`.

Remaining 2b: guardrails/auto-stop evaluator + kill switch, the Spark `scope_type='experiment_variant'` rollup, and the real `/results` query — follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)