### PR TITLE
aiqg: SLM rewrite provider config (cloud unblock)

### DIFF
--- a/cmd/llm-router/main.go
+++ b/cmd/llm-router/main.go
@@ -92,6 +92,12 @@ func NewApplication(configPath string) (*Application, error) {
 				EmbedModel:     cfg.Gatekeeper.Extraction.EmbedModel,
 				MinContentSize: cfg.Gatekeeper.Extraction.MinContentSize,
 				ApplyDisabled:  cfg.Gatekeeper.Extraction.ApplyDisabled,
+				SLMEnabled:     cfg.Gatekeeper.Extraction.SLMEnabled,
+				SLMProvider:    cfg.Gatekeeper.Extraction.SLMProvider,
+				SLMModel:       cfg.Gatekeeper.Extraction.SLMModel,
+				SLMBaseURL:     cfg.Gatekeeper.Extraction.SLMBaseURL,
+				SLMAPIKey:      cfg.Gatekeeper.Extraction.SLMAPIKey,
+				SLMMaxTokens:   cfg.Gatekeeper.Extraction.SLMMaxTokens,
 			},
 		}
 

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -125,6 +125,16 @@ gatekeeper:
     ollama_url: "http://ollama.tas-shared:11434"   # AIQG_EXTRACTION_OLLAMA_URL
     embed_model: "all-minilm"                       # AIQG_EXTRACTION_EMBED_MODEL
     min_content_size: 2000                          # AIQG_EXTRACTION_MIN_CONTENT_SIZE (bytes)
+    # Optional SLM rewrite/compression step (Plan #7). Relevance always runs on
+    # Ollama; the SLM step can run on a cloud model so it works without a local
+    # GPU. Off by default — enabling it makes a cloud LLM call per reduced
+    # request (cost + latency), so measure net savings before leaving it on.
+    slm_enabled: false                              # AIQG_EXTRACTION_SLM_ENABLED
+    slm_provider: "openai"                          # AIQG_EXTRACTION_SLM_PROVIDER (ollama|openai|anthropic)
+    slm_model: "gpt-4o-mini"                        # AIQG_EXTRACTION_SLM_MODEL
+    slm_base_url: ""                                # AIQG_EXTRACTION_SLM_BASE_URL (blank = provider default)
+    slm_api_key: ""                                 # AIQG_EXTRACTION_SLM_API_KEY (from secret)
+    slm_max_tokens: 1024                            # AIQG_EXTRACTION_SLM_MAX_TOKENS
 
 logging:
   level: "info"

--- a/docs/AIQG-FTO-CLAIM-READ.md
+++ b/docs/AIQG-FTO-CLAIM-READ.md
@@ -1,0 +1,134 @@
+# AIQG — Freedom-to-Operate Claim-Read
+
+**Status:** Technical FTO triage — 2026-06-19. Granted **independent** claims of
+four patents read against the AIQG attribution design. **Not legal advice and
+not a clearance opinion** — infringement turns on claim construction, doctrine
+of equivalents, prosecution history, and validity, none assessed here. Engage
+patent counsel before relying on any conclusion. Claim texts verified directly
+from USPTO grant PDFs.
+**Companion:** [`AIQG-PROVISIONAL-BRIEF.md`](./AIQG-PROVISIONAL-BRIEF.md)
+
+## Techniques assessed
+
+- **(a)** Content-propagation graph (Rabin chunking, TTL index, IDF-weighted,
+  zero-header inference)
+- **(b)** `tool_call_id` echo (deterministic flow linkage)
+- **(c)** Prefix chaining (hash multi-turn prefix → conversation id)
+- **(d)** 8-tier identity-confidence ladder + asserted-vs-inferred impersonation
+  signal
+- **(e)** Agent-type fingerprinting (13-signal ensemble, MinHash lineage)
+- **(f)** Per-agent / per-flow cost attribution & metering at the gateway
+
+## The four patents (verified identities)
+
+| Patent | Title | Assignee | Priority | Grant | Independent claims |
+|---|---|---|---|---|---|
+| **US 12,483,411 B1** | Blockchain-based AI agent life-cycle management & authentication | Tyntre LLC | 2025-03-04 | 2025-11-25 | 1 (system), 11 (method) |
+| **US 12,547,677 B1** | Anticipatory (JIT) authentication for account-specific AI agents | Airia LLC | 2025-05-16 | 2026-02-10 | 1 (method), 19 (CRM), 20 (system) |
+| **US 10,924,326 B2** | Clustered real-time correlation of trace-data fragments (distributed transactions) | Dynatrace LLC | 2015-09-14 | 2021-02-16 | 1 (method), 15 (system) |
+| **US 11,785,115 B2** | Request tracing | IBM Corp | 2021-09-27 | 2023-10-10 | 1 (system), 11 (method), 18 (CRM) |
+
+**What each covers (one line):**
+- **Tyntre** — blockchain-stored agent identity token + permissioned
+  cross-session context-passing, identity token attached to each response.
+- **Airia** — pause/resume agent execution to acquire **per-user** (not global)
+  OAuth-style tool credentials via a credentials service.
+- **Dynatrace** — APM tracing where each agent **stamps an explicit
+  correlation-server ID + transaction ID into outgoing messages**; dependents
+  add per-customer metric attribution + trace splitting at client boundaries.
+- **IBM** — attribute spans to a specific process by correlating **socket/port
+  connection data at a sidecar proxy** with span metadata, to disambiguate
+  name-collisions.
+
+## Risk matrix (patent × technique)
+
+HIGH = independent-claim language plausibly reads on the technique; MEDIUM =
+conceptual overlap but a claimed element likely missing; LOW = distant; NONE =
+no meaningful read.
+
+| Technique | Tyntre 12,483,411 | Airia 12,547,677 | Dynatrace 10,924,326 | IBM 11,785,115 |
+|---|---|---|---|---|
+| (a) Content-propagation graph | LOW | NONE | LOW | LOW |
+| (b) `tool_call_id` echo | MEDIUM | LOW | **MEDIUM** | LOW |
+| (c) Prefix chaining | LOW | NONE | LOW | LOW |
+| (d) Identity ladder + impersonation | MEDIUM | LOW | LOW | NONE |
+| (e) Agent-type fingerprinting | LOW | NONE | LOW | **MEDIUM** |
+| (f) Per-agent metering | LOW | LOW | **MEDIUM** | NONE |
+
+**No HIGH-risk read on any technique as the design is described.**
+
+## Key rationales (tied to claim language)
+
+- **(a) is clear of all four.** Dynatrace and IBM both require an explicit
+  propagated identifier or socket-connection observation; the zero-header
+  content-fingerprint mechanism is the opposite. Tyntre requires content on a
+  blockchain with an attached token. No claim recites content-similarity
+  matching.
+- **(b) vs Dynatrace (MEDIUM)** — Dynatrace claim 1 covers an agent
+  *propagating* a transaction id into a message and a downstream agent
+  *retrieving* it. A `tool_call_id` reappearing is functionally id-in-payload
+  linkage. **Gap that saves us:** Dynatrace requires an instrumented agent that
+  *deliberately appends* the id plus a correlation-server *selection/routing*
+  scheme; the gateway here passively observes an id the model echoed and does no
+  server selection.
+- **(b)/(d) vs Tyntre (MEDIUM)** — same problem space (agent identity, carrying
+  context across sessions) but every Tyntre independent claim **requires a
+  blockchain and an attached agent identity token**, which the design uses
+  neither of.
+- **(e) vs IBM (MEDIUM)** — IBM disambiguates same-labeled services by
+  *characteristics*; same goal as agent-type fingerprinting. **Gap:** IBM
+  requires those characteristics from **socket-connection correlation at a
+  network traffic component (sidecar proxy)**; the 13 signals here are
+  L7-semantic at an API gateway.
+- **(f) vs Dynatrace (MEDIUM)** — Dynatrace dependents 3/4/17 attribute
+  per-transaction metrics per **customer** via appended customer id + trace
+  splitting. **Gap:** the design attributes cost to *agent/flow* via *inference*
+  from the gateway ledger, not to a *customer* via a *propagated* correlation
+  id.
+
+## Overall posture
+
+| Patent | Posture |
+|---|---|
+| Tyntre 12,483,411 | Low-to-moderate — clear if no blockchain + no identity token attached to responses. |
+| Airia 12,547,677 | Low — out of scope (JIT per-user tool auth). |
+| **Dynatrace 10,924,326** | **Moderate — the one to take most seriously.** Broad, 2015 priority, sophisticated assignee, expires ~2035. |
+| IBM 11,785,115 | Low-to-moderate — clear if no socket/port correlation at a sidecar proxy. |
+
+**Clear:** (a) content-propagation graph, (c) prefix chaining.
+**Lightly encumbered, defensible on a missing element:** (b), (d), (e), (f).
+
+## Design-arounds for the MEDIUM risks
+
+**vs Dynatrace (priority target):**
+1. Keep flow linkage **inference-only** — never inject a TAS-generated
+   correlation id into outgoing requests; rely on the model-produced
+   `tool_call_id` echo and content propagation.
+2. Do **not** implement a correlation-server *listing + selection/routing*
+   scheme.
+3. For (f), bill from the gateway's **own ledger keyed on inferred identity** —
+   not a customer id appended to messages — and avoid "trace splitting at
+   client-control boundaries" as a mechanism.
+
+**vs IBM (for (e)):**
+4. Keep fingerprinting at **L7/application semantics** (toolset hash, prompt
+   template, JSON schema, call-graph, timing); **never** correlate raw
+   socket/port to process at a sidecar proxy.
+
+**vs Tyntre (for (b)/(d)):**
+5. Do **not** store agent identity tokens / permissions / context on a
+   blockchain, and do **not** attach an agent identity token to served
+   responses. Frame impersonation detection as statistical mismatch, not token
+   verification against a ledger.
+
+**vs Airia:**
+6. No change needed; just don't add a pause/resume-on-missing-credential JIT
+   per-user tool-auth flow to the gateway.
+
+## Recommendation
+
+Commission a **counsel-led opinion focused on Dynatrace 10,924,326** and on
+techniques (b) and (f) **before any billing-grade per-agent metering ships**.
+The other three patents are narrower (blockchain identity, JIT auth,
+socket-proxy tracing) and the design differs on a load-bearing element of each.
+Observability-only use (no billing) carries materially lower exposure.

--- a/docs/AIQG-PROVISIONAL-BRIEF.md
+++ b/docs/AIQG-PROVISIONAL-BRIEF.md
@@ -1,0 +1,171 @@
+# AIQG — Provisional Patent Filing Brief (Candidates 1–4)
+
+**Status:** Draft for patent counsel — 2026-06-19. Technical drafting aid, **not
+legal advice**; claim scope and filing strategy require a patent attorney.
+**Inputs:** [`AIQG-PATENT-ANALYSIS.md`](./AIQG-PATENT-ANALYSIS.md),
+[`AIQG-AGENT-FLOW-ATTRIBUTION.md`](./AIQG-AGENT-FLOW-ATTRIBUTION.md),
+[`AIQG-AGENT-IDENTITY-RESEARCH.md`](./AIQG-AGENT-IDENTITY-RESEARCH.md).
+**FTO companion:** [`AIQG-FTO-CLAIM-READ.md`](./AIQG-FTO-CLAIM-READ.md)
+
+---
+
+## 1. Title (working)
+
+*"Zero-Cooperation Attribution and Flow Reconstruction of AI-Agent Traffic at an
+LLM Gateway."*
+
+## 2. Field
+
+Observability, attribution, and security of multi-agent LLM systems at a
+network gateway / reverse proxy that mediates calls to one or more LLM
+providers.
+
+## 3. The problem
+
+A single AI-agent execution fans out into many independent LLM API calls
+(planner → workers, ReAct tool loops, RAG sub-queries) that span multiple
+processes, models, and toolsets. A gateway sees a flat stream of stateless
+chat-completion requests and cannot answer **"which agent, which run, which
+step produced this call?"** Existing approaches require the client to be
+instrumented — they propagate self-asserted identifiers in headers or SDK
+trace context (Helicone session headers, OpenTelemetry GenAI spans, LangSmith
+run ids). For **un-instrumented or third-party clients those mechanisms go
+dark**, and self-asserted ids are forgeable, so they cannot support security or
+billing-grade attribution.
+
+## 4. Core insight (the thread tying the claims together)
+
+The stateless chat-completions protocol **guarantees that the gateway's own
+served output reappears in later requests**: the client must re-send the full
+conversation history every turn, and tool results must echo the exact
+`tool_call_id` values the gateway served. A gateway that indexes what it serves
+can therefore recognize it coming back and reconstruct agent topology
+**deterministically, with zero client cooperation** — the replay is forced by
+the API shape, not merely statistically likely. On top of that deterministic
+floor, agent *type* identity can be inferred statistically from the structural
+signals programmatic callers do not randomize.
+
+## 5. Independent-claim concepts (the four candidates)
+
+### Candidate 1 — Content-propagation graph (strongest; design-only)
+
+A method of attributing inter-agent data flow at an LLM gateway by:
+1. content-defined chunking (e.g., Rabin fingerprinting, robust to byte shifts)
+   of each **served** response into a fingerprint set;
+2. storing those fingerprints in a TTL-bounded index keyed to the serving
+   flow/step;
+3. chunking each **incoming** request and looking its chunks up in the index;
+4. on partial overlap, emitting a **data-flow edge** (parent flow → child
+   sub-agent) — even across different processes, models, and toolsets where no
+   header scheme could propagate anything;
+5. **suppressing boilerplate via inverse-document-frequency weighting** so
+   chunks common across many principals/templates ("You are a helpful
+   assistant", shared RAG corpus text) carry no attribution weight.
+
+*Why novel:* the WAN-dedupe / byte-caching analogy (Bluecoat, Riverbed) is
+prior art in a different field; its application to **agent attribution in an LLM
+gateway with IDF boilerplate suppression** is absent from all surveyed prior
+art and from the four FTO patents.
+
+### Candidate 2 — Deterministic flow linkage via vendor-minted token echo
+
+A method of reconstructing a multi-step agent flow by:
+1. detecting `tool_calls` in a response the gateway serves and indexing each
+   vendor-minted `tool_call_id → (flow_id, step_id)` in a short-TTL store;
+2. on a later request carrying `role=tool` messages, matching the echoed
+   `tool_call_id` to the index;
+3. on match, asserting that the later request is the **next step of the same
+   flow** and the indexed request is its **parent step**, yielding
+   `flow_id / step_id / parent_step_id` for the full ReAct loop.
+
+*Why novel:* the correlating token was minted by the vendor *through the
+gateway* — "the client cannot fake having received `call_abc123` from us" — so a
+match is **proof, not heuristic**. No surveyed tool does this.
+
+### Candidate 3 — Graded identity-confidence ladder with inference-audits-assertion security check
+
+A system that, for each gateway event:
+1. resolves identity top-down through an ordered ladder of sources
+   (authenticated → asserted → baggage → linked → principal → transport →
+   fingerprinted → behavioral → unattributed) and **stamps the winning
+   `identity_source` plus a numeric `identity_confidence`**;
+2. applies a **split-trust rule** — an *asserted* source wins for *who* (agent
+   identity); a *linked* (evidence-based) source wins for *shape* (flow/step
+   parentage);
+3. when an asserted agent identity arrives on traffic whose **inferred**
+   signature belongs to a different cluster, emits an **agent-impersonation /
+   misconfiguration anomaly** — i.e., the inference tier audits the cooperative
+   tier.
+
+*Why novel:* individual tiers are routine; the **graded combination with a
+confidence stamp and inference-audits-assertion mismatch as a security signal**
+has no surveyed precedent. No other system can detect a client lying about
+which agent it is.
+
+### Candidate 4 — Fingerprint-ensemble agent registry with version lineage
+
+A method of identifying agent *type* without client cooperation by:
+1. extracting an ensemble of structural signals from each request (toolset
+   hash, system-prompt template via log-template mining, user-message template,
+   `response_format` JSON schema, few-shot blocks, scaffolding idioms,
+   serialized-payload vocabulary, config tuple, step-archetype sequence,
+   call-graph topology, token-count profile, periodicity, inter-step latency);
+2. clustering in the joint signal space, **scoped per `(tenant, principal)`**,
+   to a surrogate agent identity;
+3. linking partially-changed signatures as a **new version of the same lineage**
+   (MinHash Jaccard above threshold), so identity survives prompt iteration;
+4. exposing clusters in a registry where **humans label clusters, not flows**
+   ("14 agents detected, 3 named"), and where cooperatively tagged traffic
+   doubles as **labeled seeds that calibrate the clustering** (semi-supervised).
+
+*Why novel:* each technique borrows known art (Drain mining, MinHash, process
+mining); the **composition — per-(tenant,principal) ensemble + version lineage +
+human-labels-clusters registry + semi-supervised calibration from tagged
+traffic** — has no surveyed precedent.
+
+## 6. Reduction to practice / enablement evidence
+
+- **Shipped 2026-06-11 (`aiqg-v5.24`):** locked identity model, `TAS-*` +
+  `traceparent` + `baggage` header contract, `AgentContext` event sub-struct,
+  emitter field promotion, `/api/v1/events`, Traffic Explorer. Establishes the
+  event schema and resolution-ladder plumbing the claims build on.
+- **Design-only (to be built before/at filing):** the inference engine —
+  `tool_call_id` echo + prefix chaining + content-propagation chunking +
+  fingerprint ensemble + registry.
+- **Validation artifact:** `cmd/demo-traffic --untagged` synthesizes
+  multi-step agent profiles with known ground truth; running the inference
+  tiers against it yields **precision/recall per tier** — the single best
+  reduction-to-practice exhibit for the provisional. **Run this before filing.**
+
+## 7. FTO posture (summary; see companion)
+
+Claim-read of US 12,483,411 (Tyntre, blockchain agent identity), US 12,547,677
+(Airia, JIT per-user tool auth), US 10,924,326 (Dynatrace, distributed-trace
+correlation), US 11,785,115 (IBM, socket-correlation request tracing) found
+**no HIGH-risk read** on any of the four candidates as described. The
+content-propagation graph (Candidate 1) is **clear** of all four. Dynatrace
+10,924,326 is the one to take most seriously (broad correlation/metering claims)
+and warrants a counsel-led read before billing-grade metering. Design-arounds
+documented in the FTO companion.
+
+## 8. Recommended filing scope and sequence
+
+1. **File one provisional covering Candidates 1–4 as a family** before any
+   public disclosure — the four share the "gateway recognizes its own served
+   output" core and are strongest claimed together. Lean provisional over
+   defensive publication for these moat-bearing pieces.
+2. **Before filing:** run `cmd/demo-traffic --untagged`, capture per-tier
+   precision/recall, and fold the numbers + architecture diagrams into the
+   provisional as enablement.
+3. **In parallel, counsel-led FTO read** focused on Dynatrace 10,924,326 and
+   the `tool_call_id`-echo / per-agent-metering techniques before any
+   billing-grade use.
+4. **Keep candidate 5** (identity-ladder-keyed sticky experimentation) and
+   **CLEAR scoring** for a later, separate filing decision — out of scope here.
+
+## 9. Disclosure hygiene (statutory-bar guard)
+
+The inferred-attribution design currently exists only in private internal
+repos/docs — no statutory bar has started. **Do not publicly disclose, demo, or
+publish the inference design** (talks, blog posts, open-sourcing the inference
+engine, investor materials beyond NDA) until the provisional is on file.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -134,6 +134,13 @@ type ExtractionConfig struct {
 	EmbedModel     string `yaml:"embed_model"`      // e.g. all-minilm
 	MinContentSize int    `yaml:"min_content_size"` // extractor floor (bytes)
 	ApplyDisabled  bool   `yaml:"apply_disabled"`   // Phase 4 kill-switch: never APPLY active reduction
+	// SLM rewrite step — optional cloud-backed compression (Plan #7 SLM unblock).
+	SLMEnabled   bool   `yaml:"slm_enabled"`
+	SLMProvider  string `yaml:"slm_provider"` // ollama | openai | anthropic
+	SLMModel     string `yaml:"slm_model"`
+	SLMBaseURL   string `yaml:"slm_base_url"`
+	SLMAPIKey    string `yaml:"slm_api_key"`
+	SLMMaxTokens int    `yaml:"slm_max_tokens"`
 }
 
 // ScanPolicyConfig controls which messages are scanned based on role and trust metadata.
@@ -479,6 +486,27 @@ func (c *Config) loadFromEnv() {
 	// mutates payloads (downgrades to shadow). Default off.
 	if d := os.Getenv("AIQG_EXTRACTION_APPLY_DISABLED"); d == "true" {
 		c.Gatekeeper.Extraction.ApplyDisabled = true
+	}
+	// SLM rewrite step (Plan #7 SLM unblock) — cloud-backed compression.
+	if e := os.Getenv("AIQG_EXTRACTION_SLM_ENABLED"); e == "true" {
+		c.Gatekeeper.Extraction.SLMEnabled = true
+	}
+	if p := os.Getenv("AIQG_EXTRACTION_SLM_PROVIDER"); p != "" {
+		c.Gatekeeper.Extraction.SLMProvider = p
+	}
+	if m := os.Getenv("AIQG_EXTRACTION_SLM_MODEL"); m != "" {
+		c.Gatekeeper.Extraction.SLMModel = m
+	}
+	if u := os.Getenv("AIQG_EXTRACTION_SLM_BASE_URL"); u != "" {
+		c.Gatekeeper.Extraction.SLMBaseURL = u
+	}
+	if k := os.Getenv("AIQG_EXTRACTION_SLM_API_KEY"); k != "" {
+		c.Gatekeeper.Extraction.SLMAPIKey = k
+	}
+	if n := os.Getenv("AIQG_EXTRACTION_SLM_MAX_TOKENS"); n != "" {
+		if v, err := strconv.Atoi(n); err == nil {
+			c.Gatekeeper.Extraction.SLMMaxTokens = v
+		}
 	}
 
 	// AIQG ingress — env overrides for the simple scalars. Tokens are

--- a/internal/gatekeeper/gatekeeper.go
+++ b/internal/gatekeeper/gatekeeper.go
@@ -54,6 +54,16 @@ type ExtractionConfig struct {
 	// measurement. Shadow/projected are unaffected. Toggle via env without an
 	// image rebuild.
 	ApplyDisabled bool `yaml:"apply_disabled"`
+
+	// SLM rewrite step (Plan #7). The relevance/embedding step always runs on
+	// Ollama; the optional SLM compression step can run on a cloud provider so
+	// it works without a local GPU. Disabled by default.
+	SLMEnabled   bool   `yaml:"slm_enabled"`
+	SLMProvider  string `yaml:"slm_provider"` // ollama | openai | anthropic
+	SLMModel     string `yaml:"slm_model"`    // e.g. gpt-4o-mini, claude-haiku-4-5-20251001, phi3.5
+	SLMBaseURL   string `yaml:"slm_base_url"` // optional override; provider default otherwise
+	SLMAPIKey    string `yaml:"slm_api_key"`  // bearer / x-api-key for cloud providers
+	SLMMaxTokens int    `yaml:"slm_max_tokens"`
 }
 
 // ScanPolicy controls which messages are scanned based on role and trust metadata.
@@ -147,13 +157,30 @@ func New(cfg Config, logger *logrus.Logger) (*Client, error) {
 	if cfg.Extraction.Enabled {
 		ec := extract.DefaultExtractorConfig()
 		ec.EnableEmbedding = true
-		ec.EnableSLM = false
 		if cfg.Extraction.EmbedModel != "" {
 			ec.Embedding.Model = cfg.Extraction.EmbedModel
 		}
-		ec.SLM.URL = cfg.Extraction.OllamaURL // extract.NewEmbedder reads the Ollama URL from SLM.URL
+		// Embeddings always run on Ollama; its own URL is decoupled from the
+		// SLM step so the SLM can target a cloud provider.
+		ec.Embedding.URL = cfg.Extraction.OllamaURL
 		if cfg.Extraction.MinContentSize > 0 {
 			ec.MinContentSize = cfg.Extraction.MinContentSize
+		}
+		// Optional SLM compression step. Provider "ollama" needs a local GPU;
+		// "openai"/"anthropic" route the rewrite to a cloud model (Plan #7
+		// SLM unblock). Default off → relevance-only reduction.
+		ec.EnableSLM = cfg.Extraction.SLMEnabled
+		if cfg.Extraction.SLMEnabled {
+			ec.SLM = extract.SLMConfig{
+				Provider:  cfg.Extraction.SLMProvider,
+				URL:       cfg.Extraction.SLMBaseURL,
+				Model:     cfg.Extraction.SLMModel,
+				APIKey:    cfg.Extraction.SLMAPIKey,
+				MaxTokens: cfg.Extraction.SLMMaxTokens,
+			}
+			if cfg.Extraction.SLMProvider == extract.SLMProviderOllama && cfg.Extraction.SLMBaseURL == "" {
+				ec.SLM.URL = cfg.Extraction.OllamaURL // local SLM shares the Ollama endpoint
+			}
 		}
 		if ex, err := extract.NewExtractor(ec); err != nil {
 			logger.WithError(err).Warn("gatekeeper: extractor init failed; shadow reduction disabled")


### PR DESCRIPTION
Threads Gatekeeper #17 through the gateway: ExtractionConfig SLM fields + AIQG_EXTRACTION_SLM_* env; extractor enables SLM with the chosen cloud provider; embedder URL decoupled. Off by default. 🤖 Generated with [Claude Code](https://claude.com/claude-code)