### PR TITLE
feat(aiqg): gateway shadow payload-reduction measurement (Plan #7 Phase 2a)

### DIFF
--- a/cmd/llm-router/main.go
+++ b/cmd/llm-router/main.go
@@ -86,6 +86,12 @@ func NewApplication(configPath string) (*Application, error) {
 					PreScannedValue: "pre_scanned",
 				},
 			},
+			Extraction: gatekeeper.ExtractionConfig{
+				Enabled:        cfg.Gatekeeper.Extraction.Enabled,
+				OllamaURL:      cfg.Gatekeeper.Extraction.OllamaURL,
+				EmbedModel:     cfg.Gatekeeper.Extraction.EmbedModel,
+				MinContentSize: cfg.Gatekeeper.Extraction.MinContentSize,
+			},
 		}
 
 		gkClient, err := gatekeeper.New(gkCfg, logger)

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -117,6 +117,14 @@ gatekeeper:
     scan_profile: "full"
     trust_tier: "partner"
     block_on_critical: false   # Log but don't block - document content may trigger false positives
+  # AIQG shadow payload-reduction extractor (Plan #7 Phase 2). Off by default;
+  # enabled only on the AIQG gateway (env AIQG_EXTRACTION_ENABLED=true). Shadow
+  # mode measures relevance-based context reduction without mutating payloads.
+  extraction:
+    enabled: false
+    ollama_url: "http://ollama.tas-shared:11434"   # AIQG_EXTRACTION_OLLAMA_URL
+    embed_model: "all-minilm"                       # AIQG_EXTRACTION_EMBED_MODEL
+    min_content_size: 2000                          # AIQG_EXTRACTION_MIN_CONTENT_SIZE (bytes)
 
 logging:
   level: "info"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,6 +122,17 @@ type GatekeeperConfig struct {
 	ScanTimeout       time.Duration       `yaml:"scan_timeout"`
 	Inbound           ScanDirectionConfig `yaml:"inbound"`
 	Outbound          ScanDirectionConfig `yaml:"outbound"`
+	Extraction        ExtractionConfig    `yaml:"extraction"`
+}
+
+// ExtractionConfig wires the Ollama-backed extractor used for AIQG shadow
+// payload-reduction measurement (Plan #7 Phase 2). Disabled by default;
+// enabled only on the AIQG gateway via env (AIQG_EXTRACTION_*).
+type ExtractionConfig struct {
+	Enabled        bool   `yaml:"enabled"`
+	OllamaURL      string `yaml:"ollama_url"`       // e.g. http://ollama.tas-shared:11434
+	EmbedModel     string `yaml:"embed_model"`      // e.g. all-minilm
+	MinContentSize int    `yaml:"min_content_size"` // extractor floor (bytes)
 }
 
 // ScanPolicyConfig controls which messages are scanned based on role and trust metadata.
@@ -444,6 +455,23 @@ func (c *Config) loadFromEnv() {
 	if st := os.Getenv("GATEKEEPER_SCAN_TIMEOUT"); st != "" {
 		if d, err := time.ParseDuration(st); err == nil {
 			c.Gatekeeper.ScanTimeout = d
+		}
+	}
+
+	// AIQG shadow payload-reduction extractor (Plan #7 Phase 2). Off unless
+	// AIQG_EXTRACTION_ENABLED=true — only the AIQG gateway sets these.
+	if enabled := os.Getenv("AIQG_EXTRACTION_ENABLED"); enabled == "true" {
+		c.Gatekeeper.Extraction.Enabled = true
+	}
+	if u := os.Getenv("AIQG_EXTRACTION_OLLAMA_URL"); u != "" {
+		c.Gatekeeper.Extraction.OllamaURL = u
+	}
+	if m := os.Getenv("AIQG_EXTRACTION_EMBED_MODEL"); m != "" {
+		c.Gatekeeper.Extraction.EmbedModel = m
+	}
+	if n := os.Getenv("AIQG_EXTRACTION_MIN_CONTENT_SIZE"); n != "" {
+		if v, err := strconv.Atoi(n); err == nil {
+			c.Gatekeeper.Extraction.MinContentSize = v
 		}
 	}
 

--- a/internal/gatekeeper/gatekeeper.go
+++ b/internal/gatekeeper/gatekeeper.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/Tributary-ai-services/Gatekeeper/pkg/extract"
 	"github.com/Tributary-ai-services/Gatekeeper/pkg/pipeline"
 	"github.com/Tributary-ai-services/Gatekeeper/pkg/scan"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
@@ -31,6 +32,22 @@ type Config struct {
 
 	Inbound  ScanDirectionConfig `yaml:"inbound"`
 	Outbound ScanDirectionConfig `yaml:"outbound"`
+
+	// Extraction configures the shadow payload-reduction measurement
+	// (Plan #7 Phase 2). When disabled (default), MeasureReduction is a
+	// no-op and the gateway never calls the extractor — preserving the
+	// pre-Phase-2 behavior. The actual run is further gated per-request
+	// by the resolved bundle's reduction policy.
+	Extraction ExtractionConfig `yaml:"extraction"`
+}
+
+// ExtractionConfig wires the Ollama-backed extractor used for shadow
+// payload-reduction measurement.
+type ExtractionConfig struct {
+	Enabled        bool   `yaml:"enabled"`
+	OllamaURL      string `yaml:"ollama_url"`       // e.g. http://ollama.tas-shared:11434
+	EmbedModel     string `yaml:"embed_model"`      // e.g. all-minilm
+	MinContentSize int    `yaml:"min_content_size"` // extractor floor (bytes)
 }
 
 // ScanPolicy controls which messages are scanned based on role and trust metadata.
@@ -87,6 +104,7 @@ func DefaultConfig() Config {
 // Client wraps the Gatekeeper pipeline processor for LLM Router integration.
 type Client struct {
 	processor pipeline.Processor
+	extractor extract.Extractor // nil unless Extraction.Enabled — shadow measurement only
 	config    Config
 	logger    *logrus.Logger
 }
@@ -114,10 +132,75 @@ func New(cfg Config, logger *logrus.Logger) (*Client, error) {
 
 	processor := pipeline.NewProcessor(scanner, pipeline.WithConfig(procConfig))
 
+	// Optional extractor for shadow payload-reduction measurement. Built
+	// only when configured; embeddings-only (relevance step) — the SLM
+	// step needs a GPU. The embedder talks to Ollama via SLM.URL (see
+	// extract.NewExtractor). Failure to init is non-fatal: shadow
+	// measurement just stays off.
+	var extractor extract.Extractor
+	if cfg.Extraction.Enabled {
+		ec := extract.DefaultExtractorConfig()
+		ec.EnableEmbedding = true
+		ec.EnableSLM = false
+		if cfg.Extraction.EmbedModel != "" {
+			ec.Embedding.Model = cfg.Extraction.EmbedModel
+		}
+		ec.SLM.URL = cfg.Extraction.OllamaURL // extract.NewEmbedder reads the Ollama URL from SLM.URL
+		if cfg.Extraction.MinContentSize > 0 {
+			ec.MinContentSize = cfg.Extraction.MinContentSize
+		}
+		if ex, err := extract.NewExtractor(ec); err != nil {
+			logger.WithError(err).Warn("gatekeeper: extractor init failed; shadow reduction disabled")
+		} else {
+			extractor = ex
+		}
+	}
+
 	return &Client{
 		processor: processor,
+		extractor: extractor,
 		config:    cfg,
 		logger:    logger,
+	}, nil
+}
+
+// ReductionMeasurement is the byte-level result of a real (shadow)
+// extractor run, for the gateway to convert to measured token/USD savings.
+type ReductionMeasurement struct {
+	OriginalBytes           int
+	ExtractedBytes          int
+	SizeAfterRelevanceBytes int
+	ChunksProcessed         int
+	ChunksRetained          int
+}
+
+// MeasureReduction runs the extractor on the given messages purely to
+// MEASURE how much context the relevance step would drop — it never
+// mutates anything. Returns an error when the extractor isn't configured
+// or the run fails (callers treat that as "no measurement"). query is the
+// relevance anchor (typically the latest user turn).
+func (c *Client) MeasureReduction(ctx context.Context, messages []types.Message, query string) (*ReductionMeasurement, error) {
+	if c.extractor == nil {
+		return nil, fmt.Errorf("gatekeeper: extractor not configured")
+	}
+	content := extractMessagesText(messages)
+	if len(content) == 0 {
+		return nil, fmt.Errorf("gatekeeper: no content to measure")
+	}
+	er, err := c.extractor.Extract(ctx, extract.ExtractRequest{
+		Content:     content,
+		Query:       query,
+		ContentType: "chat",
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &ReductionMeasurement{
+		OriginalBytes:           er.OriginalSize,
+		ExtractedBytes:          er.ExtractedSize,
+		SizeAfterRelevanceBytes: er.SizeAfterRelevance,
+		ChunksProcessed:         er.ChunksProcessed,
+		ChunksRetained:          er.ChunksRetained,
 	}, nil
 }
 
@@ -262,6 +345,9 @@ func (c *Client) ShouldBlock(result *pipeline.ProcessResult, direction string) b
 
 // Close releases resources.
 func (c *Client) Close() error {
+	if c.extractor != nil {
+		_ = c.extractor.Close()
+	}
 	if c.processor != nil {
 		return c.processor.Close()
 	}

--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -212,6 +212,11 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// ctx lets the deferred emit read whichever resolution is current.
 	bundleResolution := &bundleResolutionHolder{res: policy.Default()}
 	ctx = withBundleResolution(ctx, bundleResolution)
+
+	// Holder for an optional shadow payload-reduction measurement, filled
+	// by the completion handler's goroutine and read by the deferred emit.
+	reductionMeasurement := &reductionMeasurementHolder{}
+	ctx = withReductionMeasurement(ctx, reductionMeasurement)
 	if cfg.PolicyResolver != nil && resolvedToken != nil {
 		res, err := cfg.PolicyResolver.Resolve(ctx, policy.ResolveRequest{
 			TenantID:           resolvedToken.TenantID,
@@ -302,8 +307,9 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 					Source:     res.Source,
 				}
 			}(),
-			ExperimentID:      expSnap.ExperimentID,
-			ExperimentVariant: expSnap.ExperimentVariant,
+			ExperimentID:         expSnap.ExperimentID,
+			ExperimentVariant:    expSnap.ExperimentVariant,
+			ReductionMeasurement: reductionMeasurement.getWait(reductionEmitWait),
 		})
 		if err := emitter.Emit(ctx, reqEnv, respEnv); err != nil {
 			cfg.Logger.WithError(err).Warn("AIQG event emission failed")
@@ -474,6 +480,96 @@ type bundleResolutionCtxKey struct{}
 
 func withBundleResolution(ctx context.Context, h *bundleResolutionHolder) context.Context {
 	return context.WithValue(ctx, bundleResolutionCtxKey{}, h)
+}
+
+// reductionMeasurementHolder is a concurrency-safe cell for the shadow
+// payload-reduction measurement (Plan #7 Phase 2). The completion handler
+// fills it from a goroutine running concurrently with the vendor call; the
+// deferred emit reads whatever is present (best-effort — absent if the
+// measurement didn't finish before emit).
+// reductionEmitWait bounds how long the deferred emit blocks for an
+// in-flight shadow measurement. The embed-only extract (all-minilm) is
+// sub-second for typical chat payloads; this is generous headroom.
+const reductionEmitWait = 5 * time.Second
+
+type reductionMeasurementHolder struct {
+	mu      sync.Mutex
+	m       *events.ReductionMeasurement
+	pending bool
+	done    chan struct{}
+}
+
+// expect marks that a shadow measurement is in flight so getWait blocks
+// (bounded) for the result instead of returning nil immediately.
+func (h *reductionMeasurementHolder) expect() {
+	h.mu.Lock()
+	if h.done == nil {
+		h.done = make(chan struct{})
+	}
+	h.pending = true
+	h.mu.Unlock()
+}
+
+func (h *reductionMeasurementHolder) set(m *events.ReductionMeasurement) {
+	h.mu.Lock()
+	h.m = m
+	h.pending = false
+	if h.done != nil {
+		close(h.done)
+		h.done = nil
+	}
+	h.mu.Unlock()
+}
+
+// getWait returns the measurement, waiting up to timeout if a shadow run
+// was started (expect) but hasn't landed yet. Called from the deferred
+// emit, which runs after the client response is flushed — so the wait adds
+// no client-facing latency, only a small delay to event emission.
+func (h *reductionMeasurementHolder) getWait(timeout time.Duration) *events.ReductionMeasurement {
+	h.mu.Lock()
+	if !h.pending {
+		m := h.m
+		h.mu.Unlock()
+		return m
+	}
+	done := h.done
+	h.mu.Unlock()
+	if done != nil {
+		select {
+		case <-done:
+		case <-time.After(timeout):
+		}
+	}
+	h.mu.Lock()
+	m := h.m
+	h.mu.Unlock()
+	return m
+}
+
+type reductionMeasurementCtxKey struct{}
+
+func withReductionMeasurement(ctx context.Context, h *reductionMeasurementHolder) context.Context {
+	return context.WithValue(ctx, reductionMeasurementCtxKey{}, h)
+}
+
+// ExpectReductionMeasurement signals that a shadow measurement goroutine has
+// been launched for this request, so the deferred emit waits (bounded) for
+// the result rather than emitting before it lands. Call BEFORE starting the
+// goroutine. No-op if no holder is on the context.
+func ExpectReductionMeasurement(ctx context.Context) {
+	if h, ok := ctx.Value(reductionMeasurementCtxKey{}).(*reductionMeasurementHolder); ok {
+		h.expect()
+	}
+}
+
+// StampReductionMeasurement records a completed shadow measurement on the
+// request so the emitted event carries the Contract v2 measured fields.
+// Called from the gateway's shadow goroutine; safe after the request
+// context is cancelled (it writes to a holder, not the ctx).
+func StampReductionMeasurement(ctx context.Context, m *events.ReductionMeasurement) {
+	if h, ok := ctx.Value(reductionMeasurementCtxKey{}).(*reductionMeasurementHolder); ok {
+		h.set(m)
+	}
 }
 
 // policyResolveCtx carries what ResolveBundleForRouting needs to re-resolve

--- a/internal/middleware/reduction_holder_test.go
+++ b/internal/middleware/reduction_holder_test.go
@@ -1,0 +1,75 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+)
+
+func TestReductionHolderGetWaitImmediate(t *testing.T) {
+	h := &reductionMeasurementHolder{}
+	// Not pending → returns immediately (nil here).
+	start := time.Now()
+	if m := h.getWait(time.Second); m != nil {
+		t.Errorf("expected nil, got %+v", m)
+	}
+	if time.Since(start) > 100*time.Millisecond {
+		t.Error("getWait blocked when no measurement was expected")
+	}
+}
+
+func TestReductionHolderExpectThenSet(t *testing.T) {
+	h := &reductionMeasurementHolder{}
+	h.expect()
+	want := &events.ReductionMeasurement{Mode: "shadow", Sampled: true, OriginalBytes: 100, ExtractedBytes: 40}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		h.set(want)
+	}()
+	got := h.getWait(time.Second)
+	if got != want {
+		t.Fatalf("getWait did not return the stamped measurement: %+v", got)
+	}
+}
+
+func TestReductionHolderWaitTimesOut(t *testing.T) {
+	h := &reductionMeasurementHolder{}
+	h.expect()
+	// Never set → getWait returns nil after the bound, doesn't hang.
+	start := time.Now()
+	if m := h.getWait(50 * time.Millisecond); m != nil {
+		t.Errorf("expected nil on timeout, got %+v", m)
+	}
+	if d := time.Since(start); d < 40*time.Millisecond || d > 500*time.Millisecond {
+		t.Errorf("getWait timeout took %v, want ~50ms", d)
+	}
+}
+
+func TestExpectAndStampViaContext(t *testing.T) {
+	h := &reductionMeasurementHolder{}
+	ctx := withReductionMeasurement(context.Background(), h)
+	ExpectReductionMeasurement(ctx)
+	want := &events.ReductionMeasurement{Mode: "shadow", Sampled: true, OriginalBytes: 10}
+	StampReductionMeasurement(ctx, want)
+	if got := h.getWait(time.Second); got != want {
+		t.Fatalf("context stamp/get mismatch: %+v", got)
+	}
+}
+
+func TestStampNilStopsWaiting(t *testing.T) {
+	h := &reductionMeasurementHolder{}
+	h.expect()
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		h.set(nil) // "ran but empty" — must unblock getWait
+	}()
+	start := time.Now()
+	if m := h.getWait(time.Second); m != nil {
+		t.Errorf("expected nil, got %+v", m)
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Error("set(nil) did not unblock getWait promptly")
+	}
+}

--- a/internal/server/reduction_helpers_test.go
+++ b/internal/server/reduction_helpers_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+func TestMessageContentString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   interface{}
+		want string
+	}{
+		{"string", "hello world", "hello world"},
+		{"contentparts", []types.ContentPart{
+			{Type: "text", Text: "a"},
+			{Type: "image_url"},
+			{Type: "text", Text: "b"},
+		}, "ab"},
+		{"json-decoded", []interface{}{
+			map[string]interface{}{"type": "text", "text": "x"},
+			map[string]interface{}{"type": "image_url"},
+			map[string]interface{}{"type": "text", "text": "y"},
+		}, "xy"},
+		{"nil", nil, ""},
+		{"number", 42, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := messageContentString(c.in); got != c.want {
+				t.Errorf("messageContentString(%v) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestMessagesByteLenAndLastUser(t *testing.T) {
+	msgs := []types.Message{
+		{Role: "system", Content: "sys"},      // 3
+		{Role: "user", Content: "first ask"},  // 9
+		{Role: "assistant", Content: "reply"}, // 5
+		{Role: "user", Content: "final ask"},  // 9
+	}
+	if got, want := messagesByteLen(msgs), 26; got != want {
+		t.Errorf("messagesByteLen = %d, want %d", got, want)
+	}
+	if got, want := lastUserText(msgs), "final ask"; got != want {
+		t.Errorf("lastUserText = %q, want %q", got, want)
+	}
+	if got := lastUserText([]types.Message{{Role: "system", Content: "x"}}); got != "" {
+		t.Errorf("lastUserText with no user = %q, want empty", got)
+	}
+}
+
+func TestSampleHit(t *testing.T) {
+	// rate <= 0 and >= 1 are deterministic; the middle is probabilistic.
+	if !sampleHit(0) {
+		t.Error("sampleHit(0) should always hit (measure all eligible)")
+	}
+	if !sampleHit(1) {
+		t.Error("sampleHit(1) should always hit")
+	}
+	if !sampleHit(2) {
+		t.Error("sampleHit(>1) should always hit")
+	}
+	// rate=0.5 over many trials should land strictly between 0 and N.
+	hits := 0
+	const n = 2000
+	for i := 0; i < n; i++ {
+		if sampleHit(0.5) {
+			hits++
+		}
+	}
+	if hits == 0 || hits == n {
+		t.Errorf("sampleHit(0.5) produced %d/%d hits — not sampling", hits, n)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand/v2"
 	"net/http"
 	"sort"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
+	"github.com/tributary-ai/llm-router-waf/pkg/clear"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -640,6 +642,43 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// AIQG payload-reduction shadow measurement (Plan #7 Phase 2). When a
+	// resolved reduction policy is in shadow/active mode, run the real
+	// extractor on a sample of size-eligible traffic purely to MEASURE how
+	// much context the relevance step would drop. Shadow never mutates the
+	// payload — the original request is routed to the vendor unchanged. The
+	// extract runs in a goroutine concurrent with the vendor call so it adds
+	// no client-facing latency; the deferred AIQG emit waits (bounded) for
+	// the result and stamps the Contract v2 measured fields onto the event.
+	if red, _ := middleware.ResolvedReduction(r.Context()); red.RunsExtractor() && s.gatekeeper != nil {
+		promptBytes := messagesByteLen(req.Messages)
+		if red.EligibleBySize(clear.TokensFromBytes(promptBytes)) && sampleHit(red.SampleRate) {
+			msgs := req.Messages
+			query := lastUserText(msgs)
+			mode := red.Mode
+			parentCtx := context.WithoutCancel(r.Context())
+			middleware.ExpectReductionMeasurement(parentCtx)
+			go func() {
+				mctx, cancel := context.WithTimeout(parentCtx, 20*time.Second)
+				defer cancel()
+				m, err := s.gatekeeper.MeasureReduction(mctx, msgs, query)
+				if err != nil || m == nil {
+					// Stamp a nil-free "ran but empty" result so the deferred
+					// emit stops waiting instead of blocking the full timeout.
+					middleware.StampReductionMeasurement(parentCtx, nil)
+					return
+				}
+				middleware.StampReductionMeasurement(parentCtx, &events.ReductionMeasurement{
+					Mode:                    mode,
+					Sampled:                 true,
+					OriginalBytes:           m.OriginalBytes,
+					ExtractedBytes:          m.ExtractedBytes,
+					SizeAfterRelevanceBytes: m.SizeAfterRelevanceBytes,
+				})
+			}()
+		}
+	}
+
 	// Route the request
 	metadata, provider, err := s.router.Route(r.Context(), &req)
 	if err != nil {
@@ -1092,6 +1131,69 @@ func applyExperimentOverride(req *types.ChatRequest, override json.RawMessage) {
 	if o.Params.MaxTokens != nil {
 		req.MaxTokens = o.Params.MaxTokens
 	}
+}
+
+// messageContentString flattens a Message.Content (string or
+// []ContentPart for multimodal) into plain text for size/relevance
+// measurement. Non-text parts (images) contribute nothing.
+func messageContentString(content interface{}) string {
+	switch v := content.(type) {
+	case string:
+		return v
+	case []types.ContentPart:
+		var b strings.Builder
+		for _, p := range v {
+			if p.Type == "text" {
+				b.WriteString(p.Text)
+			}
+		}
+		return b.String()
+	case []interface{}:
+		// JSON-decoded multimodal content arrives as []interface{} of maps.
+		var b strings.Builder
+		for _, item := range v {
+			if m, ok := item.(map[string]interface{}); ok {
+				if t, _ := m["text"].(string); t != "" {
+					b.WriteString(t)
+				}
+			}
+		}
+		return b.String()
+	default:
+		return ""
+	}
+}
+
+// messagesByteLen is a coarse byte size of the full prompt, used only for
+// the reduction MinTokens size gate.
+func messagesByteLen(messages []types.Message) int {
+	n := 0
+	for _, m := range messages {
+		n += len(messageContentString(m.Content))
+	}
+	return n
+}
+
+// lastUserText returns the text of the latest user-role message — the
+// relevance anchor for shadow extraction.
+func lastUserText(messages []types.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			return messageContentString(messages[i].Content)
+		}
+	}
+	return ""
+}
+
+// sampleHit reports whether this request is in the shadow-measurement
+// sample. A rate <= 0 means "measure all eligible traffic" (the natural
+// default for a shadow policy with no explicit sample_rate); >= 1 also
+// always hits.
+func sampleHit(rate float64) bool {
+	if rate <= 0 || rate >= 1 {
+		return true
+	}
+	return rand.Float64() < rate
 }
 
 // extractResponseContent extracts text content from a ChatResponse.

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -155,6 +155,24 @@ type BuildOptions struct {
 	// request (Phase D). Empty for untouched traffic.
 	ExperimentID      string
 	ExperimentVariant string
+
+	// ReductionMeasurement is the result of a shadow payload-reduction
+	// run (Plan #7 Phase 2). Nil when no extraction ran (the common
+	// case — projected-only). When set on priced traffic, Build fills the
+	// Contract v2 measured fields on TokenAccounting.
+	ReductionMeasurement *ReductionMeasurement
+}
+
+// ReductionMeasurement carries the byte sizes from a real (shadow)
+// extractor run so the builder can convert them to measured token/USD
+// reduction. Bytes (not tokens) because the extractor works on bytes;
+// conversion happens once in pkg/clear.
+type ReductionMeasurement struct {
+	Mode                    string // "shadow" | "active"
+	Sampled                 bool
+	OriginalBytes           int
+	ExtractedBytes          int // after all enabled steps (= after relevance when SLM off)
+	SizeAfterRelevanceBytes int
 }
 
 // Build constructs the paired (RequestEnvelope, ResponseEnvelope) from
@@ -478,6 +496,23 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 			ta.InducedOutputWasteEstimatedUSD = d.InducedOutputWasteEstimatedUSD
 			ta.GenuinePostModelWasteUSD = d.GenuinePostModelWasteUSD
 			ta.GatewayAddressablePct = d.GatewayAddressablePct
+
+			// Measured reduction (Contract v2) — a real shadow/active
+			// extractor run. Cost only; quality deltas need a baseline
+			// re-run (left unmeasured). Bytes→tokens once via pkg/clear.
+			if rm := opts.ReductionMeasurement; rm != nil && rm.OriginalBytes > 0 {
+				reducedBytes := rm.OriginalBytes - rm.ExtractedBytes
+				if reducedBytes < 0 {
+					reducedBytes = 0
+				}
+				reducedTokens := clear.TokensFromBytes(reducedBytes)
+				reducedUSD := (float64(reducedTokens) / 1000.0) * inputRate
+				ta.ReductionMode = rm.Mode // "shadow" / "active" (overrides "projected")
+				ta.ReductionSampled = rm.Sampled
+				ta.ActualDirectPayloadReductionTokens = reducedTokens
+				ta.ActualDirectPayloadReductionUSD = reducedUSD
+				ta.ActualReductionRelevanceUSD = reducedUSD // relevance is the only enabled step
+			}
 		}
 		tokenAcct = ta
 	}

--- a/pkg/clear/cost.go
+++ b/pkg/clear/cost.go
@@ -81,6 +81,20 @@ func DollarCost(vendor, model string, promptTokens, completionTokens int) (cost 
 	return cost, true
 }
 
+// bytesPerToken is the coarse char→token ratio used to convert byte
+// sizes (from the Gatekeeper extractor) into token counts. ~4 bytes/token
+// for English text. The single byte→token conversion point in the gateway
+// (per Plan #7) so projected and measured reductions speak the same unit.
+const bytesPerToken = 4.0
+
+// TokensFromBytes converts a byte size to an estimated token count.
+func TokensFromBytes(b int) int {
+	if b <= 0 {
+		return 0
+	}
+	return int(math.Ceil(float64(b) / bytesPerToken))
+}
+
 // Cost is the dollar breakdown of one request, returned by ActualCost.
 // It's the *billed* cost in Contract v1 (= the invariant denominator the
 // cost decomposition is bounded against). Priced=false when the


### PR DESCRIPTION
## What

Wires the Ollama-backed Gatekeeper extractor into the gateway so a resolved **reduction policy** in `shadow`/`active` mode **measures** relevance-based context reduction on a sample of size-eligible traffic — emitting Contract v2 measured fields alongside the always-on Contract v1 projected fields.

Shadow mode **never mutates payloads**: the original request is routed to the vendor unchanged. The extract runs in a goroutine concurrent with the vendor call, so there is **zero client-facing latency**; the deferred AIQG emit waits (bounded, post-response-flush) for the async result.

## Changes
- `pkg/clear/cost.go` — `TokensFromBytes` (the single byte→token conversion point so projected & measured speak the same unit).
- `internal/gatekeeper` — `ExtractionConfig`, embed-only extractor construction (relevance step; SLM disabled — needs GPU), `MeasureReduction` (extract-only, never mutates), `Close`.
- `pkg/aiqg/events/builder.go` — `ReductionMeasurement` + `BuildOptions.ReductionMeasurement` + Contract v2 measured-field population.
- `internal/server` — shadow seam after the inbound scan; helpers `messageContentString` / `messagesByteLen` / `lastUserText` / `sampleHit`.
- `internal/middleware/aiqg.go` — `reductionMeasurementHolder` with bounded `getWait`; `ExpectReductionMeasurement` / `StampReductionMeasurement`.
- config — `AIQG_EXTRACTION_*` env overrides; **off by default**, enabled only on the AIQG gateway (`llm-router-aiqg`).

## Deploy plan
- Build gateway image, set image on `llm-router-aiqg` **only** (container `llm-router`); main `llm-router` unchanged.
- Requires Ollama (`ollama.tas-shared:11434`, `all-minilm`) — deployed in Phase 2a1.
- Verify: set a test bundle to `shadow` mode, send priced traffic through `llm-router-aiqg`, check Loki for `reduction_mode=shadow` + `actual_reduction_relevance_usd`.

## Tests
- `go build -tags nohs ./...`, `go vet`, and targeted `go test -tags nohs` all green (clear, events, gatekeeper, middleware, server, config, policy).
- New: server reduction helpers + middleware holder wait/stamp semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)