### PR TITLE
chore(k8s): persist AIQG_EXTRACTION_* env on the strict gateway manifest

### DIFF
--- a/k8s/deployment-aiqg-strict.yaml
+++ b/k8s/deployment-aiqg-strict.yaml
@@ -84,6 +84,19 @@ spec:
         # Shared token store with the internal Deployment.
         - name: AIQG_TOKENS_FILE
           value: /app/secrets/aiqg/aiqg-tokens.yaml
+        # AIQG payload-reduction shadow extractor (Plan #7 Phase 2a).
+        # Enabled on the AIQG gateway ONLY — the internal llm-router
+        # Deployment leaves these unset so it never runs the extractor.
+        # Embeddings-only relevance step via Ollama (all-minilm); the SLM
+        # step needs a GPU and stays disabled.
+        - name: AIQG_EXTRACTION_ENABLED
+          value: "true"
+        - name: AIQG_EXTRACTION_OLLAMA_URL
+          value: http://ollama.tas-shared:11434
+        - name: AIQG_EXTRACTION_EMBED_MODEL
+          value: all-minilm
+        - name: AIQG_EXTRACTION_MIN_CONTENT_SIZE
+          value: "2000"
 
         # tcpSocket (not httpGet /health) matches the live internal
         # Deployment pattern. The /health endpoint legitimately returns


### PR DESCRIPTION
Captures the shadow payload-reduction extractor config (Plan #7 Phase 2a) in the committed `k8s/deployment-aiqg-strict.yaml` so a re-apply doesn't drop the live `kubectl set env` patch.

- AIQG gateway only — the internal `llm-router` Deployment leaves these unset and never runs the extractor.
- Embeddings-only relevance step via Ollama (`all-minilm`); SLM step disabled (needs GPU).
- Image tag unchanged (`:latest` placeholder; real versioned tag set at deploy time, currently `aiqg-v5.38`).

Follow-up to #87 (the a2 code) — IaC parity only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)