### PR TITLE
feat(gatekeeper): inbound PII redaction in the router (G1)

### DIFF
--- a/cmd/llm-router/main.go
+++ b/cmd/llm-router/main.go
@@ -99,6 +99,10 @@ func NewApplication(configPath string) (*Application, error) {
 				SLMAPIKey:      cfg.Gatekeeper.Extraction.SLMAPIKey,
 				SLMMaxTokens:   cfg.Gatekeeper.Extraction.SLMMaxTokens,
 			},
+			Redaction: gatekeeper.RedactionConfig{
+				Enabled:  cfg.Gatekeeper.Redaction.Enabled,
+				Strategy: cfg.Gatekeeper.Redaction.Strategy,
+			},
 		}
 
 		gkClient, err := gatekeeper.New(gkCfg, logger)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,15 @@ type GatekeeperConfig struct {
 	Inbound           ScanDirectionConfig `yaml:"inbound"`
 	Outbound          ScanDirectionConfig `yaml:"outbound"`
 	Extraction        ExtractionConfig    `yaml:"extraction"`
+	Redaction         RedactionConfig     `yaml:"redaction"`
+}
+
+// RedactionConfig wires inbound PII redaction (G1). Default OFF (redaction is
+// lossy). Enable via GATEKEEPER_REDACT_ENABLED=true; strategy via
+// GATEKEEPER_REDACT_STRATEGY (mask|replace|hash, default mask).
+type RedactionConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Strategy string `yaml:"strategy"`
 }
 
 // ExtractionConfig wires the Ollama-backed extractor used for AIQG shadow
@@ -464,6 +473,15 @@ func (c *Config) loadFromEnv() {
 		if d, err := time.ParseDuration(st); err == nil {
 			c.Gatekeeper.ScanTimeout = d
 		}
+	}
+
+	// Inbound PII redaction (G1). Off unless GATEKEEPER_REDACT_ENABLED=true —
+	// redaction is lossy, so it's opt-in.
+	if os.Getenv("GATEKEEPER_REDACT_ENABLED") == "true" {
+		c.Gatekeeper.Redaction.Enabled = true
+	}
+	if s := os.Getenv("GATEKEEPER_REDACT_STRATEGY"); s != "" {
+		c.Gatekeeper.Redaction.Strategy = s
 	}
 
 	// AIQG shadow payload-reduction extractor (Plan #7 Phase 2). Off unless

--- a/internal/gatekeeper/gatekeeper.go
+++ b/internal/gatekeeper/gatekeeper.go
@@ -33,6 +33,14 @@ type Config struct {
 	Inbound  ScanDirectionConfig `yaml:"inbound"`
 	Outbound ScanDirectionConfig `yaml:"outbound"`
 
+	// Redaction configures inbound message redaction (G1,
+	// docs/AIQG-GATEKEEPER-INTEGRATION.md). Default OFF: redaction is LOSSY —
+	// masking customer@acme.com to [EMAIL] degrades what the model can answer —
+	// so it is opt-in. (Per-route targeting via the resolved policy bundle is a
+	// follow-up; this global flag is the first slice.) It is also the precondition
+	// for response caching: a cache built before this stores raw PII at rest.
+	Redaction RedactionConfig `yaml:"redaction"`
+
 	// Extraction configures the shadow payload-reduction measurement
 	// (Plan #7 Phase 2). When disabled (default), MeasureReduction is a
 	// no-op and the gateway never calls the extractor — preserving the
@@ -93,6 +101,15 @@ type ScanDirectionConfig struct {
 	ScanPolicy      ScanPolicy `yaml:"scan_policy"`
 }
 
+// RedactionConfig configures inbound message redaction (G1). Strategy is a
+// deterministic, infra-free redaction — "mask" (j***@***.com, default),
+// "replace" ([EMAIL]), or "hash" ([HASH:…]). Tokenize is NOT offered: it needs
+// Databunker (not deployed) and would mint per-call tokens that break caching.
+type RedactionConfig struct {
+	Enabled  bool   `yaml:"enabled"`
+	Strategy string `yaml:"strategy"`
+}
+
 // DefaultConfig returns the default Gatekeeper configuration.
 func DefaultConfig() Config {
 	return Config{
@@ -121,8 +138,15 @@ func DefaultConfig() Config {
 type Client struct {
 	processor pipeline.Processor
 	extractor extract.Extractor // nil unless Extraction.Enabled — shadow measurement only
-	config    Config
-	logger    *logrus.Logger
+	// scanner + redactor back the inbound redaction path (G1,
+	// docs/AIQG-GATEKEEPER-INTEGRATION.md). The pipeline's only content-mutating
+	// path is the Databunker tokenizer (not deployed), so mask/replace/hash
+	// redaction goes through the scanner's ScanString + the RedactionEngine
+	// directly — deterministic and infra-free.
+	scanner  scan.Scanner
+	redactor scan.RedactionEngine
+	config   Config
+	logger   *logrus.Logger
 }
 
 // New creates a new Gatekeeper client.
@@ -192,6 +216,8 @@ func New(cfg Config, logger *logrus.Logger) (*Client, error) {
 	return &Client{
 		processor: processor,
 		extractor: extractor,
+		scanner:   scanner,
+		redactor:  scan.NewRedactionEngine(),
 		config:    cfg,
 		logger:    logger,
 	}, nil
@@ -362,6 +388,90 @@ func shouldScanMessage(msg types.Message, policy ScanPolicy) bool {
 
 	// Default: scan the message
 	return true
+}
+
+// RedactMessages returns a NEW message slice with PII redacted in each scannable
+// message, plus the number of findings redacted (G1). The original slice is not
+// mutated; the caller assigns the result to req.Messages when redaction is
+// enabled for the route.
+//
+// It re-scans per message rather than reusing the block-path scan: ScanMessages
+// concatenates message text to decide blocking, and those offsets don't map back
+// to individual messages. Per-message scan is the correct granularity for
+// write-back, at the cost of a second scan (acceptable for G1; attestation
+// removes the double-scan later).
+//
+// Redaction is deterministic and content-derived (mask/replace/hash), so the
+// redacted form is byte-stable — identical input yields identical output, which
+// keeps prompt caching intact and lets a later cache key on the redacted prompt.
+// Only string content is redacted; multimodal ([]interface{}) content is left
+// unchanged in v1. Never call this on a request that was blocked.
+//
+// On a scan error it returns the ORIGINAL messages, 0, and the error — the caller
+// fails open (send the original, same as pre-G1 behavior) rather than dropping
+// the request.
+func (c *Client) RedactMessages(ctx context.Context, messages []types.Message, meta ScanMeta, strategy string) ([]types.Message, int, error) {
+	if c == nil || c.scanner == nil || c.redactor == nil {
+		return messages, 0, nil
+	}
+
+	policy := c.config.Inbound.ScanPolicy
+	if len(policy.AlwaysScanRoles) == 0 && len(policy.NeverScanRoles) == 0 {
+		policy = DefaultScanPolicy()
+	}
+	strat := parseRedactionStrategy(strategy)
+	profile := parseScanProfile(c.config.Inbound.ScanProfile)
+	tier := parseTrustTier(c.config.Inbound.TrustTier)
+
+	out := make([]types.Message, len(messages))
+	copy(out, messages)
+
+	total := 0
+	for i := range out {
+		if !shouldScanMessage(out[i], policy) {
+			continue
+		}
+		s, ok := out[i].Content.(string)
+		if !ok || s == "" {
+			continue // multimodal / empty — not redacted in v1
+		}
+
+		cfg := scan.DefaultScanConfig()
+		cfg.Profile = profile
+		cfg.TrustTier = tier
+		cfg.RedactionMode = strat // force our strategy; never the tokenize default
+
+		res, err := c.scanner.ScanString(ctx, s, cfg)
+		if err != nil {
+			return messages, 0, err
+		}
+		if res == nil || len(res.Findings) == 0 {
+			continue
+		}
+		redacted, rerr := c.redactor.Redact(s, res.Findings, strat)
+		if rerr != nil {
+			// Detection succeeded, redaction of this message failed: leave the
+			// message unredacted rather than dropping content, and don't count it.
+			continue
+		}
+		out[i].Content = redacted
+		total += len(res.Findings)
+	}
+	return out, total, nil
+}
+
+// parseRedactionStrategy maps a config string to a deterministic, infra-free
+// strategy. Tokenize (Databunker) and remove (silent data loss) are excluded;
+// anything unrecognized → mask.
+func parseRedactionStrategy(s string) scan.RedactionStrategy {
+	switch s {
+	case "replace":
+		return scan.RedactionReplace
+	case "hash":
+		return scan.RedactionHash
+	default:
+		return scan.RedactionMask
+	}
 }
 
 // ScanResponse scans LLM output content for violations.

--- a/internal/gatekeeper/redaction_test.go
+++ b/internal/gatekeeper/redaction_test.go
@@ -1,0 +1,138 @@
+package gatekeeper
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	routerTypes "github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+func redactMeta() ScanMeta {
+	return ScanMeta{TenantID: "t", RequestID: "r", UserID: "u", Source: "llm_input"}
+}
+
+// End-to-end against the real Gatekeeper scanner + redaction engine: an email in
+// a user message is masked, the finding is counted, and the original slice is
+// left untouched (the caller assigns the returned copy).
+func TestRedactMessages_MasksEmail(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+
+	orig := []routerTypes.Message{
+		{Role: "user", Content: "email me at alice@example.com please"},
+	}
+	out, n, err := client.RedactMessages(context.Background(), orig, redactMeta(), "mask")
+	require.NoError(t, err)
+	require.Greater(t, n, 0, "an obvious email must be detected and redacted")
+
+	got, _ := out[0].Content.(string)
+	assert.NotContains(t, got, "alice@example.com", "raw email survived redaction")
+	// Original slice must be unchanged — redaction returns a copy.
+	assert.Equal(t, "email me at alice@example.com please", orig[0].Content, "original message was mutated")
+}
+
+// Determinism is the cache-safety contract: identical input redacts to identical
+// bytes, or a redacted prompt would break vendor prompt caching.
+func TestRedactMessages_Deterministic(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+
+	msgs := []routerTypes.Message{{Role: "user", Content: "reach bob@example.com now"}}
+	out1, n1, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	require.NoError(t, err)
+	out2, n2, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	require.NoError(t, err)
+
+	assert.Equal(t, n1, n2)
+	assert.Equal(t, out1[0].Content, out2[0].Content, "redaction is non-deterministic")
+}
+
+// Clean content: no findings, content unchanged, count 0.
+func TestRedactMessages_CleanUnchanged(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+
+	msgs := []routerTypes.Message{{Role: "user", Content: "what is the capital of France?"}}
+	out, n, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+	assert.Equal(t, "what is the capital of France?", out[0].Content)
+}
+
+// Multimodal ([]interface{}) content is left unchanged in v1 (not redacted, not
+// dropped) — a follow-up, but it must never corrupt the message.
+func TestRedactMessages_MultimodalUnchanged(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+
+	multimodal := []interface{}{
+		map[string]interface{}{"type": "text", "text": "ssn 123-45-6789"},
+	}
+	msgs := []routerTypes.Message{{Role: "user", Content: multimodal}}
+	out, n, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	require.NoError(t, err)
+	assert.Equal(t, 0, n, "multimodal content is not redacted in v1")
+	assert.Equal(t, multimodal, out[0].Content)
+}
+
+// The replace strategy substitutes a placeholder ([EMAIL]-style), distinct from
+// mask — proves the strategy is honored, not hard-coded.
+func TestRedactMessages_ReplaceStrategy(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+
+	msgs := []routerTypes.Message{{Role: "user", Content: "write to carol@example.com"}}
+	out, n, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "replace")
+	require.NoError(t, err)
+	require.Greater(t, n, 0)
+	got, _ := out[0].Content.(string)
+	assert.NotContains(t, got, "carol@example.com")
+	// mask keeps shape (has '@'); replace does not — a weak but real distinction.
+	maskOut, _, _ := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	assert.NotEqual(t, out[0].Content, maskOut[0].Content, "replace and mask should differ")
+}
+
+// parseRedactionStrategy must never route to tokenize/remove, whatever the input.
+func TestParseRedactionStrategy_SafeStrategiesOnly(t *testing.T) {
+	for _, in := range []string{"tokenize", "remove", "", "bogus", "mask", "replace", "hash"} {
+		got := string(parseRedactionStrategy(in))
+		if got == "tokenize" || got == "remove" {
+			t.Fatalf("parseRedactionStrategy(%q) = %q — must never be tokenize/remove", in, got)
+		}
+	}
+	assert.Equal(t, "replace", string(parseRedactionStrategy("replace")))
+	assert.Equal(t, "hash", string(parseRedactionStrategy("hash")))
+	assert.Equal(t, "mask", string(parseRedactionStrategy("bogus")), "unknown → mask")
+}
+
+// A role the scan policy skips (assistant, by default) is not redacted.
+func TestRedactMessages_HonorsScanPolicy(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+
+	// Default policy never-scans "assistant"; its email must survive.
+	msgs := []routerTypes.Message{
+		{Role: "assistant", Content: "per our chat, dave@example.com"},
+		{Role: "user", Content: "and eve@example.com"},
+	}
+	out, n, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	require.NoError(t, err)
+	require.Greater(t, n, 0)
+	assert.Contains(t, out[0].Content, "dave@example.com", "assistant message should not be scanned/redacted")
+	got, _ := out[1].Content.(string)
+	assert.NotContains(t, got, "eve@example.com", "user message should be redacted")
+}
+
+// The finding preview must stay log-safe even end-to-end (sanity that we never
+// surface raw values through the count path — count is just an int, no value).
+func TestRedactMessages_CountOnlyNoValueLeak(t *testing.T) {
+	client := newTestClient(t)
+	defer client.Close()
+	msgs := []routerTypes.Message{{Role: "user", Content: "ssn 123-45-6789 and mail x@y.com"}}
+	_, n, err := client.RedactMessages(context.Background(), msgs, redactMeta(), "mask")
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, n, 2, "both SSN and email should be found")
+}

--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -724,6 +724,7 @@ func routingView(r *Routing) events.RoutingView {
 		InboundFindings:     s.InboundFindings,
 		OutboundFindings:    s.OutboundFindings,
 		ScanRan:             s.ScanRan,
+		RedactionCount:      s.RedactionCount,
 		FinishReason:        s.FinishReason,
 		AttemptCount:        s.AttemptCount,
 		FallbackUsed:        s.FallbackUsed,

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -90,6 +90,12 @@ type Routing struct {
 	// the events builder to mint the AgentSurrogateID.
 	fingerprint string
 
+	// redaction (G1): number of PII findings redacted from the inbound messages
+	// before the vendor call. 0 when redaction is off or found nothing. Surfaced
+	// on the event as redaction_applied/redacted_count so a quality regression on
+	// a redacting route is attributable.
+	redactionCount int
+
 	// experiments (Phase D): the experiment + variant that claimed this
 	// request. Stamped at request time (so the routing override + the event
 	// stamp use one decision). Empty when no experiment claimed it.
@@ -173,6 +179,9 @@ type RoutingSnapshot struct {
 	// when nothing fingerprintable.
 	Fingerprint string
 
+	// redaction (G1): count of PII findings redacted inbound. 0 = none.
+	RedactionCount int
+
 	// experiments (Phase D): claiming experiment + variant. Empty when none.
 	ExperimentID      string
 	ExperimentVariant string
@@ -209,6 +218,7 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		PrefixHash:          r.prefixHash,
 		StateHash:           r.stateHash,
 		Fingerprint:         r.fingerprint,
+		RedactionCount:      r.redactionCount,
 		ExperimentID:        r.experimentID,
 		ExperimentVariant:   r.experimentVariant,
 	}
@@ -313,6 +323,23 @@ func StampFingerprint(ctx context.Context, fp string) {
 	defer r.mu.Unlock()
 	if r.fingerprint == "" {
 		r.fingerprint = fp
+	}
+}
+
+// StampRedaction records the number of PII findings redacted from the inbound
+// messages (G1). First-write-wins; count<=0 is a no-op.
+func StampRedaction(ctx context.Context, count int) {
+	if count <= 0 {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.redactionCount == 0 {
+		r.redactionCount = count
 	}
 }
 

--- a/internal/middleware/redaction_stamp_test.go
+++ b/internal/middleware/redaction_stamp_test.go
@@ -1,0 +1,33 @@
+package middleware
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStampRedaction_FirstWriteWinsAndNonPositiveNoop(t *testing.T) {
+	r := NewRouting()
+	ctx := WithRouting(context.Background(), r)
+
+	if got := r.Snapshot().RedactionCount; got != 0 {
+		t.Fatalf("unstamped RedactionCount = %d, want 0", got)
+	}
+
+	// Non-positive is a no-op.
+	StampRedaction(ctx, 0)
+	StampRedaction(ctx, -3)
+	if got := r.Snapshot().RedactionCount; got != 0 {
+		t.Fatalf("non-positive stamp set RedactionCount = %d, want 0", got)
+	}
+
+	// First positive write wins.
+	StampRedaction(ctx, 4)
+	StampRedaction(ctx, 9)
+	if got := r.Snapshot().RedactionCount; got != 4 {
+		t.Fatalf("RedactionCount = %d, want 4 (first-write-wins)", got)
+	}
+}
+
+func TestStampRedaction_NoRoutingInContextIsSafe(t *testing.T) {
+	StampRedaction(context.Background(), 2) // must not panic
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -655,6 +655,33 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Gatekeeper inbound REDACTION (G1, docs/AIQG-GATEKEEPER-INTEGRATION.md).
+	// Runs after the block decision (a blocked request never reaches here) and
+	// before reduction/routing, so req.Messages is redacted for everything
+	// downstream — reduction measurement, routing, and the vendor call all see
+	// the redacted content, and a later response cache would key on it.
+	//
+	// Default off (redaction is lossy). Fail-open: on a scan error we log and
+	// send the original content — the same PII exposure as pre-G1, never a
+	// dropped request. Deterministic strategy → the redacted prompt is byte-stable
+	// (cache-safe).
+	if !scanBypassed && s.gatekeeper != nil && s.gatekeeperConfig != nil && s.gatekeeperConfig.Redaction.Enabled {
+		meta := gatekeeper.ScanMeta{
+			TenantID:  s.extractTenantID(r),
+			RequestID: req.ID,
+			UserID:    s.extractUserID(r),
+			Source:    "llm_input",
+		}
+		redacted, n, err := s.gatekeeper.RedactMessages(r.Context(), req.Messages, meta, s.gatekeeperConfig.Redaction.Strategy)
+		if err != nil {
+			s.logger.WithError(err).WithField("request_id", req.ID).Warn("Inbound redaction failed; sending original content")
+		} else if n > 0 {
+			req.Messages = redacted
+			middleware.StampRedaction(r.Context(), n)
+			w.Header().Set("X-TAS-Redaction", "applied")
+		}
+	}
+
 	// AIQG payload-reduction (Plan #7 Phase 2/3). The effective reduction is
 	// an applying experiment variant's reduction (Phase 3, takes precedence
 	// and MUTATES the payload) or the bundle's resolved reduction (Phase 2,

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -77,6 +77,10 @@ type RoutingView struct {
 	OutboundFindings map[string]int
 	ScanRan          bool
 
+	// RedactionCount is the number of PII findings redacted from the
+	// inbound messages before the vendor call (G1). 0 = none/off.
+	RedactionCount int
+
 	// Vendor finish_reason captured from the response. Used both
 	// to populate ResponseEvent.FinishReason (taking precedence
 	// over the BuildOptions value) and to drive clear.Efficacy.
@@ -588,6 +592,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		EventTimestamps:      snap,
 		TokenAccounting:      tokenAcct,
 		Assurance:            assuranceSummary,
+		RedactionApplied:     routing.RedactionCount > 0,
+		RedactedCount:        routing.RedactionCount,
 		CLEAR:                clear.Compute(clearInput),
 		ScoringVersion:       ScoringVersion,
 		GatewayVersion:       GatewayVersion,

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -207,6 +207,13 @@ type ResponseEvent struct {
 	// through traffic or Gatekeeper-disabled deployments).
 	Assurance *AssuranceSummary `json:"assurance,omitempty"`
 
+	// Redaction (G1): whether inbound PII redaction rewrote the prompt before
+	// the vendor call, and how many findings were redacted. Omitted when
+	// redaction is off or found nothing. Lets a quality regression on a
+	// redacting route be attributed to redaction rather than the model.
+	RedactionApplied bool `json:"redaction_applied,omitempty"`
+	RedactedCount    int  `json:"redacted_count,omitempty"`
+
 	// CLEAR scores — populated by pkg/clear.Compute(). A nil *Scores
 	// (rather than a *Scores with all-nil dimension fields) means the
 	// scorer wasn't run at all, which today only happens on the noop


### PR DESCRIPTION
The router scans prompts and blocks, but **never redacts** — content reaches the vendor byte-for-byte. G1 wires redaction in, gated and default-off. Design: `docs/AIQG-GATEKEEPER-INTEGRATION.md` Part A / stage **G1**. Closes #102.

## Why it matters

- **Caching precondition.** `AIQG-CACHING.md` (C1) and `AIQG-SEMANTIC-CACHING.md` (C4) both promise "we never store raw PII" *because* the prompt is redacted. Today post-scan == pre-scan, so a cache built to those docs would store **raw PII at rest in Redis**. Nothing in the caching track can honestly ship before this.
- Completes the LLM-proxy boundary: it detects, now it can remediate.

## What it does

`Client.RedactMessages` — per scannable message, `ScanString` + the deterministic `RedactionEngine` (mask/replace/hash) rewrite the content; returns a **new** slice + redacted-finding count, original untouched. Re-scans per message because the block path concatenates text (offsets don't map back). **Tokenize is excluded** — needs Databunker (not deployed) and would break caching. Multimodal content left unchanged in v1.

Wired in `handleChatCompletion` **after the block decision** (a blocked request never reaches it) and **before reduction/routing**, so `req.Messages` is redacted for everything downstream — reduction measurement, routing, the vendor call, and a future response-cache key.

## Safety

- **Default OFF** — redaction is lossy (masking `customer@acme.com` → `[EMAIL]` degrades what the model can answer). Enable via `GATEKEEPER_REDACT_ENABLED=true`, strategy `GATEKEEPER_REDACT_STRATEGY` (mask|replace|hash). Per-route targeting via the resolved policy bundle is a follow-up.
- **Fail-open** — on a scan error, log and send the original (same exposure as pre-G1), never a dropped request.
- **Deterministic** — the redacted prompt is byte-stable, so redaction can't destabilize a prefix and a later cache can key on it.

## Observability

`redaction_applied` + `redacted_count` on the AIQG event (snake_case json tags — the tagged-wire discipline), via `StampRedaction` → `RoutingView` → event, so a quality regression on a redacting route is attributable to redaction rather than the model. Plus an `X-TAS-Redaction: applied` response header.

## Tests (`-tags nohs`, `-race`)

End-to-end against the **real** Gatekeeper scanner: email masked, count returned, original slice unmutated, deterministic, clean-content unchanged, multimodal unchanged, replace≠mask, scan-policy honored (assistant role skipped), never-tokenize guard; plus `StampRedaction` first-write-wins/no-op. Full module suite green (20 pkgs).

## ⚠️ Merge coordination with #101 (P0)

On the P0 branch, `StampCachePrefixHash` runs **before** this redaction, so the probe hashes **pre-redaction** content. The reuse **rate** is preserved — redaction is deterministic, so a pre-redaction prefix repeats iff the post-redaction one does — so P0's conclusion holds. But **P1 breakpoint placement should hash post-redaction** (the real cache key is on the redacted prompt). Move `StampCachePrefixHash` after redaction when both land.

## Not in this PR

Deploy (`GATEKEEPER_REDACT_ENABLED` is off everywhere); per-route targeting; multimodal redaction. G1 unblocks the caching track; it doesn't turn redaction on.

Refs: #101 #102, tas-mcp#26

🤖 Generated with [Claude Code](https://claude.com/claude-code)