### PR TITLE
Re-resolve policy bundle at routing time (Phase 2)

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -37,6 +37,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -205,7 +206,12 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// stash on the request context so events.Build can stamp it on
 	// the response event. Errors degrade to Default() so "every event
 	// has a resolution" is upheld even when the resolver is down.
-	var bundleResolution policy.Resolution
+	// Initial resolution at receipt (header / source_app / path only).
+	// The completion handler refines it at routing time via
+	// ResolveBundleForRouting once model + workflow are known. A holder on
+	// ctx lets the deferred emit read whichever resolution is current.
+	bundleResolution := &bundleResolutionHolder{res: policy.Default()}
+	ctx = withBundleResolution(ctx, bundleResolution)
 	if cfg.PolicyResolver != nil && resolvedToken != nil {
 		res, err := cfg.PolicyResolver.Resolve(ctx, policy.ResolveRequest{
 			TenantID:           resolvedToken.TenantID,
@@ -224,9 +230,18 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 				"bundle":    parsed.PolicyBundle,
 			}).Warn("AIQG policy resolver returned error; defaulting to observe-all")
 		}
-		bundleResolution = res
-	} else {
-		bundleResolution = policy.Default()
+		bundleResolution.set(res)
+		// Stash for routing-time refinement. Skipped when an explicit
+		// TAS-Policy-Bundle header already pinned the bundle — model /
+		// workflow matching can't override an operator's explicit choice.
+		if parsed.PolicyBundle == "" {
+			ctx = withPolicyResolve(ctx, &policyResolveCtx{
+				resolver:  cfg.PolicyResolver,
+				tenantID:  resolvedToken.TenantID,
+				accountID: resolvedToken.AIQGAccountID,
+				sourceApp: parsed.SourceApp,
+			})
+		}
 	}
 
 	sw := &statusCapturingResponseWriter{ResponseWriter: w}
@@ -279,11 +294,14 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 			IPCaptureMode:   cfg.IPCaptureMode,
 			ResponseEventID: respEventID,
 			Linkage:         lk,
-			ResolvedPolicyBundle: &events.ResolvedPolicyBundle{
-				BundleID:   bundleResolution.BundleID,
-				BundleName: bundleResolution.BundleName,
-				Source:     bundleResolution.Source,
-			},
+			ResolvedPolicyBundle: func() *events.ResolvedPolicyBundle {
+				res := bundleResolution.get()
+				return &events.ResolvedPolicyBundle{
+					BundleID:   res.BundleID,
+					BundleName: res.BundleName,
+					Source:     res.Source,
+				}
+			}(),
 			ExperimentID:      expSnap.ExperimentID,
 			ExperimentVariant: expSnap.ExperimentVariant,
 		})
@@ -429,6 +447,77 @@ func ResolveExperimentForRouting(ctx context.Context, model, workflowType, path 
 		StampExperiment(ctx, d.ExperimentID, d.Variant)
 	}
 	return d
+}
+
+// bundleResolutionHolder is a mutable, concurrency-safe cell for the
+// request's policy resolution. The middleware seeds it at receipt; the
+// completion handler refines it at routing time (ResolveBundleForRouting);
+// the deferred emit reads whichever value is current.
+type bundleResolutionHolder struct {
+	mu  sync.Mutex
+	res policy.Resolution
+}
+
+func (h *bundleResolutionHolder) set(r policy.Resolution) {
+	h.mu.Lock()
+	h.res = r
+	h.mu.Unlock()
+}
+
+func (h *bundleResolutionHolder) get() policy.Resolution {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.res
+}
+
+type bundleResolutionCtxKey struct{}
+
+func withBundleResolution(ctx context.Context, h *bundleResolutionHolder) context.Context {
+	return context.WithValue(ctx, bundleResolutionCtxKey{}, h)
+}
+
+// policyResolveCtx carries what ResolveBundleForRouting needs to re-resolve
+// the bundle at routing time. Only stashed when no explicit bundle header
+// was set (an explicit header is final).
+type policyResolveCtx struct {
+	resolver  policy.Resolver
+	tenantID  string
+	accountID string
+	sourceApp string
+}
+
+type policyResolveCtxKey struct{}
+
+func withPolicyResolve(ctx context.Context, pc *policyResolveCtx) context.Context {
+	return context.WithValue(ctx, policyResolveCtxKey{}, pc)
+}
+
+// ResolveBundleForRouting re-resolves the policy bundle once the requested
+// model + workflow are known (routing time), so route rules that target by
+// model/workflow take effect. Best-effort: on any error it keeps the
+// receipt-time resolution. No-op when an explicit header already pinned the
+// bundle (the policy-resolve ctx isn't stashed in that case) or outside
+// AIQG mode.
+func ResolveBundleForRouting(ctx context.Context, model, workflowType, path string) {
+	pc, _ := ctx.Value(policyResolveCtxKey{}).(*policyResolveCtx)
+	holder, _ := ctx.Value(bundleResolutionCtxKey{}).(*bundleResolutionHolder)
+	if pc == nil || holder == nil || pc.resolver == nil {
+		return
+	}
+	rctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	res, err := pc.resolver.Resolve(rctx, policy.ResolveRequest{
+		TenantID:      pc.tenantID,
+		AIQGAccountID: pc.accountID,
+		SourceApp:     pc.sourceApp,
+		Path:          path,
+		Model:         model,
+		WorkflowType:  workflowType,
+	})
+	if err != nil {
+		return
+	}
+	holder.set(res)
 }
 
 // experimentIdentity builds the sticky-key ladder from the request's parsed

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -543,6 +543,12 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// the CLEAR latency scorer uses a sensible SLA when the caller
 	// didn't send a TAS-Workflow header. Empty result is a no-op.
 	wf := workflow.Classify(&req)
+	// AIQG (Phase 4.1): refine the policy bundle now that the requested
+	// model + workflow are known, so route rules targeting by model/workflow
+	// take effect. Matches the REQUESTED model (before any experiment
+	// override), consistent with experiment cohort matching below. No-op
+	// outside AIQG / when an explicit bundle header pinned the choice.
+	middleware.ResolveBundleForRouting(r.Context(), req.Model, wf, r.URL.Path)
 	// AIQG experiments (Phase D): resolve the variant claiming this request on
 	// the REQUESTED model + workflow (the cohort matches what the caller
 	// asked), then — for a running experiment — apply the variant's override

--- a/pkg/aiqg/policy/policy.go
+++ b/pkg/aiqg/policy/policy.go
@@ -55,6 +55,11 @@ type ResolveRequest struct {
 	PolicyBundleHeader string // raw TAS-Policy-Bundle header value
 	SourceApp          string
 	Path               string
+	// Routing attributes — only known at routing time, so the gateway
+	// re-resolves then (ResolveBundleForRouting). Empty at receipt.
+	Model        string
+	WorkflowType string
+	Vendor       string
 }
 
 // DashboardResolver calls aiqg-dashboard-be's POST /internal/policy/resolve.
@@ -99,6 +104,9 @@ type resolveRequest struct {
 	PolicyBundleHeader string `json:"policy_bundle_header,omitempty"`
 	SourceApp          string `json:"source_app,omitempty"`
 	Path               string `json:"path,omitempty"`
+	Model              string `json:"model,omitempty"`
+	WorkflowType       string `json:"workflow_type,omitempty"`
+	Vendor             string `json:"vendor,omitempty"`
 }
 
 type resolveResponse struct {
@@ -136,6 +144,9 @@ func (r *DashboardResolver) Resolve(ctx context.Context, req ResolveRequest) (Re
 		PolicyBundleHeader: req.PolicyBundleHeader,
 		SourceApp:          req.SourceApp,
 		Path:               req.Path,
+		Model:              req.Model,
+		WorkflowType:       req.WorkflowType,
+		Vendor:             req.Vendor,
 	})
 	if err != nil {
 		return Default(), fmt.Errorf("policy.DashboardResolver: marshal: %w", err)


### PR DESCRIPTION
Makes Phase 1 policy targeting take effect end-to-end. Pairs with aiqg-dashboard-be resolver step 2. Part of issue aiqg-dashboard-be#68.

## Why
Policy resolution ran only at request receipt, where `model`/`workflow_type` aren't known — so route rules targeting by model/workflow could never match. Now the completion handler re-resolves once they're known, mirroring experiment cohort resolution.

## Changes
- `bundleResolutionHolder` on ctx holds the resolution; the deferred event emit reads the current value. Seeded at receipt, refined at routing.
- `ResolveBundleForRouting(model, workflow, path)` re-resolves with full attributes; no-op when an explicit `TAS-Policy-Bundle` header already pinned the bundle, or on resolver error (keeps receipt-time value).
- Called in `server.go` on the **requested** model (before any experiment override), consistent with experiment cohort matching.
- `policy.ResolveRequest` + wire shape gain `model`/`workflow_type`/`vendor`.

Still observe-only (Phase 4.0): the resolved bundle rides on the event; no enforcement yet.

## Verification
- `go build -tags nohs`, `go vet`, `go test` (policy / middleware / server) ✅
- Deployed `tas-llm-router:aiqg-v5.36` to both `llm-router` and `llm-router-aiqg`; pods healthy. Resolver step-2 verified live on the dashboard side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)