### PR TITLE
chore(k8s): persist AIQG_EXTRACTION_* env on the main llm-router (Phase 4 Slice D)

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -60,6 +60,19 @@ spec:
         # logs a warning and runs in the no-resolver permissive path.
         - name: AIQG_TOKENS_FILE
           value: /app/secrets/aiqg/aiqg-tokens.yaml
+        # AIQG payload-reduction extractor (Plan #7 Phase 4 Slice D) — rolled
+        # cluster-wide so the apply path works on the main gateway too, not
+        # just llm-router-aiqg. Embeddings-only (all-minilm); SLM off (no GPU).
+        # Active reduction is per-bundle (spec.reduction.mode) + ramp/kill-switch
+        # /auto-rollback gated. Break-glass: AIQG_EXTRACTION_APPLY_DISABLED=true.
+        - name: AIQG_EXTRACTION_ENABLED
+          value: "true"
+        - name: AIQG_EXTRACTION_OLLAMA_URL
+          value: http://ollama.tas-shared:11434
+        - name: AIQG_EXTRACTION_EMBED_MODEL
+          value: all-minilm
+        - name: AIQG_EXTRACTION_MIN_CONTENT_SIZE
+          value: "2000"
 
         resources:
           requests:


### PR DESCRIPTION
Captures the Slice D cluster-wide rollout (extraction enabled on the main gateway) in the committed manifest. Mirrors #88. Image tag stays `:latest` placeholder (real tag set at deploy). 🤖 Generated with [Claude Code](https://claude.com/claude-code)