### PR TITLE
CLEAR v0.2: projected cost decomposition + per-method savings (Phase 1)

### DIFF
--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -438,6 +438,7 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		FinishReason:               finishReason,
 		AttemptCount:               routing.AttemptCount,
 		FallbackUsed:               routing.FallbackUsed,
+		InboundBloatFindings:       bloatCount(routing.TagFindings),
 	}
 	var tokenAcct *TokenAccounting
 	if routing.UsageSet {
@@ -456,6 +457,27 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 			ta.OutputCostUSD = (float64(completion) / 1000.0) * outputRate
 			ta.TotalCostUSD = ta.InputCostUSD + ta.OutputCostUSD
 			ta.ModelPricingVersion = clear.PricingVersion
+
+			// Cost decomposition (CLEAR v0.2, Contract v1 — projected).
+			// Only on priced traffic; never fabricate waste otherwise.
+			actual := clear.ActualCost(routing.Vendor, routing.Model, prompt, completion, routing.UsageSet)
+			d := clear.DecomposeCost(clearInput, actual)
+			ta.ActualCostUSD = actual.TotalUSD
+			ta.ActualCostSource = actual.Source
+			ta.ReductionMode = d.ReductionMode
+			ta.ContextEfficiencyRatio = d.ContextEfficiencyRatio
+			ta.ProjectedDirectPayloadWasteTokens = d.DirectPayloadWasteTokens
+			ta.ProjectedDirectPayloadWasteUSD = d.DirectPayloadWasteUSD
+			ta.DirectPayloadWasteTokens = d.DirectPayloadWasteTokens // alias = projected
+			ta.DirectPayloadWasteUSD = d.DirectPayloadWasteUSD       // alias = projected
+			ta.ProjectedReductionRelevanceUSD = d.ProjectedReductionRelevanceUSD
+			ta.ProjectedReductionRelevanceConfidence = d.ProjectedReductionRelevanceConfidence
+			ta.ProjectedReductionSLMUSD = d.ProjectedReductionSLMUSD
+			ta.ProjectedReductionSLMConfidence = d.ProjectedReductionSLMConfidence
+			ta.ProjectedReductionCombinedUSD = d.ProjectedReductionCombinedUSD
+			ta.InducedOutputWasteEstimatedUSD = d.InducedOutputWasteEstimatedUSD
+			ta.GenuinePostModelWasteUSD = d.GenuinePostModelWasteUSD
+			ta.GatewayAddressablePct = d.GatewayAddressablePct
 		}
 		tokenAcct = ta
 	}
@@ -579,6 +601,16 @@ func sumCounts(m map[string]int) int {
 		total += v
 	}
 	return total
+}
+
+// bloatCount sums the inbound bloat / instruction-stuffing matches from
+// the per-pattern TagFindings map — the signal the cost decomposer uses
+// to discount context efficiency. nil-safe.
+func bloatCount(tagFindings map[string]int) int {
+	if tagFindings == nil {
+		return 0
+	}
+	return tagFindings["aiqg-bloated-context"] + tagFindings["aiqg-instruction-stuffing"]
 }
 
 // worstSeverityIn returns the highest severity present across either

--- a/pkg/aiqg/events/cost_decomp_event_test.go
+++ b/pkg/aiqg/events/cost_decomp_event_test.go
@@ -1,0 +1,59 @@
+package events
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Guards the Contract v1 JSON keys + CER pointer semantics that the
+// dashboard-be Loki queries and Spark aggregator depend on. A rename or
+// retype here is a breaking contract change.
+func TestTokenAccounting_CostDecompJSONContract(t *testing.T) {
+	cer := 0.42
+	ta := TokenAccounting{
+		PromptTokens: 1000, CompletionTokens: 200, TotalTokens: 1200,
+		TotalCostUSD: 0.0075, ActualCostUSD: 0.0075, ActualCostSource: "vendor_usage",
+		ReductionMode:                     "projected",
+		ProjectedDirectPayloadWasteTokens: 300, ProjectedDirectPayloadWasteUSD: 0.0007,
+		DirectPayloadWasteTokens: 300, DirectPayloadWasteUSD: 0.0007,
+		ProjectedReductionRelevanceUSD: 0.0007, ProjectedReductionRelevanceConfidence: "medium",
+		ProjectedReductionSLMUSD: 0.0006, ProjectedReductionSLMConfidence: "low",
+		ProjectedReductionCombinedUSD: 0.0011,
+		GenuinePostModelWasteUSD:      0,
+		GatewayAddressablePct:         9.3,
+		ContextEfficiencyRatio:        &cer,
+	}
+	b, err := json.Marshal(ta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, key := range []string{
+		"reduction_mode", "actual_cost_usd", "actual_cost_source",
+		"projected_direct_payload_waste_tokens", "projected_direct_payload_waste_usd",
+		"direct_payload_waste_tokens", "direct_payload_waste_usd",
+		"projected_reduction_relevance_usd", "projected_reduction_relevance_confidence",
+		"projected_reduction_slm_usd", "projected_reduction_slm_confidence",
+		"projected_reduction_combined_usd", "gateway_addressable_pct", "context_efficiency_ratio",
+	} {
+		if !strings.Contains(s, `"`+key+`"`) {
+			t.Errorf("missing contract key %q in %s", key, s)
+		}
+	}
+
+	// CER pointer: 0.0 is meaningful and must round-trip distinctly from absent.
+	var back TokenAccounting
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.ContextEfficiencyRatio == nil || *back.ContextEfficiencyRatio != 0.42 {
+		t.Errorf("CER pointer did not round-trip: %v", back.ContextEfficiencyRatio)
+	}
+
+	// Empty decomposition (unpriced traffic) omits the fields entirely.
+	empty, _ := json.Marshal(TokenAccounting{PromptTokens: 5, TotalCostUSD: 0})
+	if strings.Contains(string(empty), "reduction_mode") || strings.Contains(string(empty), "context_efficiency_ratio") {
+		t.Errorf("unpriced TokenAccounting must omit decomposition fields: %s", empty)
+	}
+}

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -156,6 +156,25 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 		respFields["completion_tokens"] = ta.CompletionTokens
 		respFields["total_tokens"] = ta.TotalTokens
 		respFields["total_cost_usd"] = ta.TotalCostUSD
+		// Cost decomposition (CLEAR v0.2) — promote as FIELDS (never
+		// stream labels: these are high-cardinality numerics). The
+		// Loki-fallback backend unwraps these; only present on priced
+		// traffic where the decomposer ran (ReductionMode set).
+		if ta.ReductionMode != "" {
+			respFields["reduction_mode"] = ta.ReductionMode
+			respFields["actual_cost_usd"] = ta.ActualCostUSD
+			respFields["projected_direct_payload_waste_usd"] = ta.ProjectedDirectPayloadWasteUSD
+			respFields["direct_payload_waste_usd"] = ta.DirectPayloadWasteUSD
+			respFields["projected_reduction_relevance_usd"] = ta.ProjectedReductionRelevanceUSD
+			respFields["projected_reduction_slm_usd"] = ta.ProjectedReductionSLMUSD
+			respFields["projected_reduction_combined_usd"] = ta.ProjectedReductionCombinedUSD
+			respFields["induced_output_waste_estimated_usd"] = ta.InducedOutputWasteEstimatedUSD
+			respFields["genuine_post_model_waste_usd"] = ta.GenuinePostModelWasteUSD
+			respFields["gateway_addressable_pct"] = ta.GatewayAddressablePct
+			if ta.ContextEfficiencyRatio != nil {
+				respFields["context_efficiency_ratio"] = *ta.ContextEfficiencyRatio
+			}
+		}
 	}
 	// Promote the timing decomposition so LogQL can unwrap each
 	// component directly. instrumentation.Snapshot captures the full

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -258,6 +258,34 @@ type TokenAccounting struct {
 	OutputCostUSD       float64 `json:"output_cost_usd"`
 	TotalCostUSD        float64 `json:"total_cost_usd"`
 	ModelPricingVersion string  `json:"model_pricing_version,omitempty"`
+
+	// --- Cost decomposition (CLEAR v0.2, Contract v1 — projected) ---
+	// All additive + omitempty; populated only for priced traffic when
+	// the decomposer runs. See pkg/clear/cost_decomposer.go and
+	// aether-shared/data-models/aiqg/token-accounting.md.
+	ActualCostUSD    float64 `json:"actual_cost_usd,omitempty"`    // billed total (invariant denominator); = TotalCostUSD in v1
+	ActualCostSource string  `json:"actual_cost_source,omitempty"` // "vendor_usage" | "computed"
+	ReductionMode    string  `json:"reduction_mode,omitempty"`     // always "projected" in v1
+
+	// Direct payload waste — projected basis. The bare DirectPayloadWaste*
+	// are the documented alias (= projected) kept for the existing CHECK +
+	// dashboards (relabel "projected" in UI).
+	ProjectedDirectPayloadWasteTokens int     `json:"projected_direct_payload_waste_tokens,omitempty"`
+	ProjectedDirectPayloadWasteUSD    float64 `json:"projected_direct_payload_waste_usd,omitempty"`
+	DirectPayloadWasteTokens          int     `json:"direct_payload_waste_tokens,omitempty"`
+	DirectPayloadWasteUSD             float64 `json:"direct_payload_waste_usd,omitempty"`
+
+	// Per-method projected reductions + confidence.
+	ProjectedReductionRelevanceUSD        float64 `json:"projected_reduction_relevance_usd,omitempty"`
+	ProjectedReductionRelevanceConfidence string  `json:"projected_reduction_relevance_confidence,omitempty"`
+	ProjectedReductionSLMUSD              float64 `json:"projected_reduction_slm_usd,omitempty"`
+	ProjectedReductionSLMConfidence       string  `json:"projected_reduction_slm_confidence,omitempty"`
+	ProjectedReductionCombinedUSD         float64 `json:"projected_reduction_combined_usd,omitempty"`
+
+	InducedOutputWasteEstimatedUSD float64  `json:"induced_output_waste_estimated_usd,omitempty"` // 0 in v1
+	GenuinePostModelWasteUSD       float64  `json:"genuine_post_model_waste_usd,omitempty"`
+	GatewayAddressablePct          float64  `json:"gateway_addressable_pct,omitempty"`
+	ContextEfficiencyRatio         *float64 `json:"context_efficiency_ratio,omitempty"` // pointer: 0.0 vs absent
 }
 
 // AssuranceSummary is the lightweight per-event view of Gatekeeper

--- a/pkg/clear/clear.go
+++ b/pkg/clear/clear.go
@@ -14,10 +14,10 @@
 //   - Cost, Efficacy, Assurance, Reliability — signatures defined,
 //     return nil pointers (distinct from "scored as zero"). Filled by
 //     future slices:
-//       * Cost: needs token-accounting from response body
-//       * Efficacy: needs response-body capture + structural-validity check
-//       * Assurance: needs Gatekeeper finding integration
-//       * Reliability: needs conversation-threading + retry detection
+//   - Cost: needs token-accounting from response body
+//   - Efficacy: needs response-body capture + structural-validity check
+//   - Assurance: needs Gatekeeper finding integration
+//   - Reliability: needs conversation-threading + retry detection
 //   - Composite — equal-weight average of every dimension that produced
 //     a non-nil score (per build-vs-reuse §7.5). Nil when zero dimensions
 //     were scored.
@@ -32,8 +32,10 @@ package clear
 // `clear-v<major>.<minor>-<phase>`.
 //
 // MVP (v0.1): Latency only. Cost/Efficacy/Assurance/Reliability stubbed.
-// v0.2 will add Cost once token-accounting plumbing lands.
-const Version = "clear-v0.1-mvp"
+// v0.2 (cost-decomp): adds the projected cost decomposition (see
+// cost_decomposer.go) emitted alongside the scores. Spark re-scores rows
+// scored under the prior version when this bumps.
+const Version = "clear-v0.2-cost-decomp"
 
 // Score is a 0-100 dimension or composite score. The spec
 // (response-event.md §"Why smallint not numeric") uses int16 for storage
@@ -88,6 +90,13 @@ type Input struct {
 	AssuranceScanRan           bool
 	InboundFindingsBySeverity  map[string]int
 	OutboundFindingsBySeverity map[string]int
+
+	// InboundBloatFindings counts inbound bloat/instruction-stuffing
+	// matches (aiqg-bloated-context + aiqg-instruction-stuffing). Used by
+	// the cost decomposer to discount context-efficiency — a strong
+	// signal the prompt carries droppable padding. Not a CLEAR score
+	// input; consumed only by DecomposeCost.
+	InboundBloatFindings int
 
 	// Vendor finish_reason for Efficacy scoring. Empty string means
 	// the vendor never returned one (gateway-blocked, streaming

--- a/pkg/clear/cost.go
+++ b/pkg/clear/cost.go
@@ -29,19 +29,19 @@ type modelPricingEntry struct {
 // slice will eventually pull per-account overrides.
 var modelPricing = map[string]modelPricingEntry{
 	// OpenAI
-	"openai:gpt-4o-mini":           {InputCostPer1K: 0.00015, OutputCostPer1K: 0.00060},
-	"openai:gpt-4o":                {InputCostPer1K: 0.00250, OutputCostPer1K: 0.01000},
-	"openai:gpt-4-turbo":           {InputCostPer1K: 0.01000, OutputCostPer1K: 0.03000},
-	"openai:gpt-3.5-turbo":         {InputCostPer1K: 0.00050, OutputCostPer1K: 0.00150},
+	"openai:gpt-4o-mini":   {InputCostPer1K: 0.00015, OutputCostPer1K: 0.00060},
+	"openai:gpt-4o":        {InputCostPer1K: 0.00250, OutputCostPer1K: 0.01000},
+	"openai:gpt-4-turbo":   {InputCostPer1K: 0.01000, OutputCostPer1K: 0.03000},
+	"openai:gpt-3.5-turbo": {InputCostPer1K: 0.00050, OutputCostPer1K: 0.00150},
 
 	// Anthropic — Claude 4.x family (current TAS deployment, see
 	// tas-llm-router/configs/config.yaml). Keep rates in sync with that
 	// file; the config and this table can drift independently because
 	// the config doesn't feed the scorer (the table is the
 	// authoritative source for CLEAR.Cost).
-	"anthropic:claude-opus-4-6":            {InputCostPer1K: 0.01500, OutputCostPer1K: 0.07500},
-	"anthropic:claude-sonnet-4-6":          {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
-	"anthropic:claude-haiku-4-5-20251001":  {InputCostPer1K: 0.00080, OutputCostPer1K: 0.00400},
+	"anthropic:claude-opus-4-6":           {InputCostPer1K: 0.01500, OutputCostPer1K: 0.07500},
+	"anthropic:claude-sonnet-4-6":         {InputCostPer1K: 0.00300, OutputCostPer1K: 0.01500},
+	"anthropic:claude-haiku-4-5-20251001": {InputCostPer1K: 0.00080, OutputCostPer1K: 0.00400},
 
 	// Anthropic — Claude 3.x family (legacy, kept for replay /
 	// historical re-scoring; remove once Spark re-score has caught up
@@ -79,6 +79,39 @@ func DollarCost(vendor, model string, promptTokens, completionTokens int) (cost 
 	}
 	cost = (float64(promptTokens)/1000.0)*inputRate + (float64(completionTokens)/1000.0)*outputRate
 	return cost, true
+}
+
+// Cost is the dollar breakdown of one request, returned by ActualCost.
+// It's the *billed* cost in Contract v1 (= the invariant denominator the
+// cost decomposition is bounded against). Priced=false when the
+// vendor:model pricing isn't known — callers must not fabricate waste on
+// unpriced traffic.
+type Cost struct {
+	InputUSD  float64
+	OutputUSD float64
+	TotalUSD  float64
+	Source    string // "vendor_usage" (counts from the vendor) | "computed"
+	Priced    bool
+}
+
+// ActualCost computes the billed dollar cost of a request from token
+// counts + the model's rates. In Contract v1 this equals the existing
+// DollarCost total; it's surfaced separately as `actual_cost_usd` so the
+// cost-decomposition fields have a stable denominator. usageFromVendor
+// distinguishes vendor-reported usage from gateway-estimated counts
+// (recorded as actual_cost_source).
+func ActualCost(vendor, model string, promptTokens, completionTokens int, usageFromVendor bool) Cost {
+	inputRate, outputRate, found := LookupPricing(vendor, model)
+	if !found {
+		return Cost{Priced: false}
+	}
+	in := (float64(promptTokens) / 1000.0) * inputRate
+	out := (float64(completionTokens) / 1000.0) * outputRate
+	src := "computed"
+	if usageFromVendor {
+		src = "vendor_usage"
+	}
+	return Cost{InputUSD: in, OutputUSD: out, TotalUSD: in + out, Source: src, Priced: true}
 }
 
 // scoreCost converts the request's USD cost into a 0-100 score with a

--- a/pkg/clear/cost_decomposer.go
+++ b/pkg/clear/cost_decomposer.go
@@ -1,0 +1,173 @@
+package clear
+
+import "math"
+
+// Cost decomposition (CLEAR v0.2, Contract v1 — projected basis only).
+//
+// Splits a request's billed cost into the three source-spec §1.4/§2.1
+// categories and projects per-method payload-reduction savings, using a
+// cheap inline heuristic (no network, no embeddings, <1ms). This is the
+// "projected" basis — what the gateway *could* save if extraction ran.
+// Measured/actual reductions (Contract v2) come only from the real
+// extractor under an experiment/policy and are NOT computed here.
+//
+// Invariant (#6): direct + induced + genuine ≤ actual.TotalUSD. The
+// bound clamp below enforces it at the source so the eventual SQL CHECK
+// can never be violated; TestDecompose_BoundInvariant is the canary.
+const (
+	// cerK shapes the context-efficiency proxy CER = r/(r+K) where
+	// r = completion/prompt. K=0.5 means a request whose output is half
+	// its input scores CER≈0.5 (half the context was "worth it").
+	cerK = 0.5
+	// bloatCERMultiplier discounts CER when the inbound scan flagged
+	// bloat/instruction-stuffing — strong signal that context is padded.
+	bloatCERMultiplier = 0.7
+	// slmCompress is the assumed standalone compression an SLM rewrite
+	// achieves on the prompt (~25%). Low confidence — a coarse prior
+	// until the real SLM step measures it (Contract v2).
+	slmCompress = 0.25
+
+	confMedium = "medium"
+	confLow    = "low"
+
+	reductionModeProjected = "projected"
+)
+
+// Decomposition is the projected cost breakdown for one priced request.
+// All USD fields are bounded by actual.TotalUSD (see invariant). The
+// bare DirectPayloadWaste* are the documented alias of the projected
+// basis (Contract v1 D1-B) — kept so existing dashboards/CHECK keep
+// working; relabel as "projected" in the UI.
+type Decomposition struct {
+	ReductionMode          string
+	ContextEfficiencyRatio *float64 // pointer: 0.0 (all context wasted) vs absent
+
+	DirectPayloadWasteTokens int
+	DirectPayloadWasteUSD    float64
+
+	ProjectedReductionRelevanceUSD        float64
+	ProjectedReductionRelevanceConfidence string
+	ProjectedReductionSLMUSD              float64
+	ProjectedReductionSLMConfidence       string
+	ProjectedReductionCombinedUSD         float64
+
+	InducedOutputWasteEstimatedUSD float64
+	GenuinePostModelWasteUSD       float64
+	GatewayAddressablePct          float64
+}
+
+// DecomposeCost runs the heuristic. Call only when actual.Priced — never
+// fabricate waste on unpriced traffic.
+func DecomposeCost(in Input, actual Cost) Decomposition {
+	prompt, completion := 0, 0
+	if in.PromptTokens != nil {
+		prompt = *in.PromptTokens
+	}
+	if in.CompletionTokens != nil {
+		completion = *in.CompletionTokens
+	}
+
+	// Context-efficiency ratio: how much of the input "earned its keep".
+	r := float64(completion) / math.Max(float64(prompt), 1)
+	cer := r / (r + cerK)
+	if in.InboundBloatFindings > 0 {
+		cer *= bloatCERMultiplier
+	}
+	cer = clamp01(cer)
+	relFrac := 1 - cer // fraction of input context projected droppable
+
+	inputCost := actual.InputUSD
+
+	// Direct payload waste = input dollars spent on droppable context.
+	directUSD := inputCost * relFrac
+	directTokens := int(math.Round(float64(prompt) * relFrac))
+
+	// Per-method standalone projections.
+	relevanceUSD := directUSD                                    // relevance/top-K drops the droppable context
+	slmUSD := inputCost * slmCompress                            // SLM rewrite compresses the whole prompt ~25%
+	combinedUSD := inputCost * (1 - (1-relFrac)*(1-slmCompress)) // compound the two
+
+	// Induced output waste (retries/abandonment) — 0 in v1 (retry
+	// linkage is Contract v2).
+	inducedUSD := 0.0
+
+	// Genuine post-model waste: spend that no payload reduction could
+	// have saved. A hard failure (HTTP ≥400 / content_filter) wastes the
+	// whole spend; high/critical OUTBOUND findings (the model produced
+	// something unsafe despite clean input) waste the output spend.
+	genuineUSD := 0.0
+	switch {
+	case in.HTTPStatus >= 400 || in.FinishReason == "content_filter":
+		genuineUSD = actual.TotalUSD
+	case outboundHighCritical(in.OutboundFindingsBySeverity) > 0:
+		genuineUSD = actual.OutputUSD
+	}
+
+	// Bound clamp — enforce the invariant at the source.
+	budget := actual.TotalUSD
+	genuineUSD = clampUSD(genuineUSD, 0, budget)
+	origDirect := directUSD
+	directUSD = clampUSD(directUSD, 0, budget-genuineUSD)
+	if origDirect > 0 && directUSD < origDirect {
+		// Scale tokens to the clamped dollar figure so the two agree.
+		directTokens = int(math.Round(float64(directTokens) * (directUSD / origDirect)))
+	}
+	// Per-method reductions can't exceed the input spend.
+	relevanceUSD = clampUSD(relevanceUSD, 0, inputCost)
+	slmUSD = clampUSD(slmUSD, 0, inputCost)
+	combinedUSD = clampUSD(combinedUSD, 0, inputCost)
+
+	// Gateway-addressable share of the spend (direct + induced).
+	addressablePct := 0.0
+	if budget > 0 {
+		addressablePct = (directUSD + inducedUSD) / budget * 100
+	}
+
+	cerOut := cer
+	return Decomposition{
+		ReductionMode:                         reductionModeProjected,
+		ContextEfficiencyRatio:                &cerOut,
+		DirectPayloadWasteTokens:              directTokens,
+		DirectPayloadWasteUSD:                 directUSD,
+		ProjectedReductionRelevanceUSD:        relevanceUSD,
+		ProjectedReductionRelevanceConfidence: confMedium,
+		ProjectedReductionSLMUSD:              slmUSD,
+		ProjectedReductionSLMConfidence:       confLow,
+		ProjectedReductionCombinedUSD:         combinedUSD,
+		InducedOutputWasteEstimatedUSD:        inducedUSD,
+		GenuinePostModelWasteUSD:              genuineUSD,
+		GatewayAddressablePct:                 addressablePct,
+	}
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}
+
+func clampUSD(v, lo, hi float64) float64 {
+	if hi < lo {
+		hi = lo
+	}
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// outboundHighCritical sums high+critical findings in an outbound
+// severity map (nil-safe).
+func outboundHighCritical(bySeverity map[string]int) int {
+	if bySeverity == nil {
+		return 0
+	}
+	return bySeverity["high"] + bySeverity["critical"]
+}

--- a/pkg/clear/cost_decomposer_test.go
+++ b/pkg/clear/cost_decomposer_test.go
@@ -1,0 +1,135 @@
+package clear
+
+import (
+	"math"
+	"testing"
+)
+
+func ip(v int) *int { return &v }
+
+func TestActualCost(t *testing.T) {
+	// gpt-4o: input 0.00250/1k, output 0.01000/1k.
+	c := ActualCost("openai", "gpt-4o", 1000, 500, true)
+	if !c.Priced {
+		t.Fatal("expected priced")
+	}
+	if math.Abs(c.InputUSD-0.0025) > 1e-9 || math.Abs(c.OutputUSD-0.005) > 1e-9 {
+		t.Errorf("input=%v output=%v", c.InputUSD, c.OutputUSD)
+	}
+	if math.Abs(c.TotalUSD-0.0075) > 1e-9 {
+		t.Errorf("total=%v want 0.0075", c.TotalUSD)
+	}
+	if c.Source != "vendor_usage" {
+		t.Errorf("source=%q want vendor_usage", c.Source)
+	}
+	if ActualCost("openai", "gpt-4o", 1, 1, false).Source != "computed" {
+		t.Error("expected computed source when usageFromVendor=false")
+	}
+	if ActualCost("openai", "no-such-model", 1, 1, true).Priced {
+		t.Error("unpriced model should return Priced=false")
+	}
+}
+
+func TestDecompose_ModeAndInducedAndCER(t *testing.T) {
+	in := Input{Vendor: "openai", Model: "gpt-4o", PromptTokens: ip(1000), CompletionTokens: ip(1000), HTTPStatus: 200}
+	d := DecomposeCost(in, ActualCost("openai", "gpt-4o", 1000, 1000, true))
+	if d.ReductionMode != "projected" {
+		t.Errorf("mode=%q want projected", d.ReductionMode)
+	}
+	if d.InducedOutputWasteEstimatedUSD != 0 {
+		t.Errorf("induced must be 0 in v1, got %v", d.InducedOutputWasteEstimatedUSD)
+	}
+	if d.ContextEfficiencyRatio == nil {
+		t.Fatal("CER must be set")
+	}
+	// completion==prompt → r=1 → CER=1/(1+0.5)=0.667
+	if got := *d.ContextEfficiencyRatio; math.Abs(got-0.6667) > 0.001 {
+		t.Errorf("CER=%v want ~0.667", got)
+	}
+}
+
+func TestDecompose_BloatDiscountsCER(t *testing.T) {
+	base := Input{Vendor: "openai", Model: "gpt-4o", PromptTokens: ip(1000), CompletionTokens: ip(1000), HTTPStatus: 200}
+	bloat := base
+	bloat.InboundBloatFindings = 3
+	a := ActualCost("openai", "gpt-4o", 1000, 1000, true)
+	cerBase := *DecomposeCost(base, a).ContextEfficiencyRatio
+	cerBloat := *DecomposeCost(bloat, a).ContextEfficiencyRatio
+	if !(cerBloat < cerBase) {
+		t.Errorf("bloat should lower CER: base=%v bloat=%v", cerBase, cerBloat)
+	}
+}
+
+func TestDecompose_DirectWaste(t *testing.T) {
+	// Low CER (tiny output) → most input is droppable.
+	in := Input{Vendor: "openai", Model: "gpt-4o", PromptTokens: ip(10000), CompletionTokens: ip(10), HTTPStatus: 200}
+	a := ActualCost("openai", "gpt-4o", 10000, 10, true)
+	d := DecomposeCost(in, a)
+	cer := *d.ContextEfficiencyRatio
+	wantUSD := a.InputUSD * (1 - cer)
+	if math.Abs(d.DirectPayloadWasteUSD-wantUSD) > 1e-9 {
+		t.Errorf("direct usd=%v want %v", d.DirectPayloadWasteUSD, wantUSD)
+	}
+	wantTokens := int(math.Round(10000 * (1 - cer)))
+	if d.DirectPayloadWasteTokens != wantTokens {
+		t.Errorf("direct tokens=%d want %d", d.DirectPayloadWasteTokens, wantTokens)
+	}
+	// relevance == direct; combined >= relevance and >= slm.
+	if math.Abs(d.ProjectedReductionRelevanceUSD-d.DirectPayloadWasteUSD) > 1e-9 {
+		t.Errorf("relevance should equal direct waste")
+	}
+	if d.ProjectedReductionCombinedUSD < d.ProjectedReductionRelevanceUSD-1e-9 ||
+		d.ProjectedReductionCombinedUSD < d.ProjectedReductionSLMUSD-1e-9 {
+		t.Errorf("combined %v should dominate relevance %v / slm %v",
+			d.ProjectedReductionCombinedUSD, d.ProjectedReductionRelevanceUSD, d.ProjectedReductionSLMUSD)
+	}
+}
+
+func TestDecompose_GenuineOnFailure(t *testing.T) {
+	// HTTP 500 → whole spend is genuine waste; direct clamps to 0.
+	in := Input{Vendor: "openai", Model: "gpt-4o", PromptTokens: ip(1000), CompletionTokens: ip(100), HTTPStatus: 500}
+	a := ActualCost("openai", "gpt-4o", 1000, 100, true)
+	d := DecomposeCost(in, a)
+	if math.Abs(d.GenuinePostModelWasteUSD-a.TotalUSD) > 1e-9 {
+		t.Errorf("genuine=%v want total %v", d.GenuinePostModelWasteUSD, a.TotalUSD)
+	}
+	if d.DirectPayloadWasteUSD != 0 || d.DirectPayloadWasteTokens != 0 {
+		t.Errorf("direct must clamp to 0 on full-genuine failure, got usd=%v tok=%d", d.DirectPayloadWasteUSD, d.DirectPayloadWasteTokens)
+	}
+}
+
+func TestDecompose_GenuineOnOutboundFindings(t *testing.T) {
+	in := Input{Vendor: "openai", Model: "gpt-4o", PromptTokens: ip(1000), CompletionTokens: ip(1000), HTTPStatus: 200,
+		OutboundFindingsBySeverity: map[string]int{"high": 1}}
+	a := ActualCost("openai", "gpt-4o", 1000, 1000, true)
+	d := DecomposeCost(in, a)
+	if math.Abs(d.GenuinePostModelWasteUSD-a.OutputUSD) > 1e-9 {
+		t.Errorf("genuine=%v want output %v", d.GenuinePostModelWasteUSD, a.OutputUSD)
+	}
+}
+
+// TestDecompose_BoundInvariant — the Go canary for the SQL CHECK:
+// direct + induced + genuine ≤ actual.TotalUSD, across varied inputs.
+func TestDecompose_BoundInvariant(t *testing.T) {
+	prompts := []int{0, 1, 100, 5000, 100000}
+	comps := []int{0, 1, 50, 5000}
+	statuses := []int{200, 400, 500}
+	for _, p := range prompts {
+		for _, comp := range comps {
+			for _, st := range statuses {
+				for _, bloat := range []int{0, 5} {
+					in := Input{Vendor: "openai", Model: "gpt-4o", PromptTokens: ip(p), CompletionTokens: ip(comp), HTTPStatus: st, InboundBloatFindings: bloat}
+					a := ActualCost("openai", "gpt-4o", p, comp, true)
+					d := DecomposeCost(in, a)
+					sum := d.DirectPayloadWasteUSD + d.InducedOutputWasteEstimatedUSD + d.GenuinePostModelWasteUSD
+					if sum > a.TotalUSD+1e-9 {
+						t.Errorf("invariant violated p=%d c=%d st=%d bloat=%d: sum=%v > total=%v", p, comp, st, bloat, sum, a.TotalUSD)
+					}
+					if d.GatewayAddressablePct < 0 || d.GatewayAddressablePct > 100.0001 {
+						t.Errorf("addressable pct out of range: %v", d.GatewayAddressablePct)
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Plan #7 Phase 1 (router). The always-on, **projected** payload-reduction cost metric — no network, <1ms, priced traffic only.

- `pkg/clear/cost.go`: `ActualCost()` → billed `Cost` (invariant denominator); `DollarCost`/`scoreCost` untouched.
- `pkg/clear/cost_decomposer.go` (NEW): `DecomposeCost()` — CER proxy `r/(r+0.5)` (×0.7 on inbound bloat), direct payload waste, per-method projected savings (relevance≈direct, SLM ~25%, combined compounded), induced=0, genuine on failure/unsafe-output, gateway_addressable_pct, **bound clamp** (direct+induced+genuine ≤ actual).
- `clear.go`: `Version` → `clear-v0.2-cost-decomp`; `Input.InboundBloatFindings`.
- events: `TokenAccounting` Contract v1 fields (additive/omitempty, CER `*float64`); builder populates in the priced block; emitter promotes as Loki fields (guarded by `reduction_mode`).
- Tests: `ActualCost`, CER/bloat, direct waste, genuine, per-method, `TestDecompose_BoundInvariant`, JSON contract round-trip.

Pairs with aether-shared `token-accounting.md`. Consumers: aiqg-dashboard-be report preview + aiqg-ui CostDestructionCard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)