### PR TITLE
feat(aiqg): cache within experiments (C3 gateway)

### DIFF
--- a/docs/AIQG-CACHING.md
+++ b/docs/AIQG-CACHING.md
@@ -1,10 +1,13 @@
 # AIQG — Response Caching (Design)
 
-Status: **C1 (exact-match v1) IMPLEMENTED** — `pkg/aiqg/responsecache` + the
-lookup/store wiring in `internal/server` (`maybeServeFromCache` /
-`maybeStoreInCache`). Default off; enable per deployment with
-`AIQG_RESPONSE_CACHE_ENABLED=true`. C2 (accounting/UI), C3 (experiment keying),
-and C4 (semantic, `AIQG-SEMANTIC-CACHING.md`) remain design-only. Gateway feature
+Status: **C1–C3 IMPLEMENTED** — `pkg/aiqg/responsecache` + the lookup/store wiring
+in `internal/server` (`maybeServeFromCache` / `maybeStoreInCache`). Default off;
+enable per deployment with `AIQG_RESPONSE_CACHE_ENABLED=true`. **C2** (accounting/UI)
+ships the savings metric + hit/miss split across `aiqg-dashboard-be` + `aiqg-ui`.
+**C3** (experiment integration): bypass-by-default is on; caching *within* an
+experiment is opt-in via `AIQG_RESPONSE_CACHE_IN_EXPERIMENTS=true` (variant folded
+into the key), and the experiment results query excludes cache hits. Only **C4**
+(semantic, `AIQG-SEMANTIC-CACHING.md`) remains design-only. Gateway feature
 (`tas-llm-router`). Related: `AIQG-EXTENSION.md` (already reserves a
 `cache_state` event dimension), `AIQG-EXPERIMENTS-RUNNER.md` (cache must be
 experiment-aware), `AIQG-AGENT-FLOW-ATTRIBUTION.md`, `account.md`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,6 +110,9 @@ type AIQGResponseCacheConfig struct {
 	// AllowNondeterministic caches temperature>0 requests too. Default false
 	// (require_deterministic=true) — the safe posture.
 	AllowNondeterministic bool `yaml:"allow_nondeterministic"`
+	// InExperiments caches WITHIN experiments (C3, variant folded into the key)
+	// instead of bypassing experiment-claimed requests. Default false.
+	InExperiments bool `yaml:"in_experiments"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Defined here (not in
@@ -603,6 +606,9 @@ func (c *Config) loadFromEnv() {
 	if v := os.Getenv("AIQG_RESPONSE_CACHE_ALLOW_NONDETERMINISTIC"); v != "" {
 		c.AIQG.ResponseCache.AllowNondeterministic = v == "true" || v == "1"
 	}
+	if v := os.Getenv("AIQG_RESPONSE_CACHE_IN_EXPERIMENTS"); v != "" {
+		c.AIQG.ResponseCache.InExperiments = v == "true" || v == "1"
+	}
 	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
 		c.AIQG.DashboardURL = u
 	}
@@ -800,6 +806,7 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 			TTL:                   c.AIQG.ResponseCache.TTL,
 			MaxBodyBytes:          c.AIQG.ResponseCache.MaxBodyBytes,
 			AllowNondeterministic: c.AIQG.ResponseCache.AllowNondeterministic,
+			InExperiments:         c.AIQG.ResponseCache.InExperiments,
 		},
 	}
 	if len(c.AIQG.Tokens) > 0 {

--- a/internal/server/response_cache_test.go
+++ b/internal/server/response_cache_test.go
@@ -106,7 +106,7 @@ func TestResponseCache_TenantIsolation(t *testing.T) {
 	s := cacheTestServer()
 	_, r1, req := newCacheReq(t)
 	s.maybeStoreInCache(r1.WithContext(responsecache.WithPending(r1.Context(), "tenant-a",
-		responsecache.KeyHash("tenant-a", "anthropic", req, ""))),
+		responsecache.KeyHash("tenant-a", "anthropic", req, "", ""))),
 		&types.ChatResponse{ID: "x", Model: "m", Choices: []types.Choice{{Message: types.Message{Content: "secret"}}}})
 
 	// tenant-b, same prompt → miss.
@@ -133,6 +133,65 @@ func TestResponseCache_HeaderBypass(t *testing.T) {
 	}
 	if snap := middleware.RoutingFromContext(r.Context()).Snapshot(); snap.CacheState != "bypass" {
 		t.Fatalf("expected cache_state=bypass, got %q", snap.CacheState)
+	}
+}
+
+// Default (InExperiments=false): an experiment-claimed request bypasses the
+// cache so each variant's measurement reflects real variant calls (§7).
+func TestResponseCache_ExperimentBypassByDefault(t *testing.T) {
+	s := cacheTestServer()
+	w, r, req := newCacheReq(t)
+	middleware.StampExperiment(r.Context(), "exp-1", "A")
+	got := s.maybeServeFromCache(w, r, req, "anthropic")
+	if got == nil {
+		t.Fatal("experiment request should not be served a hit")
+	}
+	if snap := middleware.RoutingFromContext(r.Context()).Snapshot(); snap.CacheState != "bypass" {
+		t.Fatalf("expected cache_state=bypass, got %q", snap.CacheState)
+	}
+	if _, ok := responsecache.PendingFromContext(got.Context()); ok {
+		t.Error("bypassed experiment request must not stash a store intent")
+	}
+}
+
+// InExperiments=true: cache within the experiment, but variant A and B never
+// share an entry (the key is variant-scoped).
+func TestResponseCache_CacheWithinExperiment(t *testing.T) {
+	s := cacheTestServer()
+	s.respCacheCfg.InExperiments = true
+
+	// Variant A miss → store.
+	_, rA, reqA := newCacheReq(t)
+	middleware.StampExperiment(rA.Context(), "exp-1", "A")
+	gotA := s.maybeServeFromCache(nil, rA, reqA, "anthropic")
+	if gotA == nil {
+		t.Fatal("variant A should be a cacheable miss, not a bypass")
+	}
+	if snap := middleware.RoutingFromContext(rA.Context()).Snapshot(); snap.CacheState != "miss" {
+		t.Fatalf("expected miss for variant A, got %q", snap.CacheState)
+	}
+	s.maybeStoreInCache(gotA, &types.ChatResponse{ID: "a", Model: "claude-opus-4-8",
+		Choices: []types.Choice{{Message: types.Message{Content: "answer-A"}}}})
+
+	// Variant B, same prompt → MISS (separate entry), not A's hit.
+	wB, rB, reqB := newCacheReq(t)
+	middleware.StampExperiment(rB.Context(), "exp-1", "B")
+	gotB := s.maybeServeFromCache(wB, rB, reqB, "anthropic")
+	if gotB == nil {
+		t.Fatal("variant B must not read variant A's entry")
+	}
+	if snap := middleware.RoutingFromContext(rB.Context()).Snapshot(); snap.CacheState != "miss" {
+		t.Fatalf("expected miss for variant B, got %q", snap.CacheState)
+	}
+
+	// Variant A again, same prompt → HIT (its own entry).
+	wA2, rA2, reqA2 := newCacheReq(t)
+	middleware.StampExperiment(rA2.Context(), "exp-1", "A")
+	if s.maybeServeFromCache(wA2, rA2, reqA2, "anthropic") != nil {
+		t.Fatal("variant A repeat should hit its own entry")
+	}
+	if snap := middleware.RoutingFromContext(rA2.Context()).Snapshot(); snap.CacheState != "hit" {
+		t.Fatalf("expected hit for variant A repeat, got %q", snap.CacheState)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -207,6 +207,7 @@ type AIQGResponseCacheConfig struct {
 	TTL                   time.Duration `yaml:"ttl"`
 	MaxBodyBytes          int           `yaml:"max_body_bytes"`
 	AllowNondeterministic bool          `yaml:"allow_nondeterministic"`
+	InExperiments         bool          `yaml:"in_experiments"`
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Brokers + topic are
@@ -351,6 +352,7 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 				TTL:                  ttl,
 				RequireDeterministic: !config.AIQG.ResponseCache.AllowNondeterministic,
 				MaxBodyBytes:         config.AIQG.ResponseCache.MaxBodyBytes,
+				InExperiments:        config.AIQG.ResponseCache.InExperiments,
 			}
 			backend := "memory"
 			if sharedRedis != nil {
@@ -861,15 +863,24 @@ func (s *Server) maybeServeFromCache(w http.ResponseWriter, r *http.Request, req
 	if !d.Cacheable {
 		return r
 	}
-	// Experiment-claimed requests bypass the cache so each variant's measurement
-	// reflects real variant calls (docs/AIQG-CACHING.md §7).
-	if rt := middleware.RoutingFromContext(r.Context()); rt != nil && rt.Snapshot().ExperimentID != "" {
-		middleware.StampCacheState(r.Context(), "bypass")
-		return r
+	// Experiment interaction (docs/AIQG-CACHING.md §7, C3). By default an
+	// experiment-claimed request bypasses the cache so each variant's measurement
+	// reflects real variant calls. When InExperiments is opted in, cache instead
+	// but fold the variant into the key so variant A and B never share an entry;
+	// the dashboard's per-variant queries then exclude cache hits from the verdict.
+	variant := ""
+	if rt := middleware.RoutingFromContext(r.Context()); rt != nil {
+		if snap := rt.Snapshot(); snap.ExperimentID != "" {
+			if !s.respCacheCfg.InExperiments {
+				middleware.StampCacheState(r.Context(), "bypass")
+				return r
+			}
+			variant = snap.ExperimentID + ":" + snap.ExperimentVariant
+		}
 	}
 
 	tenantID := s.extractTenantID(r)
-	hash := responsecache.KeyHash(tenantID, vendor, req, events.ScoringVersion)
+	hash := responsecache.KeyHash(tenantID, vendor, req, events.ScoringVersion, variant)
 	middleware.StampCacheKeyHash(r.Context(), hash)
 
 	if entry, ok, err := s.respCache.Get(r.Context(), tenantID, hash); err != nil {

--- a/pkg/aiqg/responsecache/cache.go
+++ b/pkg/aiqg/responsecache/cache.go
@@ -52,6 +52,12 @@ type Config struct {
 	RequireDeterministic bool
 	// MaxBodyBytes skips storing responses larger than this (0 = no limit).
 	MaxBodyBytes int
+	// InExperiments allows caching WITHIN an experiment (C3, docs/AIQG-CACHING.md
+	// §7). Default false: experiment-claimed requests bypass the cache so each
+	// variant's measurement reflects real variant calls. When true, the variant
+	// is folded into the key (variant A and B never share an entry) and the
+	// dashboard's per-variant queries exclude cache hits from the verdict.
+	InExperiments bool
 }
 
 // Entry is a stored response. Response is the marshaled, post-outbound-scan
@@ -228,7 +234,11 @@ var timeNow = time.Now
 // declaration order, map keys sorted — so identical inputs always yield an
 // identical digest (docs/AIQG-PROMPT-CACHE-CONTROL.md §12.1). No manual sorting
 // is needed.
-func KeyHash(tenantID, vendor string, req *types.ChatRequest, scoringVersion string) string {
+//
+// variant is the experiment scope (C3, §7): empty for normal traffic, or
+// "<experiment_id>:<variant>" when caching WITHIN an experiment, so variant A
+// and B never share an entry. Folded into the hash like any other key input.
+func KeyHash(tenantID, vendor string, req *types.ChatRequest, scoringVersion, variant string) string {
 	type sig struct {
 		Tenant           string           `json:"t"`
 		Vendor           string           `json:"v"`
@@ -245,13 +255,14 @@ func KeyHash(tenantID, vendor string, req *types.ChatRequest, scoringVersion str
 		Tools            []types.Tool     `json:"tools,omitempty"`
 		Functions        []types.Function `json:"funcs,omitempty"`
 		Scoring          string           `json:"sc"`
+		Variant          string           `json:"xv,omitempty"`
 	}
 	s := sig{
 		Tenant: tenantID, Vendor: vendor, Model: req.Model, Messages: req.Messages,
 		Temperature: req.Temperature, TopP: req.TopP, MaxTokens: req.MaxTokens,
 		FrequencyPenalty: req.FrequencyPenalty, PresencePenalty: req.PresencePenalty,
 		Stop: req.Stop, Seed: req.Seed, ResponseFormat: req.ResponseFormat,
-		Tools: req.Tools, Functions: req.Functions, Scoring: scoringVersion,
+		Tools: req.Tools, Functions: req.Functions, Scoring: scoringVersion, Variant: variant,
 	}
 	b, _ := json.Marshal(s)
 	sum := sha256.Sum256(b)

--- a/pkg/aiqg/responsecache/cache_test.go
+++ b/pkg/aiqg/responsecache/cache_test.go
@@ -23,8 +23,8 @@ func baseReq() *types.ChatRequest {
 func TestKeyHash_DeterministicAndSensitive(t *testing.T) {
 	r1 := baseReq()
 	r2 := baseReq()
-	h1 := KeyHash("tenant-a", "anthropic", r1, "clear-v1")
-	h2 := KeyHash("tenant-a", "anthropic", r2, "clear-v1")
+	h1 := KeyHash("tenant-a", "anthropic", r1, "clear-v1", "")
+	h2 := KeyHash("tenant-a", "anthropic", r2, "clear-v1", "")
 	if h1 != h2 {
 		t.Fatalf("identical requests must hash equal: %s != %s", h1, h2)
 	}
@@ -45,33 +45,50 @@ func TestKeyHash_DeterministicAndSensitive(t *testing.T) {
 		}
 		r := baseReq()
 		mut(r)
-		if got := KeyHash("tenant-a", "anthropic", r, "clear-v1"); got == h1 {
+		if got := KeyHash("tenant-a", "anthropic", r, "clear-v1", ""); got == h1 {
 			t.Errorf("%s change did not alter the hash", name)
 		}
 	}
 
 	// Tenant, vendor, and scoring_version are all in the key.
-	if KeyHash("tenant-b", "anthropic", baseReq(), "clear-v1") == h1 {
+	if KeyHash("tenant-b", "anthropic", baseReq(), "clear-v1", "") == h1 {
 		t.Error("tenant must alter the hash (isolation)")
 	}
-	if KeyHash("tenant-a", "openai", baseReq(), "clear-v1") == h1 {
+	if KeyHash("tenant-a", "openai", baseReq(), "clear-v1", "") == h1 {
 		t.Error("vendor must alter the hash")
 	}
-	if KeyHash("tenant-a", "anthropic", baseReq(), "clear-v2") == h1 {
+	if KeyHash("tenant-a", "anthropic", baseReq(), "clear-v2", "") == h1 {
 		t.Error("scoring_version must alter the hash")
 	}
 }
 
 func TestKeyHash_IgnoresNonOutputFields(t *testing.T) {
 	r := baseReq()
-	base := KeyHash("t", "anthropic", r, "v1")
+	base := KeyHash("t", "anthropic", r, "v1", "")
 	r.ID = "req-123"
 	r.UserID = "user-9"
 	r.ApplicationID = "app-x"
 	r.Timestamp = time.Unix(999, 0)
 	r.Stream = false
-	if KeyHash("t", "anthropic", r, "v1") != base {
+	if KeyHash("t", "anthropic", r, "v1", "") != base {
 		t.Error("non-output-affecting fields must not change the hash")
+	}
+}
+
+func TestKeyHash_VariantScoping(t *testing.T) {
+	// C3: a non-empty variant scopes the key so experiment arms never share.
+	base := KeyHash("t", "anthropic", baseReq(), "v1", "")
+	a := KeyHash("t", "anthropic", baseReq(), "v1", "exp-1:A")
+	b := KeyHash("t", "anthropic", baseReq(), "v1", "exp-1:B")
+	if a == base || b == base {
+		t.Error("a variant must change the hash vs the unscoped key")
+	}
+	if a == b {
+		t.Error("variant A and B must not share a cache entry")
+	}
+	// Same variant → stable.
+	if a != KeyHash("t", "anthropic", baseReq(), "v1", "exp-1:A") {
+		t.Error("same variant must hash stably")
 	}
 }
 


### PR DESCRIPTION
**C3** gateway piece. C1 already bypasses experiment-claimed requests (the safe default); C3 adds the opt-in to cache *within* an experiment (docs/AIQG-CACHING.md §7).

When `AIQG_RESPONSE_CACHE_IN_EXPERIMENTS=true`, an experiment-claimed request is cached instead of bypassed, but the variant (`<experiment_id>:<variant>`) is folded into the cache key so **variant A and B never share an entry**. Hits stay `cache_state=hit`; the dashboard's per-variant verdict query excludes them (see aiqg-dashboard-be PR).

- `responsecache.Config.InExperiments` + `AIQG_RESPONSE_CACHE_IN_EXPERIMENTS` env (default off).
- `KeyHash` takes a `variant` arg (empty for normal traffic).
- `maybeServeFromCache`: experiment-claimed → bypass (default) or variant-scoped lookup/store (opt-in).

Tests: variant-scoping (A/B never share, same variant stable), bypass-by-default, and cache-within-experiment miss(A)→miss(B, separate entry)→hit(A). `go test -tags nohs -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)