### PR TITLE
Gateway receives + parses extraction config (Plan #7 Phase 2, slice 2)

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -492,6 +492,20 @@ func withPolicyResolve(ctx context.Context, pc *policyResolveCtx) context.Contex
 	return context.WithValue(ctx, policyResolveCtxKey{}, pc)
 }
 
+// ResolvedReduction returns the parsed payload-reduction policy for the
+// current request (from the resolved bundle's Spec.reduction), or nil
+// when there's none / outside AIQG mode. Plan #7 Phase 2: the extraction
+// decision point will call this once it's wired to run/shadow Gatekeeper
+// extract. Best-effort: a malformed policy returns (nil, err) so the
+// caller logs and falls back to projected-only.
+func ResolvedReduction(ctx context.Context) (*policy.ReductionPolicy, error) {
+	holder, _ := ctx.Value(bundleResolutionCtxKey{}).(*bundleResolutionHolder)
+	if holder == nil {
+		return nil, nil
+	}
+	return policy.ParseReduction(holder.get().Reduction)
+}
+
 // ResolveBundleForRouting re-resolves the policy bundle once the requested
 // model + workflow are known (routing time), so route rules that target by
 // model/workflow take effect. Best-effort: on any error it keeps the

--- a/pkg/aiqg/policy/policy.go
+++ b/pkg/aiqg/policy/policy.go
@@ -28,6 +28,12 @@ type Resolution struct {
 	BundleID   string
 	BundleName string
 	Source     string
+	// Reduction is the resolved bundle's payload-reduction config (raw
+	// JSON; the `reduction` block of PolicyBundle.Spec). Empty when the
+	// bundle has no extraction policy. Parse with ParseReduction. Plan #7
+	// Phase 2: the gateway reads this to shadow/apply the Gatekeeper
+	// extract pipeline. Today it's only carried + parsed, not executed.
+	Reduction json.RawMessage
 }
 
 // Default returns the sentinel resolution used when the resolver is
@@ -110,9 +116,10 @@ type resolveRequest struct {
 }
 
 type resolveResponse struct {
-	BundleID   string `json:"bundle_id"`
-	BundleName string `json:"bundle_name"`
-	Source     string `json:"source"`
+	BundleID   string          `json:"bundle_id"`
+	BundleName string          `json:"bundle_name"`
+	Source     string          `json:"source"`
+	Reduction  json.RawMessage `json:"reduction,omitempty"`
 }
 
 // ErrResolverBadRequest is returned when the dashboard rejects the
@@ -172,7 +179,7 @@ func (r *DashboardResolver) Resolve(ctx context.Context, req ResolveRequest) (Re
 		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 			return Default(), fmt.Errorf("policy.DashboardResolver: decode 200: %w", err)
 		}
-		return Resolution{BundleID: v.BundleID, BundleName: v.BundleName, Source: v.Source}, nil
+		return Resolution{BundleID: v.BundleID, BundleName: v.BundleName, Source: v.Source, Reduction: v.Reduction}, nil
 	case http.StatusNotFound:
 		// Explicit header named an unknown bundle. Caller can log
 		// distinctly so operators see "your TAS-Policy-Bundle header

--- a/pkg/aiqg/policy/policy_test.go
+++ b/pkg/aiqg/policy/policy_test.go
@@ -108,7 +108,8 @@ func TestStaticResolver(t *testing.T) {
 	want := Resolution{BundleID: "x", BundleName: "y", Source: "tenant_active"}
 	r := StaticResolver{Result: want}
 	got, err := r.Resolve(context.Background(), ResolveRequest{TenantID: "t"})
-	if err != nil || got != want {
+	// Resolution carries a json.RawMessage (uncomparable), so compare fields.
+	if err != nil || got.BundleID != want.BundleID || got.BundleName != want.BundleName || got.Source != want.Source {
 		t.Errorf("got %+v err=%v want %+v err=nil", got, err, want)
 	}
 }

--- a/pkg/aiqg/policy/reduction.go
+++ b/pkg/aiqg/policy/reduction.go
@@ -1,0 +1,106 @@
+package policy
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// ReductionPolicy is the gateway-side typed view of a bundle's
+// `reduction` config (the `PolicyBundle.Spec.reduction` block — see
+// aether-shared/data-models/aiqg/extraction-policy.md). It governs the
+// Gatekeeper payload-reduction pipeline.
+//
+// Plan #7 Phase 2: this slice parses + exposes the policy. A later slice
+// reads it to shadow/apply extraction. Mode semantics:
+//   - off / "" / projected : do not run the real extractor (projected
+//     savings are still computed by CLEAR v0.2 regardless).
+//   - shadow               : run on SampleRate of eligible traffic to
+//     MEASURE reduction, but do NOT apply it to the vendor call.
+//   - active               : apply the reduction (real token drop).
+type ReductionPolicy struct {
+	Mode       string         `json:"mode"`
+	MinTokens  int            `json:"min_tokens,omitempty"`
+	SampleRate float64        `json:"sample_rate,omitempty"`
+	Steps      ReductionSteps `json:"steps"`
+}
+
+type ReductionSteps struct {
+	Chunking  *ChunkingStep  `json:"chunking,omitempty"`
+	Relevance *RelevanceStep `json:"relevance,omitempty"`
+	SLM       *SLMStep       `json:"slm,omitempty"`
+}
+
+type ChunkingStep struct {
+	Enabled bool `json:"enabled"`
+	Size    int  `json:"size,omitempty"`
+	Overlap int  `json:"overlap,omitempty"`
+}
+
+type RelevanceStep struct {
+	Enabled    bool    `json:"enabled"`
+	Threshold  float64 `json:"threshold,omitempty"`
+	TopK       int     `json:"top_k,omitempty"`
+	TopKRatio  float64 `json:"top_k_ratio,omitempty"`
+	EmbedModel string  `json:"embed_model,omitempty"`
+}
+
+type SLMStep struct {
+	Enabled   bool   `json:"enabled"`
+	Model     string `json:"model,omitempty"`
+	MaxTokens int    `json:"max_tokens,omitempty"`
+}
+
+// Reduction mode constants.
+const (
+	ReductionOff       = "off"
+	ReductionProjected = "projected"
+	ReductionShadow    = "shadow"
+	ReductionActive    = "active"
+)
+
+// ParseReduction decodes the raw `reduction` block. Returns nil (not an
+// error) for empty input — the common "no extraction policy" case. A
+// malformed block returns an error so the caller can log it and fall
+// back to projected-only rather than silently mis-extracting.
+func ParseReduction(raw json.RawMessage) (*ReductionPolicy, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	var rp ReductionPolicy
+	if err := json.Unmarshal(raw, &rp); err != nil {
+		return nil, err
+	}
+	rp.Mode = strings.ToLower(strings.TrimSpace(rp.Mode))
+	if rp.Mode == "" {
+		rp.Mode = ReductionProjected
+	}
+	return &rp, nil
+}
+
+// RunsExtractor reports whether the real extractor should run at all
+// (shadow measures, active applies). off/projected never run it.
+func (r *ReductionPolicy) RunsExtractor() bool {
+	if r == nil {
+		return false
+	}
+	return r.Mode == ReductionShadow || r.Mode == ReductionActive
+}
+
+// Applies reports whether the reduction is applied to the vendor call
+// (only active). Shadow runs the extractor but keeps the original payload.
+func (r *ReductionPolicy) Applies() bool {
+	return r != nil && r.Mode == ReductionActive
+}
+
+// EligibleBySize reports whether a prompt of promptTokens clears the
+// MinTokens floor (small prompts aren't worth extracting). True when no
+// floor is set.
+func (r *ReductionPolicy) EligibleBySize(promptTokens int) bool {
+	if r == nil {
+		return false
+	}
+	if r.MinTokens <= 0 {
+		return true
+	}
+	return promptTokens >= r.MinTokens
+}

--- a/pkg/aiqg/policy/reduction_test.go
+++ b/pkg/aiqg/policy/reduction_test.go
@@ -1,0 +1,67 @@
+package policy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseReduction(t *testing.T) {
+	raw := json.RawMessage(`{"mode":"Shadow","min_tokens":8000,"sample_rate":0.05,"steps":{"relevance":{"enabled":true,"threshold":0.3,"top_k":100},"slm":{"enabled":false}}}`)
+	rp, err := ParseReduction(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rp == nil {
+		t.Fatal("expected policy")
+	}
+	if rp.Mode != ReductionShadow { // lower-cased + trimmed
+		t.Errorf("mode=%q want shadow", rp.Mode)
+	}
+	if rp.MinTokens != 8000 || rp.SampleRate != 0.05 {
+		t.Errorf("min=%d rate=%v", rp.MinTokens, rp.SampleRate)
+	}
+	if rp.Steps.Relevance == nil || !rp.Steps.Relevance.Enabled || rp.Steps.Relevance.TopK != 100 {
+		t.Errorf("relevance step not parsed: %+v", rp.Steps.Relevance)
+	}
+}
+
+func TestParseReduction_EmptyAndMalformed(t *testing.T) {
+	if rp, err := ParseReduction(nil); rp != nil || err != nil {
+		t.Errorf("empty → (nil,nil), got (%v,%v)", rp, err)
+	}
+	if _, err := ParseReduction(json.RawMessage(`not json`)); err == nil {
+		t.Error("malformed should error")
+	}
+	// Mode defaults to projected when absent.
+	rp, _ := ParseReduction(json.RawMessage(`{"min_tokens":1}`))
+	if rp == nil || rp.Mode != ReductionProjected {
+		t.Errorf("absent mode should default projected, got %+v", rp)
+	}
+}
+
+func TestReductionModeHelpers(t *testing.T) {
+	var nilrp *ReductionPolicy
+	if nilrp.RunsExtractor() || nilrp.Applies() || nilrp.EligibleBySize(99999) {
+		t.Error("nil policy must be inert")
+	}
+	off := &ReductionPolicy{Mode: ReductionOff}
+	if off.RunsExtractor() || off.Applies() {
+		t.Error("off must not run/apply")
+	}
+	shadow := &ReductionPolicy{Mode: ReductionShadow}
+	if !shadow.RunsExtractor() || shadow.Applies() {
+		t.Error("shadow runs the extractor but does not apply")
+	}
+	active := &ReductionPolicy{Mode: ReductionActive}
+	if !active.RunsExtractor() || !active.Applies() {
+		t.Error("active runs + applies")
+	}
+	// MinTokens floor.
+	sz := &ReductionPolicy{Mode: ReductionActive, MinTokens: 8000}
+	if sz.EligibleBySize(100) {
+		t.Error("below floor should be ineligible")
+	}
+	if !sz.EligibleBySize(8000) {
+		t.Error("at floor should be eligible")
+	}
+}


### PR DESCRIPTION
Builds on aiqg-dashboard-be #73 (resolver returns the config). The gateway now **carries + parses** the bundle's `reduction` policy and exposes it — but does **not** run the extractor yet (isolating the risky hot-path change to the next slice).

- `policy.Resolution` + wire response gain `Reduction` (raw JSON).
- `pkg/aiqg/policy/reduction.go`: typed `ReductionPolicy` + `ParseReduction` + mode helpers (off/projected never run; shadow measures-not-applies; active applies; MinTokens floor).
- `middleware.ResolvedReduction(ctx)` exposes the parsed policy — the seam the next slice (shadow execution + `actual_reduction_*` emission) consumes.
- No behavior change: `EnableExtraction` stays hardcoded false; nothing reads `RunsExtractor` yet. Tests included.

⚠️ **Not deployed** — built/tested locally (`-tags nohs`) only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)