### PR TITLE
feat(aiqg): LLM-as-judge quality layer (§6.6)

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -76,6 +77,15 @@ type AIQGConfig struct {
 	// the tool_call_id echo index. Empty = linkage disabled (events emit
 	// without step/parent topology). Env: AIQG_LINKAGE_REDIS_URL.
 	LinkageRedisURL string `yaml:"linkage_redis_url"`
+
+	// LLM-as-judge quality layer (docs/AIQG-EXPERIMENTS-RUNNER.md §6.6).
+	// JudgeModel is the third model that rubric-scores a sample of responses
+	// (MUST differ from production traffic's models to avoid self-preference).
+	// JudgeSamplePct (0–100) is the fraction of AIQG responses judged async,
+	// off the hot path. Judging is off when JudgeModel is empty or pct<=0.
+	// Env: AIQG_JUDGE_MODEL, AIQG_JUDGE_SAMPLE_PCT.
+	JudgeModel     string `yaml:"judge_model"`
+	JudgeSamplePct int    `yaml:"judge_sample_pct"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Defined here (not in
@@ -460,6 +470,14 @@ func (c *Config) loadFromEnv() {
 	if u := os.Getenv("AIQG_LINKAGE_REDIS_URL"); u != "" {
 		c.AIQG.LinkageRedisURL = u
 	}
+	if m := os.Getenv("AIQG_JUDGE_MODEL"); m != "" {
+		c.AIQG.JudgeModel = m
+	}
+	if p := os.Getenv("AIQG_JUDGE_SAMPLE_PCT"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			c.AIQG.JudgeSamplePct = n
+		}
+	}
 	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
 		c.AIQG.DashboardURL = u
 	}
@@ -645,6 +663,8 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 		DashboardURL:               c.AIQG.DashboardURL,
 		DashboardInternalAuthToken: c.AIQG.DashboardInternalAuthToken,
 		LinkageRedisURL:            c.AIQG.LinkageRedisURL,
+		JudgeModel:                 c.AIQG.JudgeModel,
+		JudgeSamplePct:             c.AIQG.JudgeSamplePct,
 		Kafka: server.AIQGKafkaConfig{
 			Brokers: c.AIQG.Kafka.Brokers,
 			Topic:   c.AIQG.Kafka.Topic,

--- a/internal/server/judge.go
+++ b/internal/server/judge.go
@@ -1,0 +1,188 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/crc32"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/tributary-ai/llm-router-waf/internal/middleware"
+	"github.com/tributary-ai/llm-router-waf/internal/routing"
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/judge"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
+)
+
+// judgeRunner wires the LLM-as-judge quality layer (§6.6) into the gateway:
+// it samples completed AIQG responses, scores them off the hot path with a
+// third model, and records the score to aiqg-dashboard-be. Nil when judging
+// is disabled (no JudgeModel / pct<=0) — maybeJudge is then a no-op.
+type judgeRunner struct {
+	judge     *judge.Judge
+	samplePct int
+	recorder  *judgeRecorder
+	log       *logrus.Logger
+}
+
+// newJudgeRunner builds the runner, or returns nil when judging is off / the
+// dashboard isn't configured (nowhere to record).
+func newJudgeRunner(router *routing.Router, model string, samplePct int, dashboardURL, internalAuth string, log *logrus.Logger) *judgeRunner {
+	if model == "" || samplePct <= 0 || dashboardURL == "" || internalAuth == "" {
+		return nil
+	}
+	return &judgeRunner{
+		judge:     &judge.Judge{LLM: &routerCompletion{router: router}, Model: model},
+		samplePct: samplePct,
+		recorder:  &judgeRecorder{http: &http.Client{Timeout: 5 * time.Second}, baseURL: strings.TrimRight(dashboardURL, "/"), auth: internalAuth},
+		log:       log,
+	}
+}
+
+// sampled returns true for the fraction of events to judge — deterministic on
+// the response event id (uniform, stable, no RNG state).
+func (jr *judgeRunner) sampled(eventID string) bool {
+	if jr.samplePct >= 100 {
+		return true
+	}
+	return int(crc32.ChecksumIEEE([]byte("judge:"+eventID))%100) < jr.samplePct
+}
+
+// maybeJudge fires an async judge for a sampled, AIQG-attributed, non-streaming
+// response. Strictly off the hot path: the client already has its response; a
+// judge failure only means no score lands. Skips when judging is off, the
+// request isn't AIQG-attributed (no tenant), or the response has no text.
+func (jr *judgeRunner) maybeJudge(ctx context.Context, w http.ResponseWriter, req *types.ChatRequest, resp *types.ChatResponse) {
+	if jr == nil || req == nil || resp == nil {
+		return
+	}
+	eventID := w.Header().Get("TAS-Response-Event-Id")
+	if eventID == "" || !jr.sampled(eventID) {
+		return
+	}
+	tok := tokens.FromContext(ctx)
+	if tok == nil {
+		return // not AIQG-attributed — no tenant to scope the score
+	}
+	responseText := extractResponseContent(resp)
+	if strings.TrimSpace(responseText) == "" {
+		return // tool-call-only / empty — nothing semantic to judge
+	}
+	workflow, expID, variant := "", "", ""
+	if r := middleware.RoutingFromContext(ctx); r != nil {
+		snap := r.Snapshot()
+		workflow, expID, variant = snap.Workflow, snap.ExperimentID, snap.ExperimentVariant
+	}
+	promptText := promptFromMessages(req)
+	tenantID := tok.TenantID
+
+	// Detach from the request context (it may be canceled once the response
+	// is flushed) — the judge call is independent work.
+	go func() {
+		jctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		score, err := jr.judge.Score(jctx, workflow, promptText, responseText)
+		if err != nil {
+			jr.log.WithError(err).Debug("aiqg judge: scoring failed")
+			return
+		}
+		if score.Abstain {
+			return // judge declined — don't record a non-signal
+		}
+		// The gateway already knows the experiment/variant (routing snapshot),
+		// so the score carries its own attribution — the dashboard inserts it
+		// directly, no event re-resolution.
+		if err := jr.recorder.record(jctx, tenantID, eventID, expID, variant, score); err != nil {
+			jr.log.WithError(err).Debug("aiqg judge: record failed")
+		}
+	}()
+}
+
+// promptFromMessages flattens the request's user/system turns to text for the
+// judge (the question being answered). Tool/assistant turns are omitted —
+// the judge scores the latest response against the ask.
+func promptFromMessages(req *types.ChatRequest) string {
+	var b strings.Builder
+	for _, m := range req.Messages {
+		if m.Role != "user" && m.Role != "system" {
+			continue
+		}
+		if s, ok := m.Content.(string); ok && s != "" {
+			b.WriteString(s)
+			b.WriteString("\n")
+		}
+	}
+	return b.String()
+}
+
+// routerCompletion adapts the gateway's router to judge.Completion: it routes
+// a one-shot request for the judge model and returns the text. Bypasses the
+// AIQG HTTP middleware entirely (internal call), so judging never recurses and
+// uses the gateway's configured provider key (not a customer key).
+type routerCompletion struct{ router *routing.Router }
+
+func (rc *routerCompletion) Complete(ctx context.Context, model, system, user string) (string, error) {
+	maxTokens := 400
+	req := &types.ChatRequest{
+		Model:     model,
+		MaxTokens: &maxTokens,
+		Messages: []types.Message{
+			{Role: "system", Content: system},
+			{Role: "user", Content: user},
+		},
+	}
+	_, provider, err := rc.router.Route(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("judge route: %w", err)
+	}
+	resp, err := provider.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", fmt.Errorf("judge completion: %w", err)
+	}
+	return extractResponseContent(resp), nil
+}
+
+// judgeRecorder POSTs a judge score to aiqg-dashboard-be's internal ingest,
+// which resolves the event → tenant/experiment/variant and stores it as a
+// judge feedback row.
+type judgeRecorder struct {
+	http    *http.Client
+	baseURL string
+	auth    string
+}
+
+func (jr *judgeRecorder) record(ctx context.Context, tenantID, eventID, experimentID, variant string, s judge.Score) error {
+	body, err := json.Marshal(map[string]any{
+		"tenant_id":          tenantID,
+		"response_event_id":  eventID,
+		"experiment_id":      experimentID,
+		"experiment_variant": variant,
+		"workflow":           s.Workflow,
+		"overall":            s.Overall,
+		"dimensions":         s.Dimensions,
+		"rubric_version":     s.RubricVersion,
+	})
+	if err != nil {
+		return err
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, jr.baseURL+"/internal/judge", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Internal-Auth", jr.auth)
+	resp, err := jr.http.Do(httpReq)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("judge record: status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -50,6 +50,9 @@ type Server struct {
 	// and there is zero behavior change for existing traffic.
 	aiqgMiddleware func(http.Handler) http.Handler
 	aiqgEmitter    events.Emitter
+	// judge runs the LLM-as-judge quality layer off the hot path. Nil when
+	// judging is disabled.
+	judge *judgeRunner
 }
 
 // ServerConfig holds server configuration
@@ -160,6 +163,11 @@ type AIQGServerConfig struct {
 	// LinkageRedisURL enables the deterministic `linked`-tier attribution
 	// (tool_call_id echo index). Empty = linkage disabled.
 	LinkageRedisURL string `yaml:"linkage_redis_url"`
+
+	// JudgeModel + JudgeSamplePct configure the LLM-as-judge quality layer
+	// (§6.6). Empty model or pct<=0 disables judging.
+	JudgeModel     string `yaml:"judge_model"`
+	JudgeSamplePct int    `yaml:"judge_sample_pct"`
 
 	// EmitterType selects how AIQG events are published:
 	//   "log"   — logrus → Loki (default; works without infra)
@@ -314,6 +322,18 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			"region":           config.AIQG.Region,
 			"resolver_enabled": resolver != nil,
 		}).Info("AIQG ingress enabled on completion routes")
+
+		// LLM-as-judge quality layer (§6.6) — samples completed responses and
+		// scores them off the hot path with a third model. Disabled unless a
+		// judge model + sample pct + dashboard ingest are all configured.
+		server.judge = newJudgeRunner(router, config.AIQG.JudgeModel, config.AIQG.JudgeSamplePct,
+			config.AIQG.DashboardURL, config.AIQG.DashboardInternalAuthToken, logger)
+		if server.judge != nil {
+			logger.WithFields(logrus.Fields{
+				"judge_model": config.AIQG.JudgeModel,
+				"sample_pct":  config.AIQG.JudgeSamplePct,
+			}).Info("AIQG LLM-as-judge enabled")
+		}
 	}
 
 	return server, nil
@@ -853,6 +873,10 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 	if metadata != nil {
 		middleware.StampRetryMetadata(r.Context(), metadata.AttemptCount, metadata.FallbackUsed)
 	}
+
+	// AIQG LLM-as-judge (§6.6): fire a sampled, async quality score off the
+	// hot path. No-op when judging is disabled / unsampled / not AIQG.
+	s.judge.maybeJudge(r.Context(), w, req, resp)
 
 	// Add routing metadata to response
 	resp.RouterMetadata = metadata

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -86,6 +86,13 @@ data:
   # Deterministic `linked`-tier attribution (tool_call_id echo index,
   # docs/AIQG-AGENT-FLOW-ATTRIBUTION.md §A). Empty disables linkage.
   AIQG_LINKAGE_REDIS_URL: "redis://redis-shared.tas-shared.svc.cluster.local:6379"
+  # LLM-as-judge quality layer (docs/AIQG-EXPERIMENTS-RUNNER.md §6.6). A third
+  # model rubric-scores a sampled fraction of responses off the hot path; the
+  # score is recorded to aiqg-dashboard-be (/internal/judge) as a feedback
+  # signal for per-variant quality. Judge model differs from typical traffic
+  # to avoid self-preference bias. Empty model / 0 pct disables judging.
+  AIQG_JUDGE_MODEL: "claude-haiku-4-5-20251001"
+  AIQG_JUDGE_SAMPLE_PCT: "20"
   # When set, the AIQG middleware uses a DashboardResolver (HTTP
   # client of aiqg-dashboard-be's /internal/auth/validate) instead of
   # the K8s-Secret-mounted token list. The Internal-Auth shared

--- a/pkg/aiqg/judge/judge.go
+++ b/pkg/aiqg/judge/judge.go
@@ -1,0 +1,203 @@
+// Package judge implements the AIQG LLM-as-judge quality layer
+// (docs/AIQG-EXPERIMENTS-RUNNER.md §6.6): a *different* model rubric-scores a
+// sampled response on correctness / helpfulness / completeness (dimensions
+// keyed to workflow_type), reference-free and pointwise. It's a shared
+// capability — the Experiments runner consumes per-variant judge scores, and
+// it augments CLEAR Efficacy (which is structural-only).
+//
+// Bias controls (§6.6): the judge model MUST differ from the model that
+// produced the response (the caller enforces this via Model); the rubric is
+// versioned (RubricVersion) so scores compare over time; the judge may
+// ABSTAIN rather than guess. Pointwise scoring (no A/B position bias inline);
+// pairwise shadow-eval is a future mode.
+package judge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// RubricVersion stamps every score so a rubric change is comparable over time.
+// Bump when the dimensions or instructions below change.
+const RubricVersion = "v1"
+
+// Score is one judged response: per-dimension 0–1, an overall 0–1, and an
+// abstain flag (the judge declined — exclude from aggregates rather than
+// scoring 0).
+type Score struct {
+	Dimensions    map[string]float64 `json:"dimensions"`
+	Overall       float64            `json:"overall"`
+	Abstain       bool               `json:"abstain"`
+	RubricVersion string             `json:"rubric_version"`
+	Workflow      string             `json:"workflow"`
+}
+
+// Completion is the minimal LLM call the judge needs. Decouples the judge from
+// internal/routing so it's unit-testable and so the judge model is explicit.
+type Completion interface {
+	// Complete sends system + user prompts to model and returns the text.
+	Complete(ctx context.Context, model, system, user string) (string, error)
+}
+
+// Judge rubric-scores responses with a fixed judge model.
+type Judge struct {
+	LLM   Completion
+	Model string // the judge model — caller guarantees it ≠ the response's model
+}
+
+// rubric is a workflow_type's judged dimensions + a one-line framing the
+// system prompt embeds. Where a cheaper automatic signal exists (code
+// execution, schema match, groundedness), prefer it over the judge — the
+// caller decides; this package always offers the semantic fallback.
+type rubric struct {
+	dims    []string
+	framing string
+}
+
+var rubrics = map[string]rubric{
+	"single_turn_qa": {
+		dims:    []string{"correctness", "helpfulness", "completeness"},
+		framing: "a direct question-answering response",
+	},
+	"rag": {
+		dims:    []string{"faithfulness", "answer_relevance"},
+		framing: "a retrieval-augmented answer; faithfulness = supported by the provided context, not fabricated",
+	},
+	"summarization": {
+		dims:    []string{"faithfulness", "key_point_coverage", "concision"},
+		framing: "a summary; faithfulness = no hallucinated facts beyond the source",
+	},
+	"code_generation": {
+		dims:    []string{"solves_the_prompt", "idiomatic"},
+		framing: "generated code (prefer execution/tests over this judgment when available)",
+	},
+	"classification_extraction": {
+		dims:    []string{"label_correctness"},
+		framing: "a classification/extraction result (prefer schema+label match when labels are known)",
+	},
+	"agentic": {
+		dims:    []string{"goal_completion", "correct_tool_use"},
+		framing: "an agent turn that may call tools across steps",
+	},
+}
+
+// defaultRubric is used for unknown/empty workflow types.
+var defaultRubric = rubric{
+	dims:    []string{"correctness", "helpfulness", "completeness"},
+	framing: "an assistant response",
+}
+
+func rubricFor(workflow string) rubric {
+	if r, ok := rubrics[workflow]; ok {
+		return r
+	}
+	return defaultRubric
+}
+
+// Score rubric-scores one (prompt, response) pair for the given workflow. The
+// judge is instructed to return strict JSON; parsing is tolerant of code
+// fences and surrounding prose, clamps each score to [0,1], and treats a
+// missing/garbled body as an abstain rather than an error (so a flaky judge
+// never poisons aggregates with a hard failure — it just doesn't contribute).
+func (j *Judge) Score(ctx context.Context, workflow, prompt, response string) (Score, error) {
+	r := rubricFor(workflow)
+	sys := buildSystemPrompt(r)
+	user := buildUserPrompt(prompt, response)
+
+	raw, err := j.LLM.Complete(ctx, j.Model, sys, user)
+	if err != nil {
+		return Score{}, fmt.Errorf("judge.Score: %w", err)
+	}
+	return parseScore(raw, workflow, r), nil
+}
+
+func buildSystemPrompt(r rubric) string {
+	var b strings.Builder
+	b.WriteString("You are an impartial evaluator scoring ")
+	b.WriteString(r.framing)
+	b.WriteString(".\nScore each dimension from 0.0 (poor) to 1.0 (excellent). Dimensions: ")
+	b.WriteString(strings.Join(r.dims, ", "))
+	b.WriteString(".\nIf you cannot fairly judge (insufficient context, refusal, off-topic), set \"abstain\": true.\n")
+	b.WriteString("Respond with ONLY a JSON object, no prose:\n")
+	b.WriteString(`{"dimensions":{`)
+	for i, d := range r.dims {
+		if i > 0 {
+			b.WriteString(",")
+		}
+		b.WriteString(fmt.Sprintf("%q:0.0", d))
+	}
+	b.WriteString(`},"overall":0.0,"abstain":false}`)
+	return b.String()
+}
+
+func buildUserPrompt(prompt, response string) string {
+	return "PROMPT:\n" + truncate(prompt, 6000) + "\n\nRESPONSE:\n" + truncate(response, 6000)
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…[truncated]"
+}
+
+// parseScore extracts the JSON object from the judge's reply, clamps scores,
+// and fills RubricVersion/Workflow. A missing overall is averaged from the
+// dimensions; an unparseable reply becomes an abstain.
+func parseScore(raw, workflow string, r rubric) Score {
+	out := Score{Dimensions: map[string]float64{}, RubricVersion: RubricVersion, Workflow: workflow}
+	body := extractJSON(raw)
+	if body == "" {
+		out.Abstain = true
+		return out
+	}
+	var parsed struct {
+		Dimensions map[string]float64 `json:"dimensions"`
+		Overall    *float64           `json:"overall"`
+		Abstain    bool               `json:"abstain"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		out.Abstain = true
+		return out
+	}
+	out.Abstain = parsed.Abstain
+	for _, d := range r.dims {
+		if v, ok := parsed.Dimensions[d]; ok {
+			out.Dimensions[d] = clamp01(v)
+		}
+	}
+	switch {
+	case parsed.Overall != nil:
+		out.Overall = clamp01(*parsed.Overall)
+	case len(out.Dimensions) > 0:
+		sum := 0.0
+		for _, v := range out.Dimensions {
+			sum += v
+		}
+		out.Overall = sum / float64(len(out.Dimensions))
+	}
+	return out
+}
+
+// extractJSON pulls the first {...} object out of a reply that may be wrapped
+// in ```json fences or surrounded by prose.
+func extractJSON(s string) string {
+	start := strings.IndexByte(s, '{')
+	end := strings.LastIndexByte(s, '}')
+	if start < 0 || end <= start {
+		return ""
+	}
+	return s[start : end+1]
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/pkg/aiqg/judge/judge_test.go
+++ b/pkg/aiqg/judge/judge_test.go
@@ -1,0 +1,119 @@
+package judge
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeLLM returns a canned reply (or error) and records what it was asked.
+type fakeLLM struct {
+	reply     string
+	err       error
+	gotModel  string
+	gotSystem string
+	gotUser   string
+}
+
+func (f *fakeLLM) Complete(_ context.Context, model, system, user string) (string, error) {
+	f.gotModel, f.gotSystem, f.gotUser = model, system, user
+	return f.reply, f.err
+}
+
+func TestScore_ParsesAndClamps(t *testing.T) {
+	f := &fakeLLM{reply: `{"dimensions":{"correctness":0.9,"helpfulness":1.4,"completeness":-0.2},"overall":0.8,"abstain":false}`}
+	j := &Judge{LLM: f, Model: "judge-model"}
+	s, err := j.Score(context.Background(), "single_turn_qa", "What is 2+2?", "4")
+	if err != nil {
+		t.Fatalf("Score: %v", err)
+	}
+	if s.Dimensions["correctness"] != 0.9 {
+		t.Errorf("correctness = %v", s.Dimensions["correctness"])
+	}
+	if s.Dimensions["helpfulness"] != 1.0 {
+		t.Errorf("helpfulness should clamp to 1.0, got %v", s.Dimensions["helpfulness"])
+	}
+	if s.Dimensions["completeness"] != 0.0 {
+		t.Errorf("completeness should clamp to 0.0, got %v", s.Dimensions["completeness"])
+	}
+	if s.Overall != 0.8 || s.Abstain {
+		t.Errorf("overall=%v abstain=%v", s.Overall, s.Abstain)
+	}
+	if s.RubricVersion != RubricVersion || s.Workflow != "single_turn_qa" {
+		t.Errorf("metadata: %+v", s)
+	}
+}
+
+func TestScore_JudgeModelUsed(t *testing.T) {
+	// Bias control: the judge calls its OWN model, not the variant's.
+	f := &fakeLLM{reply: `{"overall":0.5}`}
+	j := &Judge{LLM: f, Model: "claude-haiku-4-5"}
+	_, _ = j.Score(context.Background(), "rag", "p", "r")
+	if f.gotModel != "claude-haiku-4-5" {
+		t.Errorf("judge used model %q, want the configured judge model", f.gotModel)
+	}
+	// RAG rubric must mention faithfulness in the system prompt.
+	if !contains(f.gotSystem, "faithfulness") {
+		t.Errorf("rag system prompt missing faithfulness dimension: %s", f.gotSystem)
+	}
+}
+
+func TestScore_OverallAveragedWhenMissing(t *testing.T) {
+	f := &fakeLLM{reply: "```json\n{\"dimensions\":{\"correctness\":0.6,\"helpfulness\":0.8,\"completeness\":1.0}}\n```"}
+	j := &Judge{LLM: f, Model: "m"}
+	s, _ := j.Score(context.Background(), "single_turn_qa", "p", "r")
+	// (0.6+0.8+1.0)/3 = 0.8
+	if s.Overall < 0.79 || s.Overall > 0.81 {
+		t.Errorf("overall should average dims to ~0.8, got %v", s.Overall)
+	}
+}
+
+func TestScore_FencedAndProseTolerant(t *testing.T) {
+	f := &fakeLLM{reply: "Sure! Here is my assessment:\n```json\n{\"overall\":0.7,\"abstain\":false}\n```\nHope that helps."}
+	j := &Judge{LLM: f, Model: "m"}
+	s, _ := j.Score(context.Background(), "single_turn_qa", "p", "r")
+	if s.Overall != 0.7 {
+		t.Errorf("should extract JSON from prose+fences, got overall=%v", s.Overall)
+	}
+}
+
+func TestScore_GarbledReplyAbstains(t *testing.T) {
+	f := &fakeLLM{reply: "I think it's pretty good honestly"}
+	j := &Judge{LLM: f, Model: "m"}
+	s, err := j.Score(context.Background(), "single_turn_qa", "p", "r")
+	if err != nil {
+		t.Fatalf("garbled reply must not error: %v", err)
+	}
+	if !s.Abstain {
+		t.Error("unparseable judge reply should abstain, not score")
+	}
+}
+
+func TestScore_LLMErrorPropagates(t *testing.T) {
+	f := &fakeLLM{err: errors.New("boom")}
+	j := &Judge{LLM: f, Model: "m"}
+	if _, err := j.Score(context.Background(), "rag", "p", "r"); err == nil {
+		t.Error("LLM transport error should propagate")
+	}
+}
+
+func TestRubricFor_FallsBack(t *testing.T) {
+	if got := rubricFor("nonsense").dims[0]; got != "correctness" {
+		t.Errorf("unknown workflow should use default rubric, got first dim %q", got)
+	}
+	if len(rubricFor("code_generation").dims) != 2 {
+		t.Error("code_generation rubric should have 2 dims")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
A *third* model rubric-scores a sampled fraction of AIQG responses **off the hot path** — the planned Efficacy augmentation (CLEAR Efficacy is structural-only) that the Experiments runner consumes as a per-variant quality signal.

- **`pkg/aiqg/judge`** — reference-free pointwise rubric keyed to `workflow_type` (single_turn_qa/rag/summarization/code_generation/classification_extraction/agentic), per-dimension 0–1 + overall + **ABSTAIN**; tolerant JSON parse (fences/prose), clamps, versioned rubric (v1). `Completion` injected (unit-tested with a fake).
- **Gateway integration** — samples by `hash(response_event_id) % 100 < AIQG_JUDGE_SAMPLE_PCT`; after a non-streaming AIQG response is served, an async goroutine scores the in-memory prompt+response with `AIQG_JUDGE_MODEL` via the router (configured provider key, bypasses AIQG middleware → no recursion), then records to `/internal/judge` with the experiment/variant from the routing snapshot. Never touches the client's response.
- **Config** `AIQG_JUDGE_MODEL` + `AIQG_JUDGE_SAMPLE_PCT`; configmap sets judge=claude-haiku-4-5 (≠ typical traffic — the bias control), sample 20%.

**Verified live (aiqg-v5.34):** a gpt-4o-mini response was judged by claude-haiku (single_turn_qa, v1); score landed as a judge feedback row. Unit tests cover parse/clamp, judge-model use, overall averaging, fenced/prose tolerance, garbled→abstain, error propagation.

Pairs with aiqg-dashboard-be (judge ingest + per-variant results) + aiqg-ui (judge column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)