### PR TITLE
aiqg: active reduction ramp + kill-switch (Plan #7 Phase 4 slice A)

### DIFF
--- a/cmd/llm-router/main.go
+++ b/cmd/llm-router/main.go
@@ -91,6 +91,7 @@ func NewApplication(configPath string) (*Application, error) {
 				OllamaURL:      cfg.Gatekeeper.Extraction.OllamaURL,
 				EmbedModel:     cfg.Gatekeeper.Extraction.EmbedModel,
 				MinContentSize: cfg.Gatekeeper.Extraction.MinContentSize,
+				ApplyDisabled:  cfg.Gatekeeper.Extraction.ApplyDisabled,
 			},
 		}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -133,6 +133,7 @@ type ExtractionConfig struct {
 	OllamaURL      string `yaml:"ollama_url"`       // e.g. http://ollama.tas-shared:11434
 	EmbedModel     string `yaml:"embed_model"`      // e.g. all-minilm
 	MinContentSize int    `yaml:"min_content_size"` // extractor floor (bytes)
+	ApplyDisabled  bool   `yaml:"apply_disabled"`   // Phase 4 kill-switch: never APPLY active reduction
 }
 
 // ScanPolicyConfig controls which messages are scanned based on role and trust metadata.
@@ -473,6 +474,11 @@ func (c *Config) loadFromEnv() {
 		if v, err := strconv.Atoi(n); err == nil {
 			c.Gatekeeper.Extraction.MinContentSize = v
 		}
+	}
+	// Phase 4 break-glass kill-switch — when "true", active reduction never
+	// mutates payloads (downgrades to shadow). Default off.
+	if d := os.Getenv("AIQG_EXTRACTION_APPLY_DISABLED"); d == "true" {
+		c.Gatekeeper.Extraction.ApplyDisabled = true
 	}
 
 	// AIQG ingress — env overrides for the simple scalars. Tokens are

--- a/internal/gatekeeper/gatekeeper.go
+++ b/internal/gatekeeper/gatekeeper.go
@@ -48,6 +48,12 @@ type ExtractionConfig struct {
 	OllamaURL      string `yaml:"ollama_url"`       // e.g. http://ollama.tas-shared:11434
 	EmbedModel     string `yaml:"embed_model"`      // e.g. all-minilm
 	MinContentSize int    `yaml:"min_content_size"` // extractor floor (bytes)
+	// ApplyDisabled is the global break-glass kill-switch for ACTIVE payload
+	// reduction (Plan #7 Phase 4). When true, active bundles still resolve but
+	// the gateway never mutates the payload — they downgrade to shadow
+	// measurement. Shadow/projected are unaffected. Toggle via env without an
+	// image rebuild.
+	ApplyDisabled bool `yaml:"apply_disabled"`
 }
 
 // ScanPolicy controls which messages are scanned based on role and trust metadata.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -44,8 +44,13 @@ type Server struct {
 	validationMiddleware *middleware.ValidationMiddleware
 	gatekeeper           *gatekeeper.Client
 	gatekeeperConfig     *gatekeeper.Config
-	bypassManager        *gatekeeper.BypassManager
-	bypassHandler        *gatekeeper.BypassHandler
+	// extractionApplyDisabled is the global break-glass kill-switch for
+	// active payload reduction (Plan #7 Phase 4). When true the gateway
+	// never APPLIES a reduction — active bundles downgrade to shadow
+	// measurement — without an image rebuild. Set from AIQG_EXTRACTION_APPLY_DISABLED.
+	extractionApplyDisabled bool
+	bypassManager           *gatekeeper.BypassManager
+	bypassHandler           *gatekeeper.BypassHandler
 
 	// AIQG ingress wire-up. aiqgMiddleware is nil when AIQG is disabled
 	// in config, in which case completion handlers register unwrapped
@@ -348,6 +353,9 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 func (s *Server) SetGatekeeper(client *gatekeeper.Client, cfg *gatekeeper.Config, bypass *gatekeeper.BypassManager) {
 	s.gatekeeper = client
 	s.gatekeeperConfig = cfg
+	if cfg != nil {
+		s.extractionApplyDisabled = cfg.Extraction.ApplyDisabled
+	}
 	if bypass != nil {
 		s.bypassManager = bypass
 		s.bypassHandler = gatekeeper.NewBypassHandler(bypass, s.logger)
@@ -657,25 +665,30 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	}
 	if red.RunsExtractor() && s.gatekeeper != nil {
 		promptBytes := messagesByteLen(req.Messages)
-		if red.EligibleBySize(clear.TokensFromBytes(promptBytes)) && sampleHit(red.SampleRate) {
+		if red.EligibleBySize(clear.TokensFromBytes(promptBytes)) {
 			query := lastUserText(req.Messages)
-			mode := red.Mode
 			// Honor per-method relevance tuning (threshold / top-K); zero
 			// fields fall back to the extractor's env defaults.
 			var rel gatekeeper.RelevanceOverride
 			if rs := red.Steps.Relevance; rs != nil {
 				rel = gatekeeper.RelevanceOverride{Threshold: rs.Threshold, TopK: rs.TopK, Ratio: rs.TopKRatio}
 			}
-			if red.Applies() {
+			// Active applies to the sampled fraction (the ramp knob); the
+			// global break-glass kill-switch downgrades active → shadow. The
+			// ramp remainder routes normally (projected fields still emitted),
+			// while shadow mode measures on its sampled fraction. (Plan #7
+			// Phase 4 slice A.)
+			sampled := sampleHit(red.SampleRate)
+			switch {
+			case red.Applies() && !s.extractionApplyDisabled && sampled:
 				// APPLY (active): reduce the largest context message in place
-				// BEFORE routing, so the vendor sees the smaller payload. This
-				// is synchronous — the added latency is part of what an
-				// extraction experiment measures. Gated to experiment-claimed
-				// running variants (expReduction) or an active bundle.
-				s.applyReductionInline(r.Context(), &req, query, rel, mode)
-			} else {
-				// SHADOW (measure-only): run concurrently with the vendor call
-				// so it adds no client latency; the deferred emit waits for it.
+				// BEFORE routing, so the vendor sees the smaller payload.
+				// Synchronous — the added latency is real and measured.
+				s.applyReductionInline(r.Context(), &req, query, rel, "active")
+			case red.RunsExtractor() && sampled:
+				// SHADOW (measure-only): shadow mode, or a kill-switched active
+				// bundle downgraded to measurement. Runs concurrently with the
+				// vendor call so it adds no client latency.
 				msgs := req.Messages
 				parentCtx := context.WithoutCancel(r.Context())
 				middleware.ExpectReductionMeasurement(parentCtx)
@@ -688,7 +701,7 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					middleware.StampReductionMeasurement(parentCtx, &events.ReductionMeasurement{
-						Mode:                    mode,
+						Mode:                    "shadow",
 						Sampled:                 true,
 						OriginalBytes:           m.OriginalBytes,
 						ExtractedBytes:          m.ExtractedBytes,


### PR DESCRIPTION
Reduction seam: `sample_rate` is the active APPLY fraction (ramp); shadow measures its sampled fraction; global `AIQG_EXTRACTION_APPLY_DISABLED` downgrades active→shadow with no rebuild. No live behavior change until a bundle is set active. Deployed aiqg-v5.41. 🤖 Generated with [Claude Code](https://claude.com/claude-code)