### PR TITLE
feat(aiqg): pairwise shadow-eval — strongest experiment quality signal

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -86,6 +86,11 @@ type AIQGConfig struct {
 	// Env: AIQG_JUDGE_MODEL, AIQG_JUDGE_SAMPLE_PCT.
 	JudgeModel     string `yaml:"judge_model"`
 	JudgeSamplePct int    `yaml:"judge_sample_pct"`
+	// ShadowEvalPct (0–100) is the fraction of CONTROL-arm experiment samples
+	// to pairwise shadow-eval — replay through each variant offline + judge
+	// head-to-head. Costs ~2× per shadow sample, so default 0 (off; opt-in).
+	// Env: AIQG_SHADOW_EVAL_PCT.
+	ShadowEvalPct int `yaml:"shadow_eval_pct"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Defined here (not in
@@ -478,6 +483,11 @@ func (c *Config) loadFromEnv() {
 			c.AIQG.JudgeSamplePct = n
 		}
 	}
+	if p := os.Getenv("AIQG_SHADOW_EVAL_PCT"); p != "" {
+		if n, err := strconv.Atoi(p); err == nil {
+			c.AIQG.ShadowEvalPct = n
+		}
+	}
 	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
 		c.AIQG.DashboardURL = u
 	}
@@ -665,6 +675,7 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 		LinkageRedisURL:            c.AIQG.LinkageRedisURL,
 		JudgeModel:                 c.AIQG.JudgeModel,
 		JudgeSamplePct:             c.AIQG.JudgeSamplePct,
+		ShadowEvalPct:              c.AIQG.ShadowEvalPct,
 		Kafka: server.AIQGKafkaConfig{
 			Brokers: c.AIQG.Kafka.Brokers,
 			Topic:   c.AIQG.Kafka.Topic,

--- a/internal/server/judge.go
+++ b/internal/server/judge.go
@@ -15,6 +15,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/middleware"
 	"github.com/tributary-ai/llm-router-waf/internal/routing"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/experiments"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/judge"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 )
@@ -24,23 +25,30 @@ import (
 // third model, and records the score to aiqg-dashboard-be. Nil when judging
 // is disabled (no JudgeModel / pct<=0) — maybeJudge is then a no-op.
 type judgeRunner struct {
-	judge     *judge.Judge
-	samplePct int
-	recorder  *judgeRecorder
-	log       *logrus.Logger
+	judge       *judge.Judge
+	samplePct   int
+	shadowPct   int                   // % of control-arm experiment samples to shadow-eval (0 = off)
+	experiments *experiments.Resolver // source of variant overrides for the replay
+	router      *routing.Router       // for the offline variant replay
+	recorder    *judgeRecorder
+	log         *logrus.Logger
 }
 
 // newJudgeRunner builds the runner, or returns nil when judging is off / the
-// dashboard isn't configured (nowhere to record).
-func newJudgeRunner(router *routing.Router, model string, samplePct int, dashboardURL, internalAuth string, log *logrus.Logger) *judgeRunner {
+// dashboard isn't configured (nowhere to record). shadowPct>0 + an experiments
+// resolver enable pairwise shadow-eval (§6.3) on top of the pointwise judge.
+func newJudgeRunner(router *routing.Router, model string, samplePct, shadowPct int, exp *experiments.Resolver, dashboardURL, internalAuth string, log *logrus.Logger) *judgeRunner {
 	if model == "" || samplePct <= 0 || dashboardURL == "" || internalAuth == "" {
 		return nil
 	}
 	return &judgeRunner{
-		judge:     &judge.Judge{LLM: &routerCompletion{router: router}, Model: model},
-		samplePct: samplePct,
-		recorder:  &judgeRecorder{http: &http.Client{Timeout: 5 * time.Second}, baseURL: strings.TrimRight(dashboardURL, "/"), auth: internalAuth},
-		log:       log,
+		judge:       &judge.Judge{LLM: &routerCompletion{router: router}, Model: model},
+		samplePct:   samplePct,
+		shadowPct:   shadowPct,
+		experiments: exp,
+		router:      router,
+		recorder:    &judgeRecorder{http: &http.Client{Timeout: 5 * time.Second}, baseURL: strings.TrimRight(dashboardURL, "/"), auth: internalAuth},
+		log:         log,
 	}
 }
 
@@ -53,6 +61,18 @@ func (jr *judgeRunner) sampled(eventID string) bool {
 	return int(crc32.ChecksumIEEE([]byte("judge:"+eventID))%100) < jr.samplePct
 }
 
+// shadowSampled is the (separate, usually smaller) shadow-eval sample — it
+// replays + pairwise-judges, so it costs ~2× per sampled request.
+func (jr *judgeRunner) shadowSampled(eventID string) bool {
+	if jr.shadowPct <= 0 {
+		return false
+	}
+	if jr.shadowPct >= 100 {
+		return true
+	}
+	return int(crc32.ChecksumIEEE([]byte("shadow:"+eventID))%100) < jr.shadowPct
+}
+
 // maybeJudge fires an async judge for a sampled, AIQG-attributed, non-streaming
 // response. Strictly off the hot path: the client already has its response; a
 // judge failure only means no score lands. Skips when judging is off, the
@@ -62,7 +82,7 @@ func (jr *judgeRunner) maybeJudge(ctx context.Context, w http.ResponseWriter, re
 		return
 	}
 	eventID := w.Header().Get("TAS-Response-Event-Id")
-	if eventID == "" || !jr.sampled(eventID) {
+	if eventID == "" {
 		return
 	}
 	tok := tokens.FromContext(ctx)
@@ -81,26 +101,79 @@ func (jr *judgeRunner) maybeJudge(ctx context.Context, w http.ResponseWriter, re
 	promptText := promptFromMessages(req)
 	tenantID := tok.TenantID
 
-	// Detach from the request context (it may be canceled once the response
-	// is flushed) — the judge call is independent work.
-	go func() {
-		jctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		score, err := jr.judge.Score(jctx, workflow, promptText, responseText)
-		if err != nil {
-			jr.log.WithError(err).Debug("aiqg judge: scoring failed")
-			return
+	// Pointwise judge on the sampled fraction.
+	if jr.sampled(eventID) {
+		go func() {
+			jctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			score, err := jr.judge.Score(jctx, workflow, promptText, responseText)
+			if err != nil {
+				jr.log.WithError(err).Debug("aiqg judge: scoring failed")
+				return
+			}
+			if score.Abstain {
+				return
+			}
+			// The gateway knows the experiment/variant (routing snapshot), so
+			// the score carries its own attribution — no event re-resolution.
+			if err := jr.recorder.record(jctx, tenantID, eventID, expID, variant, score); err != nil {
+				jr.log.WithError(err).Debug("aiqg judge: record failed")
+			}
+		}()
+	}
+
+	// Pairwise shadow-eval (§6.3): for a CONTROL-arm sample of an experiment,
+	// replay the same prompt through each variant offline and judge head-to-
+	// head. Zero user impact (the client already has control's response);
+	// ~2× cost on the shadow sample. Pairs with dry_run (everyone is control).
+	if expID != "" && variant == "control" && jr.experiments != nil && jr.shadowSampled(eventID) {
+		msgs := append([]types.Message(nil), req.Messages...) // snapshot for the goroutine
+		baseModel := req.Model
+		go jr.shadowEval(eventID, tenantID, expID, workflow, promptText, responseText, msgs, baseModel)
+	}
+}
+
+// shadowEval replays the control prompt through each non-control variant and
+// pairwise-judges control vs variant, recording a per-variant preference.
+// Best-effort; off the hot path.
+func (jr *judgeRunner) shadowEval(eventID, tenantID, expID, workflow, prompt, controlResp string, msgs []types.Message, baseModel string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+	variants := jr.experiments.NonControlOverrides(ctx, tenantID, expID)
+	for _, v := range variants {
+		variantResp, err := jr.replay(ctx, msgs, baseModel, v.Override)
+		if err != nil || strings.TrimSpace(variantResp) == "" {
+			jr.log.WithError(err).Debug("aiqg shadow-eval: replay failed")
+			continue
 		}
-		if score.Abstain {
-			return // judge declined — don't record a non-signal
+		// Randomize A/B order per the bias control (§6.6).
+		variantFirst := crc32.ChecksumIEEE([]byte(eventID+":"+v.Key))%2 == 0
+		pw, err := jr.judge.ScorePairwise(ctx, workflow, prompt, controlResp, variantResp, variantFirst)
+		if err != nil || pw.Abstain {
+			continue
 		}
-		// The gateway already knows the experiment/variant (routing snapshot),
-		// so the score carries its own attribution — the dashboard inserts it
-		// directly, no event re-resolution.
-		if err := jr.recorder.record(jctx, tenantID, eventID, expID, variant, score); err != nil {
-			jr.log.WithError(err).Debug("aiqg judge: record failed")
+		if err := jr.recorder.recordPairwise(ctx, tenantID, eventID, expID, v.Key, workflow, pw); err != nil {
+			jr.log.WithError(err).Debug("aiqg shadow-eval: record failed")
 		}
-	}()
+	}
+}
+
+// replay runs the control prompt through a variant's override offline and
+// returns the variant's response text. Uses the configured provider key (no
+// customer key) and bypasses the AIQG middleware, same as the judge call.
+func (jr *judgeRunner) replay(ctx context.Context, msgs []types.Message, baseModel string, override json.RawMessage) (string, error) {
+	maxTokens := 256
+	req := &types.ChatRequest{Model: baseModel, Messages: msgs, MaxTokens: &maxTokens}
+	applyExperimentOverride(req, override) // swaps model / params to the variant
+	_, provider, err := jr.router.Route(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	resp, err := provider.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", err
+	}
+	return extractResponseContent(resp), nil
 }
 
 // promptFromMessages flattens the request's user/system turns to text for the
@@ -156,8 +229,10 @@ type judgeRecorder struct {
 	auth    string
 }
 
+// record posts a pointwise judge score (signal_type=judge, value=overall).
 func (jr *judgeRecorder) record(ctx context.Context, tenantID, eventID, experimentID, variant string, s judge.Score) error {
-	body, err := json.Marshal(map[string]any{
+	return jr.post(ctx, map[string]any{
+		"signal_type":        "judge",
 		"tenant_id":          tenantID,
 		"response_event_id":  eventID,
 		"experiment_id":      experimentID,
@@ -167,6 +242,25 @@ func (jr *judgeRecorder) record(ctx context.Context, tenantID, eventID, experime
 		"dimensions":         s.Dimensions,
 		"rubric_version":     s.RubricVersion,
 	})
+}
+
+// recordPairwise posts a shadow-eval result (signal_type=judge_pairwise,
+// value=variant preference 0/0.5/1) attributed to the NON-control variant.
+func (jr *judgeRecorder) recordPairwise(ctx context.Context, tenantID, eventID, experimentID, variant, workflow string, pw judge.PairwiseResult) error {
+	return jr.post(ctx, map[string]any{
+		"signal_type":        "judge_pairwise",
+		"tenant_id":          tenantID,
+		"response_event_id":  eventID,
+		"experiment_id":      experimentID,
+		"experiment_variant": variant,
+		"workflow":           workflow,
+		"overall":            pw.VariantPreference,
+		"rubric_version":     pw.RubricVersion,
+	})
+}
+
+func (jr *judgeRecorder) post(ctx context.Context, payload map[string]any) error {
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -168,6 +168,7 @@ type AIQGServerConfig struct {
 	// (§6.6). Empty model or pct<=0 disables judging.
 	JudgeModel     string `yaml:"judge_model"`
 	JudgeSamplePct int    `yaml:"judge_sample_pct"`
+	ShadowEvalPct  int    `yaml:"shadow_eval_pct"`
 
 	// EmitterType selects how AIQG events are published:
 	//   "log"   — logrus → Loki (default; works without infra)
@@ -327,11 +328,13 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 		// scores them off the hot path with a third model. Disabled unless a
 		// judge model + sample pct + dashboard ingest are all configured.
 		server.judge = newJudgeRunner(router, config.AIQG.JudgeModel, config.AIQG.JudgeSamplePct,
+			config.AIQG.ShadowEvalPct, experimentResolver,
 			config.AIQG.DashboardURL, config.AIQG.DashboardInternalAuthToken, logger)
 		if server.judge != nil {
 			logger.WithFields(logrus.Fields{
 				"judge_model": config.AIQG.JudgeModel,
 				"sample_pct":  config.AIQG.JudgeSamplePct,
+				"shadow_pct":  config.AIQG.ShadowEvalPct,
 			}).Info("AIQG LLM-as-judge enabled")
 		}
 	}

--- a/k8s/configmap.yaml
+++ b/k8s/configmap.yaml
@@ -93,6 +93,11 @@ data:
   # to avoid self-preference bias. Empty model / 0 pct disables judging.
   AIQG_JUDGE_MODEL: "claude-haiku-4-5-20251001"
   AIQG_JUDGE_SAMPLE_PCT: "20"
+  # Pairwise shadow-eval (§6.3): % of CONTROL-arm experiment samples to replay
+  # through each variant offline + judge head-to-head. ~2× cost per shadow
+  # sample, so opt-in (0 = off). Raise per-experiment when a paired quality
+  # delta is wanted (pairs naturally with dry_run).
+  AIQG_SHADOW_EVAL_PCT: "0"
   # When set, the AIQG middleware uses a DashboardResolver (HTTP
   # client of aiqg-dashboard-be's /internal/auth/validate) instead of
   # the K8s-Secret-mounted token list. The Internal-Auth shared

--- a/pkg/aiqg/experiments/experiments.go
+++ b/pkg/aiqg/experiments/experiments.go
@@ -290,6 +290,28 @@ func (r *Resolver) Resolve(ctx context.Context, tenantID string, id Identity, at
 	return nil
 }
 
+// NonControlOverrides returns the non-control variants of an active experiment
+// for a tenant — the arms a control-arm request is shadow-evaluated against.
+// Empty when the experiment isn't active/known.
+func (r *Resolver) NonControlOverrides(ctx context.Context, tenantID, experimentID string) []Variant {
+	if r == nil {
+		return nil
+	}
+	for _, e := range r.active(ctx, tenantID) {
+		if e.ID != experimentID {
+			continue
+		}
+		out := make([]Variant, 0, len(e.Variants))
+		for _, v := range e.Variants {
+			if v.Key != "control" {
+				out = append(out, v)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
 // HTTPLoader loads experiments from aiqg-dashboard-be's internal cache endpoint.
 type HTTPLoader struct {
 	HTTP              *http.Client

--- a/pkg/aiqg/judge/pairwise.go
+++ b/pkg/aiqg/judge/pairwise.go
@@ -1,0 +1,102 @@
+package judge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Pairwise shadow-eval (AIQG-EXPERIMENTS-RUNNER.md §6.3/§6.6): the strongest
+// quality signal for an experiment. The same prompt is answered by control
+// (the served response) and by the variant (replayed offline), and a third
+// model judges which is better — controlling for prompt variance, which
+// pointwise scoring can't. Position bias is countered by randomizing which
+// response is shown as "A" (the caller passes variantFirst, flipped per call).
+
+// PairwiseResult is one head-to-head comparison from the variant's point of
+// view. VariantPreference: 1=variant better, 0.5=tie, 0=control better — so a
+// per-variant mean is a win-rate (>0.5 = variant beats control).
+type PairwiseResult struct {
+	VariantPreference float64 `json:"variant_preference"`
+	Winner            string  `json:"winner"` // variant | control | tie
+	Abstain           bool    `json:"abstain"`
+	RubricVersion     string  `json:"rubric_version"`
+	Workflow          string  `json:"workflow"`
+}
+
+// ScorePairwise judges controlResp vs variantResp for the same prompt. The
+// caller flips a coin into variantFirst so the variant isn't always in the
+// same slot (position-bias control); ScorePairwise maps the judged winner slot
+// back to a variant preference. An unparseable reply abstains.
+func (j *Judge) ScorePairwise(ctx context.Context, workflow, prompt, controlResp, variantResp string, variantFirst bool) (PairwiseResult, error) {
+	r := rubricFor(workflow)
+
+	a, b := controlResp, variantResp
+	if variantFirst {
+		a, b = variantResp, controlResp
+	}
+	sys := buildPairwiseSystem(r)
+	user := "PROMPT:\n" + truncate(prompt, 6000) +
+		"\n\nRESPONSE A:\n" + truncate(a, 4000) +
+		"\n\nRESPONSE B:\n" + truncate(b, 4000)
+
+	raw, err := j.LLM.Complete(ctx, j.Model, sys, user)
+	if err != nil {
+		return PairwiseResult{}, fmt.Errorf("judge.ScorePairwise: %w", err)
+	}
+	return parsePairwise(raw, workflow, variantFirst), nil
+}
+
+func buildPairwiseSystem(r rubric) string {
+	return "You are an impartial judge comparing two responses (A and B) to the same prompt — " +
+		r.framing + ".\nDecide which response is better overall on: " + strings.Join(r.dims, ", ") +
+		".\nIf they are equally good, answer \"tie\". If you cannot fairly judge, set \"abstain\": true.\n" +
+		"Respond with ONLY a JSON object, no prose:\n" +
+		`{"winner":"A","abstain":false}`
+}
+
+// parsePairwise maps the judged winner slot (A/B) back to a variant
+// preference, given which slot the variant occupied.
+func parsePairwise(raw, workflow string, variantFirst bool) PairwiseResult {
+	out := PairwiseResult{RubricVersion: RubricVersion, Workflow: workflow}
+	body := extractJSON(raw)
+	if body == "" {
+		out.Abstain = true
+		return out
+	}
+	var parsed struct {
+		Winner  string `json:"winner"`
+		Abstain bool   `json:"abstain"`
+	}
+	if err := json.Unmarshal([]byte(body), &parsed); err != nil {
+		out.Abstain = true
+		return out
+	}
+	if parsed.Abstain {
+		out.Abstain = true
+		return out
+	}
+	// The variant is slot A when variantFirst, else slot B.
+	variantSlot := "B"
+	if variantFirst {
+		variantSlot = "A"
+	}
+	switch strings.ToUpper(strings.TrimSpace(parsed.Winner)) {
+	case "A", "B":
+		if strings.EqualFold(parsed.Winner, variantSlot) {
+			out.Winner, out.VariantPreference = "variant", 1.0
+		} else {
+			out.Winner, out.VariantPreference = "control", 0.0
+		}
+	case "TIE", "":
+		if parsed.Winner == "" {
+			out.Abstain = true
+			return out
+		}
+		out.Winner, out.VariantPreference = "tie", 0.5
+	default:
+		out.Abstain = true
+	}
+	return out
+}

--- a/pkg/aiqg/judge/pairwise_test.go
+++ b/pkg/aiqg/judge/pairwise_test.go
@@ -1,0 +1,81 @@
+package judge
+
+import (
+	"context"
+	"testing"
+)
+
+func TestScorePairwise_VariantWinsEitherSlot(t *testing.T) {
+	// variantFirst=true → variant is slot A; judge picks A → variant wins.
+	f := &fakeLLM{reply: `{"winner":"A"}`}
+	j := &Judge{LLM: f, Model: "judge"}
+	r, err := j.ScorePairwise(context.Background(), "single_turn_qa", "p", "control resp", "variant resp", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Winner != "variant" || r.VariantPreference != 1.0 {
+		t.Errorf("variantFirst + winner A should be variant win, got %+v", r)
+	}
+
+	// variantFirst=false → variant is slot B; judge picks B → variant wins.
+	f2 := &fakeLLM{reply: `{"winner":"B"}`}
+	j2 := &Judge{LLM: f2, Model: "judge"}
+	r2, _ := j2.ScorePairwise(context.Background(), "single_turn_qa", "p", "control resp", "variant resp", false)
+	if r2.Winner != "variant" || r2.VariantPreference != 1.0 {
+		t.Errorf("!variantFirst + winner B should be variant win, got %+v", r2)
+	}
+}
+
+func TestScorePairwise_ControlWins(t *testing.T) {
+	// variantFirst=true → control is slot B; judge picks B → control wins.
+	f := &fakeLLM{reply: `{"winner":"B"}`}
+	j := &Judge{LLM: f, Model: "judge"}
+	r, _ := j.ScorePairwise(context.Background(), "rag", "p", "control resp", "variant resp", true)
+	if r.Winner != "control" || r.VariantPreference != 0.0 {
+		t.Errorf("expected control win (pref 0), got %+v", r)
+	}
+}
+
+func TestScorePairwise_Tie(t *testing.T) {
+	f := &fakeLLM{reply: `{"winner":"tie"}`}
+	j := &Judge{LLM: f, Model: "judge"}
+	r, _ := j.ScorePairwise(context.Background(), "single_turn_qa", "p", "c", "v", false)
+	if r.Winner != "tie" || r.VariantPreference != 0.5 {
+		t.Errorf("expected tie (pref 0.5), got %+v", r)
+	}
+}
+
+func TestScorePairwise_AbstainAndGarble(t *testing.T) {
+	for _, reply := range []string{`{"abstain":true}`, "no idea honestly", `{}`} {
+		f := &fakeLLM{reply: reply}
+		j := &Judge{LLM: f, Model: "judge"}
+		r, err := j.ScorePairwise(context.Background(), "single_turn_qa", "p", "c", "v", true)
+		if err != nil {
+			t.Fatalf("reply %q errored: %v", reply, err)
+		}
+		if !r.Abstain {
+			t.Errorf("reply %q should abstain, got %+v", reply, r)
+		}
+	}
+}
+
+func TestParsePairwise_SlotMapping(t *testing.T) {
+	// Direct table over (winner, variantFirst) → preference.
+	cases := []struct {
+		winner       string
+		variantFirst bool
+		wantPref     float64
+		wantWinner   string
+	}{
+		{"A", true, 1.0, "variant"},
+		{"A", false, 0.0, "control"},
+		{"B", true, 0.0, "control"},
+		{"B", false, 1.0, "variant"},
+	}
+	for _, c := range cases {
+		r := parsePairwise(`{"winner":"`+c.winner+`"}`, "single_turn_qa", c.variantFirst)
+		if r.VariantPreference != c.wantPref || r.Winner != c.wantWinner {
+			t.Errorf("winner=%s variantFirst=%v → %+v, want pref=%v %s", c.winner, c.variantFirst, r, c.wantPref, c.wantWinner)
+		}
+	}
+}


### PR DESCRIPTION
In a live split a prompt hits only one arm, so inline same-prompt A/B isn't possible. **Shadow-eval (§6.3)** closes that: for a sampled **control-arm** response, replay the same prompt through each variant **offline** and judge the pair head-to-head. Zero user impact, ~2× cost on the shadow sample, and it controls for prompt variance — a cleaner quality delta than pointwise. Pairs naturally with dry-run.

- **`judge.ScorePairwise`** — compares control vs variant for the same prompt with **randomized A/B order** (position-bias control, §6.6), maps winner slot → variant preference (1/0.5/0), abstains on garble. Unit-tested incl. the slot-mapping table.
- **`experiments.Resolver.NonControlOverrides`** — the variants a control sample is replayed against.
- **`judgeRunner`** — on a control-arm shadow sample (`AIQG_SHADOW_EVAL_PCT`, separate bucket), replays each variant via the router (configured key, bypasses AIQG middleware) → `ScorePairwise` → records `signal_type=judge_pairwise`. Default off (2× cost).
- Config `AIQG_SHADOW_EVAL_PCT` (dual-struct + env + converter); configmap documents it at 0.

### Verified live (aiqg-v5.35)
dry_run control(100)/gpt4o(0→gpt-4o), shadow 100%: 4 control requests each replayed through gpt-4o + pairwise-judged → 4 `judge_pairwise` rows, avg preference 0.50 (tie — both answer the trivia identically, as expected).

Pairs with aiqg-dashboard-be (ingest + verdict prefers pairwise) + aiqg-ui (win-rate column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)