### PR TITLE
aiqg: honor per-bundle relevance tuning in shadow extraction (Plan #7 Phase 2)

### DIFF
--- a/internal/gatekeeper/gatekeeper.go
+++ b/internal/gatekeeper/gatekeeper.go
@@ -174,12 +174,22 @@ type ReductionMeasurement struct {
 	ChunksRetained          int
 }
 
+// RelevanceOverride carries per-bundle relevance tuning (from an AIQG
+// policy bundle's reduction.steps.relevance) into a measurement run. Zero
+// fields fall back to the extractor's configured defaults.
+type RelevanceOverride struct {
+	Threshold float64
+	TopK      int
+	Ratio     float64
+}
+
 // MeasureReduction runs the extractor on the given messages purely to
 // MEASURE how much context the relevance step would drop — it never
 // mutates anything. Returns an error when the extractor isn't configured
 // or the run fails (callers treat that as "no measurement"). query is the
-// relevance anchor (typically the latest user turn).
-func (c *Client) MeasureReduction(ctx context.Context, messages []types.Message, query string) (*ReductionMeasurement, error) {
+// relevance anchor (typically the latest user turn). rel applies the
+// resolved bundle's relevance tuning (zero fields = extractor defaults).
+func (c *Client) MeasureReduction(ctx context.Context, messages []types.Message, query string, rel RelevanceOverride) (*ReductionMeasurement, error) {
 	if c.extractor == nil {
 		return nil, fmt.Errorf("gatekeeper: extractor not configured")
 	}
@@ -188,9 +198,12 @@ func (c *Client) MeasureReduction(ctx context.Context, messages []types.Message,
 		return nil, fmt.Errorf("gatekeeper: no content to measure")
 	}
 	er, err := c.extractor.Extract(ctx, extract.ExtractRequest{
-		Content:     content,
-		Query:       query,
-		ContentType: "chat",
+		Content:            content,
+		Query:              query,
+		ContentType:        "chat",
+		RelevanceThreshold: rel.Threshold,
+		TopKChunks:         rel.TopK,
+		TopKRatio:          rel.Ratio,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -656,12 +656,18 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 			msgs := req.Messages
 			query := lastUserText(msgs)
 			mode := red.Mode
+			// Honor the bundle's per-method relevance tuning (threshold /
+			// top-K). Zero fields fall back to the extractor's env defaults.
+			var rel gatekeeper.RelevanceOverride
+			if rs := red.Steps.Relevance; rs != nil {
+				rel = gatekeeper.RelevanceOverride{Threshold: rs.Threshold, TopK: rs.TopK, Ratio: rs.TopKRatio}
+			}
 			parentCtx := context.WithoutCancel(r.Context())
 			middleware.ExpectReductionMeasurement(parentCtx)
 			go func() {
 				mctx, cancel := context.WithTimeout(parentCtx, 20*time.Second)
 				defer cancel()
-				m, err := s.gatekeeper.MeasureReduction(mctx, msgs, query)
+				m, err := s.gatekeeper.MeasureReduction(mctx, msgs, query, rel)
 				if err != nil || m == nil {
 					// Stamp a nil-free "ran but empty" result so the deferred
 					// emit stops waiting instead of blocking the full timeout.


### PR DESCRIPTION
The shadow path now passes the resolved bundle's `reduction.steps.relevance` (threshold / top_k / top_k_ratio) into the extractor, so the Policies-page extraction editor's relevance controls actually take effect instead of being decorative.

- `gatekeeper.MeasureReduction` takes a `RelevanceOverride`; zero fields fall back to the extractor's env-configured defaults.
- `server.go` reads `ResolvedReduction(ctx).Steps.Relevance` and threads it through.
- SLM tuning remains inert (SLM step disabled pending GPU).

Closes the one real code gap left in Plan #7 Phase 2 (#2). **Depends on Gatekeeper #16** (per-request `ExtractRequest` overrides) — the gateway image build copies local Gatekeeper, so merge order is flexible, but merge #16 first for repo consistency.

`go build -tags nohs`/`vet`/`test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)