### PR TITLE
feat(aiqg): C1 exact-match response cache

### DIFF
--- a/docs/AIQG-CACHING.md
+++ b/docs/AIQG-CACHING.md
@@ -1,10 +1,26 @@
 # AIQG — Response Caching (Design)
 
-Status: **Design / for review** — NOT implemented. Gateway feature
+Status: **C1 (exact-match v1) IMPLEMENTED** — `pkg/aiqg/responsecache` + the
+lookup/store wiring in `internal/server` (`maybeServeFromCache` /
+`maybeStoreInCache`). Default off; enable per deployment with
+`AIQG_RESPONSE_CACHE_ENABLED=true`. C2 (accounting/UI), C3 (experiment keying),
+and C4 (semantic, `AIQG-SEMANTIC-CACHING.md`) remain design-only. Gateway feature
 (`tas-llm-router`). Related: `AIQG-EXTENSION.md` (already reserves a
 `cache_state` event dimension), `AIQG-EXPERIMENTS-RUNNER.md` (cache must be
 experiment-aware), `AIQG-AGENT-FLOW-ATTRIBUTION.md`, `account.md`
 (payload_retention_mode), `token-accounting.md` (vendor prompt-cache tokens).
+
+> **What C1 ships (2026-07-17):** tenant-namespaced exact-match cache keyed on
+> `hash(tenant + vendor + model + post-redaction messages + output-affecting
+> params + scoring_version)` (§3); default-safe eligibility — deterministic-only,
+> never streaming / tools / experiment-claimed (§1, §4, §7); `TAS-Cache: off|bypass`
+> header (§4); Redis store (reuses the AIQG client) with an in-memory fallback,
+> per-entry TTL, `max_body_bytes`, LRU + `PurgeTenant` for right-to-be-forgotten
+> (§5, §8); `cache_state` + `cache_key_hash` on every event (§6). A hit skips the
+> vendor call and does **not** stamp token usage, so cost/latency accounting reads
+> ~0. **Deferred to C2+:** the savings metric and hit/miss dashboard split, route-
+> level cache profiles (v1 is one global profile), and experiment-keyed entries
+> (v1 bypasses experiment-claimed requests rather than partitioning them).
 
 ---
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -91,6 +91,25 @@ type AIQGConfig struct {
 	// head-to-head. Costs ~2× per shadow sample, so default 0 (off; opt-in).
 	// Env: AIQG_SHADOW_EVAL_PCT.
 	ShadowEvalPct int `yaml:"shadow_eval_pct"`
+
+	// ResponseCache is the C1 exact-match response cache (docs/AIQG-CACHING.md).
+	// Default off. Reuses the linkage Redis client; falls back to a per-pod
+	// in-memory cache when Redis isn't configured.
+	ResponseCache AIQGResponseCacheConfig `yaml:"response_cache"`
+}
+
+// AIQGResponseCacheConfig configures the C1 response cache. Env:
+// AIQG_RESPONSE_CACHE_ENABLED, AIQG_RESPONSE_CACHE_TTL (Go duration),
+// AIQG_RESPONSE_CACHE_MAX_BODY_BYTES, AIQG_RESPONSE_CACHE_ALLOW_NONDETERMINISTIC.
+type AIQGResponseCacheConfig struct {
+	Enabled bool `yaml:"enabled"`
+	// TTL is the entry lifetime. Empty/zero defaults to 5m at wire-up.
+	TTL time.Duration `yaml:"ttl"`
+	// MaxBodyBytes skips storing responses larger than this (0 = no limit).
+	MaxBodyBytes int `yaml:"max_body_bytes"`
+	// AllowNondeterministic caches temperature>0 requests too. Default false
+	// (require_deterministic=true) — the safe posture.
+	AllowNondeterministic bool `yaml:"allow_nondeterministic"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Defined here (not in
@@ -568,6 +587,22 @@ func (c *Config) loadFromEnv() {
 			c.AIQG.ShadowEvalPct = n
 		}
 	}
+	if v := os.Getenv("AIQG_RESPONSE_CACHE_ENABLED"); v != "" {
+		c.AIQG.ResponseCache.Enabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("AIQG_RESPONSE_CACHE_TTL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			c.AIQG.ResponseCache.TTL = d
+		}
+	}
+	if v := os.Getenv("AIQG_RESPONSE_CACHE_MAX_BODY_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			c.AIQG.ResponseCache.MaxBodyBytes = n
+		}
+	}
+	if v := os.Getenv("AIQG_RESPONSE_CACHE_ALLOW_NONDETERMINISTIC"); v != "" {
+		c.AIQG.ResponseCache.AllowNondeterministic = v == "true" || v == "1"
+	}
 	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
 		c.AIQG.DashboardURL = u
 	}
@@ -759,6 +794,12 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 		Kafka: server.AIQGKafkaConfig{
 			Brokers: c.AIQG.Kafka.Brokers,
 			Topic:   c.AIQG.Kafka.Topic,
+		},
+		ResponseCache: server.AIQGResponseCacheConfig{
+			Enabled:               c.AIQG.ResponseCache.Enabled,
+			TTL:                   c.AIQG.ResponseCache.TTL,
+			MaxBodyBytes:          c.AIQG.ResponseCache.MaxBodyBytes,
+			AllowNondeterministic: c.AIQG.ResponseCache.AllowNondeterministic,
 		},
 	}
 	if len(c.AIQG.Tokens) > 0 {

--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -795,6 +795,8 @@ func routingView(r *Routing) events.RoutingView {
 		OutboundFindings:    s.OutboundFindings,
 		ScanRan:             s.ScanRan,
 		RedactionCount:      s.RedactionCount,
+		CacheState:          s.CacheState,
+		CacheKeyHash:        s.CacheKeyHash,
 		FinishReason:        s.FinishReason,
 		AttemptCount:        s.AttemptCount,
 		FallbackUsed:        s.FallbackUsed,

--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -103,6 +103,14 @@ type Routing struct {
 	// the request has nothing cacheable (no system text, no tools).
 	cachePrefixHash string
 
+	// response cache (C1, docs/AIQG-CACHING.md §6): how this request interacted
+	// with the exact-match response cache — "hit" (served from cache, vendor not
+	// called), "miss" (looked up, stored on the way out), "bypass" (TAS-Cache
+	// header or experiment-claimed), or "" (not eligible / cache off). cacheKeyHash
+	// is the exact-match key so a hit and its populating miss can be correlated.
+	cacheState    string
+	cacheKeyHash  string
+
 	// experiments (Phase D): the experiment + variant that claimed this
 	// request. Stamped at request time (so the routing override + the event
 	// stamp use one decision). Empty when no experiment claimed it.
@@ -193,6 +201,10 @@ type RoutingSnapshot struct {
 	// breakpoint would cover. Empty when nothing is cacheable.
 	CachePrefixHash string
 
+	// response cache (C1): hit / miss / bypass / "" and the exact-match key.
+	CacheState   string
+	CacheKeyHash string
+
 	// experiments (Phase D): claiming experiment + variant. Empty when none.
 	ExperimentID      string
 	ExperimentVariant string
@@ -231,6 +243,8 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		Fingerprint:         r.fingerprint,
 		RedactionCount:      r.redactionCount,
 		CachePrefixHash:     r.cachePrefixHash,
+		CacheState:          r.cacheState,
+		CacheKeyHash:        r.cacheKeyHash,
 		ExperimentID:        r.experimentID,
 		ExperimentVariant:   r.experimentVariant,
 	}
@@ -301,6 +315,42 @@ func StampCachePrefixHash(ctx context.Context, hash string) {
 	defer r.mu.Unlock()
 	if r.cachePrefixHash == "" {
 		r.cachePrefixHash = hash
+	}
+}
+
+// StampCacheState records how the request interacted with the C1 response cache
+// ("hit" / "miss" / "bypass"). First-write-wins so a hit isn't later overwritten
+// by a store path; empty is a no-op.
+func StampCacheState(ctx context.Context, state string) {
+	if state == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cacheState == "" {
+		r.cacheState = state
+	}
+}
+
+// StampCacheKeyHash records the exact-match response-cache key for this request
+// so a hit and the miss that populated it can be correlated in the event stream.
+// First-write-wins; empty is a no-op.
+func StampCacheKeyHash(ctx context.Context, hash string) {
+	if hash == "" {
+		return
+	}
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cacheKeyHash == "" {
+		r.cacheKeyHash = hash
 	}
 }
 

--- a/internal/server/response_cache_test.go
+++ b/internal/server/response_cache_test.go
@@ -1,0 +1,161 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/tributary-ai/llm-router-waf/internal/middleware"
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/responsecache"
+)
+
+func cacheTestServer() *Server {
+	return &Server{
+		logger:    logrus.New(),
+		respCache: responsecache.NewMemoryCache(0),
+		respCacheCfg: responsecache.Config{
+			Enabled:              true,
+			TTL:                  time.Minute,
+			RequireDeterministic: true,
+		},
+	}
+}
+
+func newCacheReq(t *testing.T) (*httptest.ResponseRecorder, *http.Request, *types.ChatRequest) {
+	t.Helper()
+	req := &types.ChatRequest{
+		Model:       "claude-opus-4-8",
+		Messages:    []types.Message{{Role: "user", Content: "what is 2+2?"}},
+		Temperature: f32p(0),
+	}
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	r.Header.Set("X-Tenant-ID", "tenant-a")
+	// Attach a Routing sidecar so cache_state / cache_key_hash stamps land.
+	r = r.WithContext(middleware.WithRouting(r.Context(), middleware.NewRouting()))
+	return httptest.NewRecorder(), r, req
+}
+
+func f32p(v float32) *float32 { return &v }
+
+// Full lifecycle: first request misses and marks a pending store; storing the
+// produced response makes an identical second request a hit that skips routing.
+func TestResponseCache_MissStoreHit(t *testing.T) {
+	s := cacheTestServer()
+	vendor := "anthropic"
+
+	// --- request 1: miss ---
+	w1, r1, req := newCacheReq(t)
+	got := s.maybeServeFromCache(w1, r1, req, vendor)
+	if got == nil {
+		t.Fatal("first request should miss, not serve a hit")
+	}
+	if snap := middleware.RoutingFromContext(got.Context()).Snapshot(); snap.CacheState != "miss" {
+		t.Fatalf("expected cache_state=miss, got %q", snap.CacheState)
+	}
+	if _, ok := responsecache.PendingFromContext(got.Context()); !ok {
+		t.Fatal("cacheable miss must stash a pending store intent")
+	}
+
+	// --- store the produced response (as the completion handler would) ---
+	resp := &types.ChatResponse{
+		ID:      "resp-1",
+		Model:   "claude-opus-4-8",
+		Choices: []types.Choice{{Message: types.Message{Role: "assistant", Content: "4"}, FinishReason: "stop"}},
+		Usage:   &types.Usage{PromptTokens: 10, CompletionTokens: 1},
+	}
+	s.maybeStoreInCache(got, resp)
+
+	// --- request 2: identical → hit, served without routing ---
+	w2, r2, req2 := newCacheReq(t)
+	got2 := s.maybeServeFromCache(w2, r2, req2, vendor)
+	if got2 != nil {
+		t.Fatal("second identical request should be a hit (nil return)")
+	}
+	if snap := middleware.RoutingFromContext(r2.Context()).Snapshot(); snap.CacheState != "hit" {
+		t.Fatalf("expected cache_state=hit, got %q", snap.CacheState)
+	}
+	if w2.Header().Get("X-TAS-Cache") != "hit" {
+		t.Errorf("hit should set X-TAS-Cache: hit, got %q", w2.Header().Get("X-TAS-Cache"))
+	}
+	var served types.ChatResponse
+	if err := json.Unmarshal(w2.Body.Bytes(), &served); err != nil {
+		t.Fatalf("hit body not JSON: %v", err)
+	}
+	if len(served.Choices) != 1 || served.Choices[0].Message.Content != "4" {
+		t.Fatalf("hit served wrong body: %+v", served)
+	}
+}
+
+// A different tenant with the same prompt must not read another tenant's entry.
+func TestResponseCache_TenantIsolation(t *testing.T) {
+	s := cacheTestServer()
+	_, r1, req := newCacheReq(t)
+	s.maybeStoreInCache(r1.WithContext(responsecache.WithPending(r1.Context(), "tenant-a",
+		responsecache.KeyHash("tenant-a", "anthropic", req, ""))),
+		&types.ChatResponse{ID: "x", Model: "m", Choices: []types.Choice{{Message: types.Message{Content: "secret"}}}})
+
+	// tenant-b, same prompt → miss.
+	w, r2, req2 := newCacheReq(t)
+	r2.Header.Set("X-Tenant-ID", "tenant-b")
+	if got := s.maybeServeFromCache(w, r2, req2, "anthropic"); got == nil {
+		t.Fatal("tenant-b must not hit tenant-a's entry")
+	}
+}
+
+// TAS-Cache: bypass forces a fresh call and stamps bypass, even with a warm entry.
+func TestResponseCache_HeaderBypass(t *testing.T) {
+	s := cacheTestServer()
+	// warm the cache
+	_, r0, req := newCacheReq(t)
+	got := s.maybeServeFromCache(nil, r0, req, "anthropic") // nil w is fine on a miss
+	s.maybeStoreInCache(got, &types.ChatResponse{ID: "x", Model: "claude-opus-4-8",
+		Choices: []types.Choice{{Message: types.Message{Content: "4"}}}})
+
+	w, r, req2 := newCacheReq(t)
+	r.Header.Set("TAS-Cache", "bypass")
+	if s.maybeServeFromCache(w, r, req2, "anthropic") == nil {
+		t.Fatal("bypass must not serve a hit even with a warm entry")
+	}
+	if snap := middleware.RoutingFromContext(r.Context()).Snapshot(); snap.CacheState != "bypass" {
+		t.Fatalf("expected cache_state=bypass, got %q", snap.CacheState)
+	}
+}
+
+// A tool-calling request is never cached (side-effecting).
+func TestResponseCache_ToolRequestNotCached(t *testing.T) {
+	s := cacheTestServer()
+	w, r, req := newCacheReq(t)
+	req.Tools = []types.Tool{{Type: "function", Function: types.Function{Name: "lookup"}}}
+	got := s.maybeServeFromCache(w, r, req, "anthropic")
+	if got == nil {
+		t.Fatal("tool request should not be served from cache")
+	}
+	if _, ok := responsecache.PendingFromContext(got.Context()); ok {
+		t.Error("tool request must not stash a store intent")
+	}
+}
+
+// A response that comes back with tool calls is not stored even on a cacheable
+// miss (defense in depth).
+func TestResponseCache_ToolResponseNotStored(t *testing.T) {
+	s := cacheTestServer()
+	_, r, req := newCacheReq(t)
+	got := s.maybeServeFromCache(nil, r, req, "anthropic")
+	if got == nil {
+		t.Fatal("expected miss")
+	}
+	toolResp := &types.ChatResponse{ID: "x", Model: "claude-opus-4-8",
+		Choices: []types.Choice{{Message: types.Message{ToolCalls: []types.ToolCall{{ID: "c1"}}}}}}
+	s.maybeStoreInCache(got, toolResp)
+
+	// nothing should have been stored → next identical request misses.
+	w2, r2, req2 := newCacheReq(t)
+	if s.maybeServeFromCache(w2, r2, req2, "anthropic") == nil {
+		t.Fatal("tool-call response must not have been cached")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/policy"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/promptcache"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/responsecache"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/tokens"
 	"github.com/tributary-ai/llm-router-waf/pkg/clear"
 
@@ -61,6 +62,11 @@ type Server struct {
 	// judge runs the LLM-as-judge quality layer off the hot path. Nil when
 	// judging is disabled.
 	judge *judgeRunner
+
+	// respCache is the C1 exact-match response cache (docs/AIQG-CACHING.md).
+	// Nil when disabled — every cache branch is a no-op in that case.
+	respCache    responsecache.Cache
+	respCacheCfg responsecache.Config
 }
 
 // ServerConfig holds server configuration
@@ -189,6 +195,18 @@ type AIQGServerConfig struct {
 	// Kafka block — read when EmitterType is "kafka" or "both".
 	// Brokers takes a list ("host:9092,host:9092") via env override.
 	Kafka AIQGKafkaConfig `yaml:"kafka"`
+
+	// ResponseCache is the C1 exact-match response cache (docs/AIQG-CACHING.md).
+	ResponseCache AIQGResponseCacheConfig `yaml:"response_cache"`
+}
+
+// AIQGResponseCacheConfig configures the C1 response cache. Mirrors
+// config.AIQGResponseCacheConfig (straight field copy in ToServerConfig).
+type AIQGResponseCacheConfig struct {
+	Enabled               bool          `yaml:"enabled"`
+	TTL                   time.Duration `yaml:"ttl"`
+	MaxBodyBytes          int           `yaml:"max_body_bytes"`
+	AllowNondeterministic bool          `yaml:"allow_nondeterministic"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Brokers + topic are
@@ -302,17 +320,50 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 		// a per-pod MemoryProbe would under-count across replicas rather than
 		// fail honestly.
 		var cacheProbe promptcache.Probe
+		// sharedRedis is reused by every AIQG Redis consumer (linkage, the P0
+		// probe, and the C1 response cache) — one client, one lifecycle.
+		var sharedRedis redis.UniversalClient
 		if config.AIQG.LinkageRedisURL != "" {
 			if opt, err := redis.ParseURL(config.AIQG.LinkageRedisURL); err != nil {
 				logger.WithError(err).Warn("AIQG linkage: invalid AIQG_LINKAGE_REDIS_URL; linkage disabled")
 			} else {
 				rc := redis.NewClient(opt)
+				sharedRedis = rc
 				linkageStore = linkage.NewRedisStore(rc, 0)
 				cacheProbe = promptcache.NewRedisProbe(rc, 0)
 				logger.WithField("redis_addr", opt.Addr).Info("AIQG linkage: tool_call_id echo index enabled (linked tier)")
 				logger.WithFields(logrus.Fields{"redis_addr": opt.Addr, "ttl": promptcache.DefaultTTL}).
 					Info("AIQG prompt-cache probe enabled (P0 measure-only: reports prefix reuse, changes no requests)")
 			}
+		}
+
+		// C1 exact-match response cache (docs/AIQG-CACHING.md). Prefers the
+		// shared Redis (correct across replicas); falls back to a per-pod
+		// in-memory cache when Redis isn't configured, so a single-replica dev
+		// deploy still exercises the feature. Off unless explicitly enabled.
+		if config.AIQG.ResponseCache.Enabled {
+			ttl := config.AIQG.ResponseCache.TTL
+			if ttl <= 0 {
+				ttl = 5 * time.Minute
+			}
+			server.respCacheCfg = responsecache.Config{
+				Enabled:              true,
+				TTL:                  ttl,
+				RequireDeterministic: !config.AIQG.ResponseCache.AllowNondeterministic,
+				MaxBodyBytes:         config.AIQG.ResponseCache.MaxBodyBytes,
+			}
+			backend := "memory"
+			if sharedRedis != nil {
+				server.respCache = responsecache.NewRedisCache(sharedRedis)
+				backend = "redis"
+			} else {
+				server.respCache = responsecache.NewMemoryCache(0)
+			}
+			logger.WithFields(logrus.Fields{
+				"backend":               backend,
+				"ttl":                   ttl,
+				"require_deterministic": server.respCacheCfg.RequireDeterministic,
+			}).Info("AIQG response cache enabled (C1 exact-match)")
 		}
 
 		// Experiments runner resolver (Phase D). Reuses the dashboard URL +
@@ -774,7 +825,17 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	// AIQG: stamp the chosen provider's name onto the routing sidecar.
 	// Done here (not in router.Route) so AIQG plumbing stays in the
 	// server/middleware layer and doesn't leak into the routing package.
-	middleware.StampVendor(r.Context(), provider.GetProviderName())
+	vendor := provider.GetProviderName()
+	middleware.StampVendor(r.Context(), vendor)
+
+	// AIQG C1 exact-match response cache (docs/AIQG-CACHING.md §2). Checked after
+	// routing so the key carries the resolved vendor, but before the vendor call —
+	// a hit skips that 1–5s call entirely (the whole latency win). Routing itself
+	// is in-memory selection, not a network call. On a miss we stash the store
+	// intent so the completion handler persists the post-outbound-scan response.
+	if r = s.maybeServeFromCache(w, r, &req, vendor); r == nil {
+		return // hit: cached response already written
+	}
 
 	// Handle streaming vs non-streaming with retry/fallback support
 	if req.Stream {
@@ -782,6 +843,64 @@ func (s *Server) handleChatCompletion(w http.ResponseWriter, r *http.Request) {
 	} else {
 		s.handleNonStreamingCompletionWithRetry(w, r, &req, provider, metadata)
 	}
+}
+
+// maybeServeFromCache runs the C1 cache lookup. It returns nil when it served a
+// hit (the caller must stop); otherwise it returns the request to continue with,
+// possibly carrying a store-intent context on a cacheable miss. All branches are
+// no-ops when the cache is disabled, so non-AIQG traffic is unaffected.
+func (s *Server) maybeServeFromCache(w http.ResponseWriter, r *http.Request, req *types.ChatRequest, vendor string) *http.Request {
+	if s.respCache == nil || !s.respCacheCfg.Enabled {
+		return r
+	}
+	d := responsecache.Decide(req, s.respCacheCfg, r.Header.Get("TAS-Cache"))
+	if d.Bypass {
+		middleware.StampCacheState(r.Context(), "bypass")
+		return r
+	}
+	if !d.Cacheable {
+		return r
+	}
+	// Experiment-claimed requests bypass the cache so each variant's measurement
+	// reflects real variant calls (docs/AIQG-CACHING.md §7).
+	if rt := middleware.RoutingFromContext(r.Context()); rt != nil && rt.Snapshot().ExperimentID != "" {
+		middleware.StampCacheState(r.Context(), "bypass")
+		return r
+	}
+
+	tenantID := s.extractTenantID(r)
+	hash := responsecache.KeyHash(tenantID, vendor, req, events.ScoringVersion)
+	middleware.StampCacheKeyHash(r.Context(), hash)
+
+	if entry, ok, err := s.respCache.Get(r.Context(), tenantID, hash); err != nil {
+		s.logger.WithError(err).WithField("request_id", req.ID).Warn("response cache lookup failed; treating as miss")
+	} else if ok {
+		if s.writeCachedResponse(w, entry) {
+			middleware.StampCacheState(r.Context(), "hit")
+			w.Header().Set("X-TAS-Cache", "hit")
+			return nil
+		}
+		// A corrupt/undecodable entry falls through to a live call.
+	}
+
+	middleware.StampCacheState(r.Context(), "miss")
+	return r.WithContext(responsecache.WithPending(r.Context(), tenantID, hash))
+}
+
+// writeCachedResponse writes a stored response to the client. Returns false
+// (without writing) if the entry can't be decoded, so the caller falls through
+// to a live vendor call. A hit deliberately does NOT stamp vendor token usage:
+// the vendor wasn't called, so cost/latency accounting stays ~0 (§6), and the
+// cache_state=hit split lets dashboards surface the saving explicitly.
+func (s *Server) writeCachedResponse(w http.ResponseWriter, entry *responsecache.Entry) bool {
+	var resp types.ChatResponse
+	if err := json.Unmarshal(entry.Response, &resp); err != nil {
+		return false
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(&resp)
+	return true
 }
 
 // extractTenantID extracts tenant ID from request context or headers.
@@ -1011,12 +1130,56 @@ func (s *Server) handleNonStreamingCompletionWithRetry(w http.ResponseWriter, r 
 	// hot path. No-op when judging is disabled / unsampled / not AIQG.
 	s.judge.maybeJudge(r.Context(), w, req, resp)
 
+	// AIQG C1: store the post-outbound-scan response for the next equivalent
+	// request. Runs before RouterMetadata is attached so the cached body carries
+	// no request-specific routing info. No-op unless the lookup marked this a
+	// cacheable miss (PendingFromContext) and the produced response is itself
+	// cacheable (no tool calls).
+	s.maybeStoreInCache(r, resp)
+
 	// Add routing metadata to response
 	resp.RouterMetadata = metadata
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(resp)
+}
+
+// maybeStoreInCache persists a produced response under the key stamped at lookup
+// time. Best-effort and off the client's latency path: a store failure is logged
+// and swallowed. Skips responses over MaxBodyBytes and any response carrying tool
+// calls (ResponseCacheable).
+func (s *Server) maybeStoreInCache(r *http.Request, resp *types.ChatResponse) {
+	if s.respCache == nil || !s.respCacheCfg.Enabled {
+		return
+	}
+	p, ok := responsecache.PendingFromContext(r.Context())
+	if !ok || !responsecache.ResponseCacheable(resp) {
+		return
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return
+	}
+	if s.respCacheCfg.MaxBodyBytes > 0 && len(body) > s.respCacheCfg.MaxBodyBytes {
+		return
+	}
+	entry := &responsecache.Entry{
+		Response:       body,
+		Model:          resp.Model,
+		ScoringVersion: events.ScoringVersion,
+		StoredAtUnix:   time.Now().Unix(),
+	}
+	if rt := middleware.RoutingFromContext(r.Context()); rt != nil {
+		entry.Vendor = rt.Snapshot().Vendor // debug aid; vendor is already folded into the key
+	}
+	if resp.Usage != nil {
+		entry.PromptTokens = resp.Usage.PromptTokens
+		entry.CompletionTokens = resp.Usage.CompletionTokens
+	}
+	if err := s.respCache.Set(r.Context(), p.TenantID, p.Hash, entry, s.respCacheCfg.TTL); err != nil {
+		s.logger.WithError(err).WithField("request_id", resp.ID).Warn("response cache store failed")
+	}
 }
 
 // echoedToolCallIDs returns the tool_call_ids this request echoes back in

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -81,6 +81,12 @@ type RoutingView struct {
 	// inbound messages before the vendor call (G1). 0 = none/off.
 	RedactionCount int
 
+	// CacheState / CacheKeyHash carry the C1 response-cache interaction
+	// (docs/AIQG-CACHING.md §6): "hit" / "miss" / "bypass" / "" and the
+	// exact-match key. A hit means the vendor was not called.
+	CacheState   string
+	CacheKeyHash string
+
 	// Vendor finish_reason captured from the response. Used both
 	// to populate ResponseEvent.FinishReason (taking precedence
 	// over the BuildOptions value) and to drive clear.Efficacy.
@@ -594,6 +600,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		Assurance:            assuranceSummary,
 		RedactionApplied:     routing.RedactionCount > 0,
 		RedactedCount:        routing.RedactionCount,
+		CacheState:           routing.CacheState,
+		CacheKeyHash:         routing.CacheKeyHash,
 		CLEAR:                clear.Compute(clearInput),
 		ScoringVersion:       ScoringVersion,
 		GatewayVersion:       GatewayVersion,

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -214,6 +214,14 @@ type ResponseEvent struct {
 	RedactionApplied bool `json:"redaction_applied,omitempty"`
 	RedactedCount    int  `json:"redacted_count,omitempty"`
 
+	// Response cache (C1, docs/AIQG-CACHING.md §6): how the request interacted
+	// with the exact-match cache — "hit" (vendor not called), "miss", "bypass",
+	// or omitted when the cache didn't participate. cache_key_hash correlates a
+	// hit with the miss that populated it. On a hit, vendor cost/latency ≈ 0;
+	// dashboards split hit/miss so "as-served" and "true vendor" cost both show.
+	CacheState   string `json:"cache_state,omitempty"`
+	CacheKeyHash string `json:"cache_key_hash,omitempty"`
+
 	// CLEAR scores — populated by pkg/clear.Compute(). A nil *Scores
 	// (rather than a *Scores with all-nil dimension fields) means the
 	// scorer wasn't run at all, which today only happens on the noop

--- a/pkg/aiqg/responsecache/cache.go
+++ b/pkg/aiqg/responsecache/cache.go
@@ -1,0 +1,303 @@
+// Package responsecache implements the AIQG exact-match response cache (C1,
+// docs/AIQG-CACHING.md). A hit serves a previously-computed response for an
+// equivalent request without calling the vendor — the ultimate token reduction
+// (100%) and, more importantly, a 1–5s call collapsed to ~gateway latency.
+//
+// Three invariants make this an AIQG cache rather than a generic one:
+//
+//   - Tenant isolation is the cardinal rule. tenant_id is always in the key AND
+//     the entry is Redis-namespaced aiqg:cache:{tenant}:{hash}, so a purge or a
+//     scan is tenant-scoped and a cross-tenant read is structurally impossible.
+//   - The key is built on the POST-inbound-scan (redacted) messages, so the
+//     cache never keys on or stores raw PII (docs/AIQG-CACHING.md §2/§5; the G1
+//     redaction it depends on is a precondition, wired in server.go).
+//   - Default-safe: only deterministic requests (temperature==0 or seed set) are
+//     cached, and streaming / tool-calling / experiment-claimed requests never
+//     are (§1 scope, §4). Everything is opt-in behind Config.Enabled.
+//
+// This package is the storage + key + eligibility core. The request-path wiring
+// (lookup before routing, store after the outbound scan, cache_state stamping)
+// lives in internal/server.
+package responsecache
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+// keyPrefix namespaces every entry. The tenant segment follows so a KEYS/SCAN
+// over aiqg:cache:{tenant}:* is a tenant-scoped purge (right-to-be-forgotten).
+const keyPrefix = "aiqg:cache"
+
+// Config is the C1 cache profile. v1 is a single global profile; per-route
+// profiles (docs/AIQG-CACHING.md §4) layer on top of this later.
+type Config struct {
+	// Enabled gates the whole feature. Default off.
+	Enabled bool
+	// TTL bounds how long an entry lives. Also the ceiling on any per-route TTL.
+	TTL time.Duration
+	// RequireDeterministic caches only requests that pin their sampling
+	// (temperature==0 or seed set). Default true — serving one sampled answer
+	// to repeated temperature>0 prompts is wrong for most workflows.
+	RequireDeterministic bool
+	// MaxBodyBytes skips storing responses larger than this (0 = no limit).
+	MaxBodyBytes int
+}
+
+// Entry is a stored response. Response is the marshaled, post-outbound-scan
+// *types.ChatResponse — already safe to return on a hit.
+type Entry struct {
+	Response         json.RawMessage `json:"response"`
+	Vendor           string          `json:"vendor,omitempty"`
+	Model            string          `json:"model,omitempty"`
+	PromptTokens     int             `json:"prompt_tokens,omitempty"`
+	CompletionTokens int             `json:"completion_tokens,omitempty"`
+	ScoringVersion   string          `json:"scoring_version,omitempty"`
+	StoredAtUnix     int64           `json:"stored_at"`
+}
+
+// Cache is the storage port. Get/Set take tenant and hash separately so the
+// implementation owns the namespacing and a cross-tenant read cannot be
+// expressed by a caller.
+type Cache interface {
+	Get(ctx context.Context, tenantID, hash string) (*Entry, bool, error)
+	Set(ctx context.Context, tenantID, hash string, e *Entry, ttl time.Duration) error
+	// PurgeTenant flushes a tenant's whole namespace (tenant delete /
+	// right-to-be-forgotten). Returns the number of entries removed.
+	PurgeTenant(ctx context.Context, tenantID string) (int, error)
+}
+
+func redisKey(tenantID, hash string) string {
+	return fmt.Sprintf("%s:%s:%s", keyPrefix, tenantID, hash)
+}
+
+// RedisCache is the shared-across-replicas implementation. It reuses the AIQG
+// Redis client (same lifecycle as linkage / the prompt-cache probe).
+type RedisCache struct {
+	r redis.UniversalClient
+}
+
+// NewRedisCache wraps a Redis client. Nil client is a programming error.
+func NewRedisCache(r redis.UniversalClient) *RedisCache { return &RedisCache{r: r} }
+
+func (c *RedisCache) Get(ctx context.Context, tenantID, hash string) (*Entry, bool, error) {
+	b, err := c.r.Get(ctx, redisKey(tenantID, hash)).Bytes()
+	if err == redis.Nil {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	var e Entry
+	if err := json.Unmarshal(b, &e); err != nil {
+		// A corrupt entry is a miss, not an error — never fail a request on it.
+		return nil, false, nil
+	}
+	return &e, true, nil
+}
+
+func (c *RedisCache) Set(ctx context.Context, tenantID, hash string, e *Entry, ttl time.Duration) error {
+	b, err := json.Marshal(e)
+	if err != nil {
+		return err
+	}
+	return c.r.Set(ctx, redisKey(tenantID, hash), b, ttl).Err()
+}
+
+func (c *RedisCache) PurgeTenant(ctx context.Context, tenantID string) (int, error) {
+	pattern := fmt.Sprintf("%s:%s:*", keyPrefix, tenantID)
+	var (
+		cursor uint64
+		total  int
+	)
+	for {
+		keys, next, err := c.r.Scan(ctx, cursor, pattern, 256).Result()
+		if err != nil {
+			return total, err
+		}
+		if len(keys) > 0 {
+			if err := c.r.Del(ctx, keys...).Err(); err != nil {
+				return total, err
+			}
+			total += len(keys)
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return total, nil
+}
+
+// MemoryCache is a bounded, TTL-honoring in-process cache for tests and
+// single-replica deployments. Across replicas it under-shares (each pod has its
+// own map) but never serves a stale-past-TTL or cross-tenant entry.
+type MemoryCache struct {
+	mu      sync.Mutex
+	m       map[string]memEntry
+	maxKeys int
+}
+
+type memEntry struct {
+	e       Entry
+	expires time.Time
+}
+
+// NewMemoryCache bounds the map at maxKeys (<=0 uses 4096). Eviction on insert
+// drops an arbitrary entry — deterministic recompute on the next miss, never a
+// correctness cost.
+func NewMemoryCache(maxKeys int) *MemoryCache {
+	if maxKeys <= 0 {
+		maxKeys = 4096
+	}
+	return &MemoryCache{m: make(map[string]memEntry), maxKeys: maxKeys}
+}
+
+func (c *MemoryCache) Get(_ context.Context, tenantID, hash string) (*Entry, bool, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	k := redisKey(tenantID, hash)
+	me, ok := c.m[k]
+	if !ok {
+		return nil, false, nil
+	}
+	if !me.expires.IsZero() && timeNow().After(me.expires) {
+		delete(c.m, k)
+		return nil, false, nil
+	}
+	cp := me.e
+	return &cp, true, nil
+}
+
+func (c *MemoryCache) Set(_ context.Context, tenantID, hash string, e *Entry, ttl time.Duration) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	k := redisKey(tenantID, hash)
+	if _, exists := c.m[k]; !exists && len(c.m) >= c.maxKeys {
+		for ek := range c.m { // evict one arbitrary entry
+			delete(c.m, ek)
+			break
+		}
+	}
+	var exp time.Time
+	if ttl > 0 {
+		exp = timeNow().Add(ttl)
+	}
+	c.m[k] = memEntry{e: *e, expires: exp}
+	return nil
+}
+
+func (c *MemoryCache) PurgeTenant(_ context.Context, tenantID string) (int, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	prefix := fmt.Sprintf("%s:%s:", keyPrefix, tenantID)
+	n := 0
+	for k := range c.m {
+		if strings.HasPrefix(k, prefix) {
+			delete(c.m, k)
+			n++
+		}
+	}
+	return n, nil
+}
+
+// timeNow is overridable in tests. Kept package-local (not time.Now inline) so
+// TTL expiry is testable without sleeping.
+var timeNow = time.Now
+
+// KeyHash canonicalizes the output-affecting shape of a request into a stable
+// sha256 hex digest — the {hash} segment of the Redis key.
+//
+// tenantID is folded into the hash (belt-and-suspenders with the key
+// namespace), and messages MUST be the post-redaction array so a hit never
+// depends on raw PII. Only fields that change the vendor's answer are included;
+// request id, user id, timestamp, streaming flag and routing hints are excluded
+// so genuinely-equivalent requests collapse to one entry.
+//
+// Determinism note: encoding/json is deterministic — struct fields in
+// declaration order, map keys sorted — so identical inputs always yield an
+// identical digest (docs/AIQG-PROMPT-CACHE-CONTROL.md §12.1). No manual sorting
+// is needed.
+func KeyHash(tenantID, vendor string, req *types.ChatRequest, scoringVersion string) string {
+	type sig struct {
+		Tenant           string           `json:"t"`
+		Vendor           string           `json:"v"`
+		Model            string           `json:"m"`
+		Messages         []types.Message  `json:"msgs"`
+		Temperature      *float32         `json:"temp,omitempty"`
+		TopP             *float32         `json:"top_p,omitempty"`
+		MaxTokens        *int             `json:"max_tokens,omitempty"`
+		FrequencyPenalty *float32         `json:"fp,omitempty"`
+		PresencePenalty  *float32         `json:"pp,omitempty"`
+		Stop             []string         `json:"stop,omitempty"`
+		Seed             *int             `json:"seed,omitempty"`
+		ResponseFormat   any              `json:"rf,omitempty"`
+		Tools            []types.Tool     `json:"tools,omitempty"`
+		Functions        []types.Function `json:"funcs,omitempty"`
+		Scoring          string           `json:"sc"`
+	}
+	s := sig{
+		Tenant: tenantID, Vendor: vendor, Model: req.Model, Messages: req.Messages,
+		Temperature: req.Temperature, TopP: req.TopP, MaxTokens: req.MaxTokens,
+		FrequencyPenalty: req.FrequencyPenalty, PresencePenalty: req.PresencePenalty,
+		Stop: req.Stop, Seed: req.Seed, ResponseFormat: req.ResponseFormat,
+		Tools: req.Tools, Functions: req.Functions, Scoring: scoringVersion,
+	}
+	b, _ := json.Marshal(s)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// Decision is the eligibility verdict for one request.
+type Decision struct {
+	// Cacheable: the request may be looked up and, on a miss, stored.
+	Cacheable bool
+	// Bypass: the caller explicitly opted out (TAS-Cache: off|bypass). Distinct
+	// from "not eligible" so the event can stamp cache_state=bypass.
+	Bypass bool
+	// Reason is a short human tag for the not-cacheable case (logging/debug).
+	Reason string
+}
+
+// Decide applies the C1 eligibility rules (docs/AIQG-CACHING.md §1 scope, §4).
+// It does NOT consider experiment claims — that's a request-path concern the
+// caller layers on (experiment-claimed ⇒ bypass, §7).
+func Decide(req *types.ChatRequest, cfg Config, header string) Decision {
+	switch strings.ToLower(strings.TrimSpace(header)) {
+	case "off", "bypass", "no-cache", "no-store":
+		return Decision{Bypass: true, Reason: "header"}
+	}
+	if !cfg.Enabled {
+		return Decision{Reason: "disabled"}
+	}
+	if req.Stream {
+		return Decision{Reason: "streaming"} // never cache streaming (v1)
+	}
+	if len(req.Tools) > 0 || len(req.Functions) > 0 {
+		return Decision{Reason: "tools"} // tool/function calls are side-effecting
+	}
+	if cfg.RequireDeterministic && !isDeterministic(req) {
+		return Decision{Reason: "nondeterministic"}
+	}
+	return Decision{Cacheable: true}
+}
+
+// isDeterministic is true when the request pins its sampling: temperature
+// explicitly 0, or a seed set. A nil temperature means the vendor default
+// (typically 1.0), so it is treated as non-deterministic.
+func isDeterministic(req *types.ChatRequest) bool {
+	if req.Seed != nil {
+		return true
+	}
+	return req.Temperature != nil && *req.Temperature == 0
+}

--- a/pkg/aiqg/responsecache/cache_test.go
+++ b/pkg/aiqg/responsecache/cache_test.go
@@ -1,0 +1,247 @@
+package responsecache
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+func f32(v float32) *float32 { return &v }
+func iptr(v int) *int        { return &v }
+
+func baseReq() *types.ChatRequest {
+	return &types.ChatRequest{
+		Model:       "claude-opus-4-8",
+		Messages:    []types.Message{{Role: "user", Content: "hello"}},
+		Temperature: f32(0),
+	}
+}
+
+func TestKeyHash_DeterministicAndSensitive(t *testing.T) {
+	r1 := baseReq()
+	r2 := baseReq()
+	h1 := KeyHash("tenant-a", "anthropic", r1, "clear-v1")
+	h2 := KeyHash("tenant-a", "anthropic", r2, "clear-v1")
+	if h1 != h2 {
+		t.Fatalf("identical requests must hash equal: %s != %s", h1, h2)
+	}
+
+	// Each output-affecting axis must move the hash.
+	cases := map[string]func(*types.ChatRequest){
+		"tenant":  nil, // handled separately below
+		"model":   func(r *types.ChatRequest) { r.Model = "claude-sonnet-5" },
+		"message": func(r *types.ChatRequest) { r.Messages[0].Content = "hello!" },
+		"temp":    func(r *types.ChatRequest) { r.Temperature = f32(0.7) },
+		"maxtok":  func(r *types.ChatRequest) { r.MaxTokens = iptr(64) },
+		"seed":    func(r *types.ChatRequest) { r.Seed = iptr(7) },
+		"stop":    func(r *types.ChatRequest) { r.Stop = []string{"\n"} },
+	}
+	for name, mut := range cases {
+		if mut == nil {
+			continue
+		}
+		r := baseReq()
+		mut(r)
+		if got := KeyHash("tenant-a", "anthropic", r, "clear-v1"); got == h1 {
+			t.Errorf("%s change did not alter the hash", name)
+		}
+	}
+
+	// Tenant, vendor, and scoring_version are all in the key.
+	if KeyHash("tenant-b", "anthropic", baseReq(), "clear-v1") == h1 {
+		t.Error("tenant must alter the hash (isolation)")
+	}
+	if KeyHash("tenant-a", "openai", baseReq(), "clear-v1") == h1 {
+		t.Error("vendor must alter the hash")
+	}
+	if KeyHash("tenant-a", "anthropic", baseReq(), "clear-v2") == h1 {
+		t.Error("scoring_version must alter the hash")
+	}
+}
+
+func TestKeyHash_IgnoresNonOutputFields(t *testing.T) {
+	r := baseReq()
+	base := KeyHash("t", "anthropic", r, "v1")
+	r.ID = "req-123"
+	r.UserID = "user-9"
+	r.ApplicationID = "app-x"
+	r.Timestamp = time.Unix(999, 0)
+	r.Stream = false
+	if KeyHash("t", "anthropic", r, "v1") != base {
+		t.Error("non-output-affecting fields must not change the hash")
+	}
+}
+
+func TestDecide(t *testing.T) {
+	cfg := Config{Enabled: true, RequireDeterministic: true}
+
+	if d := Decide(baseReq(), cfg, ""); !d.Cacheable || d.Bypass {
+		t.Fatalf("deterministic req should be cacheable: %+v", d)
+	}
+	for _, h := range []string{"off", "bypass", "No-Cache", " no-store "} {
+		if d := Decide(baseReq(), cfg, h); d.Cacheable || !d.Bypass {
+			t.Errorf("header %q should bypass: %+v", h, d)
+		}
+	}
+	// Streaming, tools, functions never cache.
+	rs := baseReq()
+	rs.Stream = true
+	if Decide(rs, cfg, "").Cacheable {
+		t.Error("streaming must not be cacheable")
+	}
+	rt := baseReq()
+	rt.Tools = []types.Tool{{Type: "function"}}
+	if Decide(rt, cfg, "").Cacheable {
+		t.Error("tool request must not be cacheable")
+	}
+	// Non-deterministic gated by RequireDeterministic.
+	rn := baseReq()
+	rn.Temperature = f32(0.9)
+	if Decide(rn, cfg, "").Cacheable {
+		t.Error("temperature>0 must not cache when RequireDeterministic")
+	}
+	rn.Seed = iptr(3) // a seed pins sampling → deterministic again
+	if !Decide(rn, cfg, "").Cacheable {
+		t.Error("seed should make it cacheable")
+	}
+	// Disabled config caches nothing (but a bypass header still reads as bypass).
+	if Decide(baseReq(), Config{Enabled: false}, "").Cacheable {
+		t.Error("disabled config must not cache")
+	}
+	if !Decide(baseReq(), Config{Enabled: false}, "off").Bypass {
+		t.Error("bypass header should register even when disabled")
+	}
+	// nil-temperature default is treated as non-deterministic.
+	rd := baseReq()
+	rd.Temperature = nil
+	if Decide(rd, cfg, "").Cacheable {
+		t.Error("nil temperature (vendor default sampling) must not cache under RequireDeterministic")
+	}
+	// RequireDeterministic=false caches regardless of sampling.
+	if !Decide(rd, Config{Enabled: true, RequireDeterministic: false}, "").Cacheable {
+		t.Error("RequireDeterministic=false should cache nondeterministic req")
+	}
+}
+
+func entryFor(text string) *Entry {
+	resp := types.ChatResponse{
+		ID:      "resp-1",
+		Choices: []types.Choice{{Message: types.Message{Role: "assistant", Content: text}}},
+	}
+	b, _ := json.Marshal(resp)
+	return &Entry{Response: b, Vendor: "anthropic", Model: "claude-opus-4-8", StoredAtUnix: 1}
+}
+
+// cacheContract exercises any Cache implementation.
+func cacheContract(t *testing.T, c Cache) {
+	t.Helper()
+	ctx := context.Background()
+
+	if _, ok, _ := c.Get(ctx, "t1", "h1"); ok {
+		t.Fatal("empty cache should miss")
+	}
+	if err := c.Set(ctx, "t1", "h1", entryFor("answer"), time.Minute); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, ok, err := c.Get(ctx, "t1", "h1")
+	if err != nil || !ok {
+		t.Fatalf("expected hit: ok=%v err=%v", ok, err)
+	}
+	if string(got.Response) != string(entryFor("answer").Response) {
+		t.Errorf("round-trip mismatch: %s", got.Response)
+	}
+
+	// Tenant isolation: same hash, different tenant, must miss.
+	if _, ok, _ := c.Get(ctx, "t2", "h1"); ok {
+		t.Error("tenant isolation violated — t2 read t1's entry")
+	}
+
+	// PurgeTenant scopes to the tenant.
+	if err := c.Set(ctx, "t1", "h2", entryFor("b"), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Set(ctx, "t2", "h9", entryFor("c"), time.Minute); err != nil {
+		t.Fatal(err)
+	}
+	n, err := c.PurgeTenant(ctx, "t1")
+	if err != nil {
+		t.Fatalf("purge: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("expected 2 purged, got %d", n)
+	}
+	if _, ok, _ := c.Get(ctx, "t1", "h1"); ok {
+		t.Error("t1 entry survived purge")
+	}
+	if _, ok, _ := c.Get(ctx, "t2", "h9"); !ok {
+		t.Error("purge of t1 removed t2's entry")
+	}
+}
+
+func TestMemoryCache_Contract(t *testing.T) {
+	cacheContract(t, NewMemoryCache(0))
+}
+
+func TestMemoryCache_TTLExpiry(t *testing.T) {
+	c := NewMemoryCache(0)
+	ctx := context.Background()
+	now := time.Unix(1000, 0)
+	timeNow = func() time.Time { return now }
+	defer func() { timeNow = time.Now }()
+
+	if err := c.Set(ctx, "t", "h", entryFor("x"), 30*time.Second); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, _ := c.Get(ctx, "t", "h"); !ok {
+		t.Fatal("should hit before TTL")
+	}
+	now = now.Add(31 * time.Second)
+	if _, ok, _ := c.Get(ctx, "t", "h"); ok {
+		t.Error("should miss after TTL")
+	}
+}
+
+func TestMemoryCache_Eviction(t *testing.T) {
+	c := NewMemoryCache(2)
+	ctx := context.Background()
+	for _, h := range []string{"a", "b", "c"} {
+		if err := c.Set(ctx, "t", h, entryFor(h), time.Minute); err != nil {
+			t.Fatal(err)
+		}
+	}
+	c.mu.Lock()
+	n := len(c.m)
+	c.mu.Unlock()
+	if n > 2 {
+		t.Errorf("eviction failed: %d entries, cap 2", n)
+	}
+}
+
+func TestResponseCacheable(t *testing.T) {
+	ok := &types.ChatResponse{Choices: []types.Choice{{Message: types.Message{Content: "hi"}}}}
+	if !ResponseCacheable(ok) {
+		t.Error("plain response should be cacheable")
+	}
+	if ResponseCacheable(nil) || ResponseCacheable(&types.ChatResponse{}) {
+		t.Error("nil / no-choice response must not be cacheable")
+	}
+	tool := &types.ChatResponse{Choices: []types.Choice{{Message: types.Message{ToolCalls: []types.ToolCall{{ID: "x"}}}}}}
+	if ResponseCacheable(tool) {
+		t.Error("response with tool calls must not be cacheable")
+	}
+}
+
+func TestPendingContext(t *testing.T) {
+	ctx := context.Background()
+	if _, ok := PendingFromContext(ctx); ok {
+		t.Fatal("empty ctx should have no pending")
+	}
+	ctx = WithPending(ctx, "tenant-a", "hash-1")
+	p, ok := PendingFromContext(ctx)
+	if !ok || p.TenantID != "tenant-a" || p.Hash != "hash-1" {
+		t.Fatalf("pending round-trip failed: %+v ok=%v", p, ok)
+	}
+}

--- a/pkg/aiqg/responsecache/pending.go
+++ b/pkg/aiqg/responsecache/pending.go
@@ -1,0 +1,48 @@
+package responsecache
+
+import (
+	"context"
+
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+)
+
+// Pending carries the store decision from the lookup site (before routing) to
+// the store site (after the outbound scan), which run in different functions
+// sharing one request context. Set only on a cacheable miss; its presence is
+// the signal to store the produced response.
+type Pending struct {
+	TenantID string
+	Hash     string
+}
+
+type ctxKey int
+
+const pendingCtxKey ctxKey = 0
+
+// WithPending returns a context carrying the store intent. The caller reassigns
+// its *http.Request to the returned context so the downstream handler sees it.
+func WithPending(ctx context.Context, tenantID, hash string) context.Context {
+	return context.WithValue(ctx, pendingCtxKey, &Pending{TenantID: tenantID, Hash: hash})
+}
+
+// PendingFromContext returns the store intent stamped by WithPending, if any.
+func PendingFromContext(ctx context.Context) (*Pending, bool) {
+	p, ok := ctx.Value(pendingCtxKey).(*Pending)
+	return p, ok && p != nil
+}
+
+// ResponseCacheable reports whether a produced response may be stored. A
+// response that carries tool calls is side-effecting downstream and is never
+// cached, even if the request itself passed Decide (defense in depth — a vendor
+// can emit tool calls the request didn't ask for).
+func ResponseCacheable(resp *types.ChatResponse) bool {
+	if resp == nil || len(resp.Choices) == 0 {
+		return false
+	}
+	for _, ch := range resp.Choices {
+		if len(ch.Message.ToolCalls) > 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Implements **C1** from `docs/AIQG-CACHING.md` — the exact-match response cache. A hit serves a previously-computed response for an equivalent request without calling the vendor, turning a 1–5s call into ~gateway latency (a hit is the ultimate 100% token reduction). It is also the L0 tier of the C4 semantic-cache cascade, so it's the required foundation for that work.

**Default off** — enable per deployment with `AIQG_RESPONSE_CACHE_ENABLED=true`.

### Core — `pkg/aiqg/responsecache`
- `Cache` port with a `RedisCache` (namespaced `aiqg:cache:{tenant}:{hash}`, reuses the AIQG Redis client) and a bounded TTL `MemoryCache` fallback; `PurgeTenant` for right-to-be-forgotten.
- `KeyHash` over `tenant + vendor + model + post-redaction messages + output-affecting params + scoring_version`. Deterministic (`encoding/json`), so equivalent requests collapse to one entry; request id / user id / timestamp are excluded.
- `Decide()` — default-safe eligibility: deterministic-only (`temperature==0` or `seed`), never streaming / tools / functions; `TAS-Cache: off|bypass` honored.

### Wiring — `internal/server`
- `maybeServeFromCache` runs after routing (so the key carries the resolved vendor) but before the vendor call — a hit skips it. Experiment-claimed requests bypass (§7). A hit does **not** stamp token usage, so cost/latency accounting reads ~0 (§6).
- `maybeStoreInCache` runs after the outbound Gatekeeper scan, before `RouterMetadata` is attached, so the cached body is clean. Best-effort, off the client's latency path.

### Observability
`cache_state` (hit/miss/bypass) + `cache_key_hash` stamped on the Routing sidecar and threaded onto every `ResponseEvent`.

### Privacy precondition
The key is built on **post-redaction** messages, so with G1 redaction enabled the cache never keys on or stores raw PII (§2/§5). G1 is merged but default-off; operators enabling the cache on PII traffic should enable redaction too.

### Scope
This is C1 only. **Deferred:** C2 (savings metric + hit/miss dashboard split), route-level cache profiles (v1 is one global profile), C3 experiment-keyed entries (v1 bypasses experiment-claimed requests), and C4 semantic caching.

### Tests
Key determinism/sensitivity + tenant isolation, the full eligibility matrix, `MemoryCache` contract/TTL/eviction, and a server-level miss→store→hit lifecycle (incl. tenant isolation, header bypass, tool skip). `go test -tags nohs -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)