### PR TITLE
Contract v2 measured-reduction fields on TokenAccounting (Plan #7 Phase 2)

### DIFF
--- a/pkg/aiqg/events/cost_measured_event_test.go
+++ b/pkg/aiqg/events/cost_measured_event_test.go
@@ -1,0 +1,49 @@
+package events
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// Guards the Contract v2 (measured) JSON keys + pointer semantics. These
+// are populated only when the real extractor runs (shadow/active); the
+// dashboard-be reader and Spark aggregator depend on these exact names.
+func TestTokenAccounting_MeasuredJSONContract(t *testing.T) {
+	eff, asr := -0.01, 0.0
+	ta := TokenAccounting{
+		ReductionMode:                      "shadow",
+		ReductionSampled:                   true,
+		ActualDirectPayloadReductionTokens: 1200,
+		ActualDirectPayloadReductionUSD:    0.0009,
+		ActualReductionRelevanceUSD:        0.0008,
+		ActualReductionSLMUSD:              0.0003,
+		ReductionEfficacyDelta:             &eff,
+		ReductionAssuranceDelta:            &asr,
+	}
+	b, _ := json.Marshal(ta)
+	s := string(b)
+	for _, k := range []string{
+		"reduction_sampled", "actual_direct_payload_reduction_tokens",
+		"actual_direct_payload_reduction_usd", "actual_reduction_relevance_usd",
+		"actual_reduction_slm_usd", "reduction_efficacy_delta", "reduction_assurance_delta",
+	} {
+		if !strings.Contains(s, `"`+k+`"`) {
+			t.Errorf("missing measured key %q in %s", k, s)
+		}
+	}
+	// assurance delta is 0.0 (measured no change) — must round-trip via pointer.
+	var back TokenAccounting
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.ReductionAssuranceDelta == nil || *back.ReductionAssuranceDelta != 0.0 {
+		t.Errorf("0.0 assurance delta must round-trip distinctly from absent")
+	}
+
+	// Projected-only (Contract v1) traffic omits all measured fields.
+	v1, _ := json.Marshal(TokenAccounting{ReductionMode: "projected", ProjectedDirectPayloadWasteUSD: 0.001})
+	if strings.Contains(string(v1), "actual_reduction") || strings.Contains(string(v1), "reduction_sampled") {
+		t.Errorf("projected traffic must omit measured fields: %s", v1)
+	}
+}

--- a/pkg/aiqg/events/emitter.go
+++ b/pkg/aiqg/events/emitter.go
@@ -174,6 +174,20 @@ func (e *LogEmitter) Emit(_ context.Context, req RequestEnvelope, resp ResponseE
 			if ta.ContextEfficiencyRatio != nil {
 				respFields["context_efficiency_ratio"] = *ta.ContextEfficiencyRatio
 			}
+			// Measured reduction (Contract v2) — only when the real
+			// extractor ran (shadow/active). Absent under projected.
+			if ta.ReductionMode == "shadow" || ta.ReductionMode == "active" {
+				respFields["reduction_sampled"] = ta.ReductionSampled
+				respFields["actual_direct_payload_reduction_usd"] = ta.ActualDirectPayloadReductionUSD
+				respFields["actual_reduction_relevance_usd"] = ta.ActualReductionRelevanceUSD
+				respFields["actual_reduction_slm_usd"] = ta.ActualReductionSLMUSD
+				if ta.ReductionEfficacyDelta != nil {
+					respFields["reduction_efficacy_delta"] = *ta.ReductionEfficacyDelta
+				}
+				if ta.ReductionAssuranceDelta != nil {
+					respFields["reduction_assurance_delta"] = *ta.ReductionAssuranceDelta
+				}
+			}
 		}
 	}
 	// Promote the timing decomposition so LogQL can unwrap each

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -286,6 +286,22 @@ type TokenAccounting struct {
 	GenuinePostModelWasteUSD       float64  `json:"genuine_post_model_waste_usd,omitempty"`
 	GatewayAddressablePct          float64  `json:"gateway_addressable_pct,omitempty"`
 	ContextEfficiencyRatio         *float64 `json:"context_efficiency_ratio,omitempty"` // pointer: 0.0 vs absent
+
+	// --- Measured reduction (Contract v2 — Phase 2 shadow/active) ---
+	// Populated only when the real Gatekeeper extractor ran on this
+	// request (reduction_mode = shadow|active). Empty under Contract v1
+	// (projected). The execution slice fills these; the contract is
+	// defined here so emitter/consumers/docs are ready. See
+	// aether-shared/data-models/aiqg/extraction-policy.md.
+	ReductionSampled                   bool    `json:"reduction_sampled,omitempty"` // request was in the shadow sample
+	ActualDirectPayloadReductionTokens int     `json:"actual_direct_payload_reduction_tokens,omitempty"`
+	ActualDirectPayloadReductionUSD    float64 `json:"actual_direct_payload_reduction_usd,omitempty"`
+	ActualReductionRelevanceUSD        float64 `json:"actual_reduction_relevance_usd,omitempty"`
+	ActualReductionSLMUSD              float64 `json:"actual_reduction_slm_usd,omitempty"`
+	// Quality deltas vs the un-reduced baseline (shadow eval). Pointers
+	// to distinguish "measured 0 change" from "not measured".
+	ReductionEfficacyDelta  *float64 `json:"reduction_efficacy_delta,omitempty"`
+	ReductionAssuranceDelta *float64 `json:"reduction_assurance_delta,omitempty"`
 }
 
 // AssuranceSummary is the lightweight per-event view of Gatekeeper


### PR DESCRIPTION
Defines the measured-reduction event contract (additive/omitempty) so the gateway execution slice just populates it. Emitted only when the real extractor runs (`reduction_mode` shadow|active) — **nothing populates them yet**.

- `actual_direct_payload_reduction_{tokens,usd}`, `actual_reduction_{relevance,slm}_usd`, `reduction_sampled`, and quality deltas (`reduction_efficacy_delta`/`_assurance_delta` as `*float64`).
- Emitter promotes them as Loki fields, guarded by shadow/active mode.
- Contract round-trip test; projected traffic omits them.

Pairs with aether-shared token-accounting.md §3.4.1. ⚠️ **Not deployed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)