### PR TITLE
feat(aiqg): semantic-cache cascade core (C4, store-agnostic)

### DIFF
--- a/docs/AIQG-SEMANTIC-CACHING.md
+++ b/docs/AIQG-SEMANTIC-CACHING.md
@@ -1,8 +1,15 @@
 # AIQG — Semantic Response Caching (Design)
 
-Status: **Design / for review** — NOT implemented. Gateway feature
-(`tas-llm-router`). Expands §9 of [`AIQG-CACHING.md`](AIQG-CACHING.md) (phase C4)
-and closes out issue
+Status: **C4 STARTED** — the store-agnostic cascade core is implemented in
+`pkg/aiqg/semcache` (L1 candidate gen + the L2 verification gate + L2 lexical
+guards + a FLAT `MemoryStore` + the `VectorStore`/`Embedder` ports), with the
+adversarial cases from §1.1/§5 as tests (Chase Sapphire vs Sapphire **Reserve**,
+negation, number/date/version, tenant/model isolation, freshness). Redaction —
+the other S0 prerequisite (§4.1.1) — is DONE and deployed (G1). **Still gated on
+S0 infra**: a shared vector store (Redis 8 `FT.*` or pgvector — §7) plus the
+production `Embedder` (TEI/Ollama), before S1 shadow mode can run in-cluster.
+Gateway feature (`tas-llm-router`). Expands §9 of [`AIQG-CACHING.md`](AIQG-CACHING.md)
+(phase C4) and closes out issue
 [tas-llm-router#97](https://github.com/Tributary-ai-services/tas-llm-router/issues/97).
 
 Related: [`AIQG-CACHING.md`](AIQG-CACHING.md) (exact-match v1 — **this doc depends

--- a/pkg/aiqg/semcache/cascade.go
+++ b/pkg/aiqg/semcache/cascade.go
@@ -1,0 +1,131 @@
+package semcache
+
+import (
+	"context"
+	"time"
+)
+
+// Outcome is what the cascade decided for one lookup — the record that drives
+// the event fields (cache_state / cache_similarity / cache_threshold) and, in
+// shadow mode, the "what would have hit" log (§14, §15 S1).
+type Outcome struct {
+	// State is "semantic_hit" (L2 passed AND not shadow), "shadow_hit" (L2 passed
+	// but shadow mode suppressed serving), "miss" (no L1 candidate or L2 rejected
+	// all), or "" when the cache didn't run (disabled / not eligible).
+	State string
+	// Entry is the winning entry — set only for semantic_hit and shadow_hit.
+	Entry *Entry
+	// Similarity is the L1 cosine similarity of the top candidate considered.
+	Similarity float64
+	// Threshold is the L1 floor in force (for the event / danger-band chart).
+	Threshold float64
+	// RejectReason is the L2 guard that rejected the top candidate (empty when a
+	// candidate passed or none was generated). Feeds the shadow-mode analysis.
+	RejectReason string
+}
+
+const (
+	StateSemanticHit = "semantic_hit"
+	StateShadowHit   = "shadow_hit"
+	StateMiss        = "miss"
+)
+
+// Cache is the store-agnostic semantic cascade (L1 candidate gen → L2 gate). L0
+// (exact match) is handled upstream by C1 before this runs; L3 (async judge) is
+// a later stage. Nil-safe: a nil *Cache Lookups to a no-op miss so callers need
+// no branch.
+type Cache struct {
+	cfg   Config
+	store VectorStore
+	embed Embedder
+}
+
+// New builds a semantic cache. A nil store or embedder, or Enabled=false, yields
+// a cache whose Lookup always returns an empty (didn't-run) Outcome.
+func New(cfg Config, store VectorStore, embed Embedder) *Cache {
+	return &Cache{cfg: cfg, store: store, embed: embed}
+}
+
+func (c *Cache) ready() bool {
+	return c != nil && c.cfg.Enabled && c.store != nil && c.embed != nil
+}
+
+// Serving reports whether a passing L2 hit would actually be served (vs shadow-
+// logged). False in shadow mode.
+func (c *Cache) Serving() bool { return c.ready() && !c.cfg.Shadow }
+
+// Lookup runs the cascade for one post-redaction prompt. It NEVER mutates the
+// request and NEVER serves in shadow mode. Errors from the embedder/store are
+// swallowed into a miss (a cache must fail open — a broken cache is a slow path,
+// never a wrong answer).
+func (c *Cache) Lookup(ctx context.Context, scope Scope, prompt string) Outcome {
+	if !c.ready() || prompt == "" {
+		return Outcome{}
+	}
+	out := Outcome{State: StateMiss, Threshold: c.cfg.MinSimilarity}
+
+	// L1 — embed + range search. A shortlist, not a decision.
+	vec, err := c.embed.Embed(ctx, prompt)
+	if err != nil || len(vec) == 0 {
+		return out
+	}
+	k := c.cfg.CandidateK
+	if k <= 0 {
+		k = 5
+	}
+	cands, err := c.store.Search(ctx, scope, vec, c.cfg.MinSimilarity, k)
+	if err != nil || len(cands) == 0 {
+		return out
+	}
+
+	// L2 — verification gate. Candidates are similarity-sorted; the first that
+	// passes ALL guards wins. Record the top candidate's similarity + the reason
+	// the strongest rejected candidate failed (for shadow analysis).
+	now := timeNow()
+	out.Similarity = cands[0].Similarity
+	out.RejectReason = "" // set below if the top candidate fails
+	for i, cand := range cands {
+		res := Verify(prompt, cand.Entry, scope, now, c.cfg.TTL)
+		if res.Pass {
+			if c.cfg.Shadow {
+				out.State = StateShadowHit // would have hit — logged, not served
+			} else {
+				out.State = StateSemanticHit
+			}
+			out.Entry = cand.Entry
+			out.Similarity = cand.Similarity
+			return out
+		}
+		if i == 0 {
+			out.RejectReason = res.Reason // why the closest match was not a hit
+		}
+	}
+	return out // miss: candidates existed but none survived L2
+}
+
+// Store embeds and persists a (prompt, response) pair for future semantic hits.
+// Called on a miss after the vendor responds (post-outbound-scan). Best-effort;
+// a store failure is not a request error.
+func (c *Cache) Store(ctx context.Context, scope Scope, key, prompt string, response []byte, clearScore float64) error {
+	if !c.ready() || prompt == "" {
+		return nil
+	}
+	vec, err := c.embed.Embed(ctx, prompt)
+	if err != nil || len(vec) == 0 {
+		return err
+	}
+	return c.store.Put(ctx, &Entry{
+		Key:            key,
+		Prompt:         prompt,
+		Response:       response,
+		Embedding:      vec,
+		TenantID:       scope.TenantID,
+		Model:          scope.Model,
+		ScoringVersion: scope.ScoringVersion,
+		CreatedAtUnix:  now().Unix(),
+		ClearScore:     clearScore,
+	}, c.cfg.TTL)
+}
+
+// now is a package indirection so Store + tests share the clock with the store.
+func now() time.Time { return timeNow() }

--- a/pkg/aiqg/semcache/cascade_test.go
+++ b/pkg/aiqg/semcache/cascade_test.go
@@ -1,0 +1,150 @@
+package semcache
+
+import (
+	"context"
+	"hash/fnv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// bagEmbedder is a deterministic bag-of-words embedder for tests: each lowercase
+// word is hashed into a fixed-dim vector. Texts sharing words get high cosine —
+// so paraphrases and near-duplicates (Sapphire vs Sapphire Reserve) both surface
+// as L1 candidates, which is exactly when L2 has to do its job.
+type bagEmbedder struct{ dim int }
+
+func (b bagEmbedder) Dim() int { return b.dim }
+func (b bagEmbedder) Embed(_ context.Context, text string) ([]float32, error) {
+	v := make([]float32, b.dim)
+	for w := range strings.FieldsSeq(strings.ToLower(text)) {
+		h := fnv.New32a()
+		_, _ = h.Write([]byte(w))
+		v[h.Sum32()%uint32(b.dim)] += 1
+	}
+	return v, nil
+}
+
+func newCache(t *testing.T, shadow bool) (*Cache, *MemoryStore) {
+	t.Helper()
+	store := NewMemoryStore(0)
+	cfg := Config{Enabled: true, Shadow: shadow, MinSimilarity: 0.8, CandidateK: 5, TTL: time.Hour}
+	return New(cfg, store, bagEmbedder{dim: 256}), store
+}
+
+func seed(t *testing.T, c *Cache, scope Scope, prompt, resp string) {
+	t.Helper()
+	if err := c.Store(context.Background(), scope, "k:"+prompt, prompt, []byte(resp), 100); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+}
+
+// A clean paraphrase (same entities, same polarity, high cosine) is a hit.
+func TestCascade_ParaphraseHit(t *testing.T) {
+	c, _ := newCache(t, false /* serving */)
+	sc := scopeOf("t1", "m1")
+	seed(t, c, sc, "how do I reset my password", "click forgot password")
+
+	out := c.Lookup(context.Background(), sc, "how do I reset my password")
+	if out.State != StateSemanticHit {
+		t.Fatalf("expected semantic_hit, got %q (sim=%.3f reason=%s)", out.State, out.Similarity, out.RejectReason)
+	}
+	if string(out.Entry.Response) != "click forgot password" {
+		t.Errorf("wrong response served: %s", out.Entry.Response)
+	}
+}
+
+// The Sapphire/Reserve near-duplicate surfaces at L1 (high cosine) but L2 rejects
+// it → miss, not a wrong-answer hit. The whole reason the cascade exists.
+func TestCascade_NearDuplicateRejectedByL2(t *testing.T) {
+	c, _ := newCache(t, false)
+	sc := scopeOf("t1", "m1")
+	// Real prompts capitalize proper nouns; the embedder lowercases internally
+	// (high cosine), but L2 sees the original casing (entity "Reserve" differs).
+	seed(t, c, sc, "What are the fees on the Chase Sapphire Reserve card", "reserve: $550/yr")
+
+	out := c.Lookup(context.Background(), sc, "What are the fees on the Chase Sapphire card")
+	if out.State != StateMiss {
+		t.Fatalf("near-duplicate must MISS, got %q (entry=%v)", out.State, out.Entry)
+	}
+	if out.Similarity < 0.8 {
+		t.Errorf("expected a high-similarity L1 candidate (that L2 then rejects), sim=%.3f", out.Similarity)
+	}
+	if out.RejectReason != "entity_number_date" {
+		t.Errorf("expected L2 entity rejection recorded, got %q", out.RejectReason)
+	}
+}
+
+// Shadow mode: a passing L2 candidate is reported as shadow_hit but never served.
+func TestCascade_ShadowMode(t *testing.T) {
+	c, _ := newCache(t, true /* shadow */)
+	if c.Serving() {
+		t.Fatal("shadow cache must report Serving()=false")
+	}
+	sc := scopeOf("t1", "m1")
+	seed(t, c, sc, "how do I reset my password", "click forgot password")
+	out := c.Lookup(context.Background(), sc, "how can I reset my password")
+	if out.State != StateShadowHit {
+		t.Fatalf("expected shadow_hit, got %q (sim=%.3f)", out.State, out.Similarity)
+	}
+}
+
+// Tenant isolation: an identical prompt under a different tenant never hits.
+func TestCascade_TenantIsolation(t *testing.T) {
+	c, _ := newCache(t, false)
+	seed(t, c, scopeOf("t1", "m1"), "how do I reset my password", "t1 answer")
+
+	out := c.Lookup(context.Background(), scopeOf("t2", "m1"), "how do I reset my password")
+	if out.State != StateMiss || out.Entry != nil {
+		t.Fatalf("cross-tenant must MISS with no entry, got %q %v", out.State, out.Entry)
+	}
+}
+
+// Cross-model never cross-serves.
+func TestCascade_ModelIsolation(t *testing.T) {
+	c, _ := newCache(t, false)
+	seed(t, c, scopeOf("t1", "m1"), "how do I reset my password", "m1 answer")
+	if out := c.Lookup(context.Background(), scopeOf("t1", "m2"), "how do I reset my password"); out.State != StateMiss {
+		t.Fatalf("cross-model must MISS, got %q", out.State)
+	}
+}
+
+// A disabled / nil cache is a no-op miss with no panic.
+func TestCascade_DisabledAndNil(t *testing.T) {
+	var nilC *Cache
+	if out := nilC.Lookup(context.Background(), scopeOf("t1", "m1"), "x"); out.State != "" {
+		t.Errorf("nil cache should return empty outcome, got %q", out.State)
+	}
+	off := New(Config{Enabled: false}, NewMemoryStore(0), bagEmbedder{dim: 64})
+	if out := off.Lookup(context.Background(), scopeOf("t1", "m1"), "x"); out.State != "" {
+		t.Errorf("disabled cache should return empty outcome, got %q", out.State)
+	}
+}
+
+func TestMemoryStore_TTLAndPurge(t *testing.T) {
+	store := NewMemoryStore(0)
+	sc := scopeOf("t1", "m1")
+	base := time.Unix(1000, 0)
+	timeNow = func() time.Time { return base }
+	defer func() { timeNow = time.Now }()
+	e := &Entry{Key: "k1", Prompt: "p", Embedding: []float32{1, 0}, TenantID: "t1", Model: "m1", ScoringVersion: "v1"}
+	_ = store.Put(context.Background(), e, 30*time.Second)
+
+	if got, _ := store.Search(context.Background(), sc, []float32{1, 0}, 0.9, 5); len(got) != 1 {
+		t.Fatalf("expected 1 candidate before TTL, got %d", len(got))
+	}
+	base = base.Add(31 * time.Second)
+	if got, _ := store.Search(context.Background(), sc, []float32{1, 0}, 0.9, 5); len(got) != 0 {
+		t.Errorf("expected 0 candidates after TTL, got %d", len(got))
+	}
+	// Purge scoping.
+	base = time.Unix(1000, 0)
+	_ = store.Put(context.Background(), &Entry{Key: "k2", Prompt: "p", Embedding: []float32{1, 0}, TenantID: "t1", Model: "m1", ScoringVersion: "v1"}, time.Hour)
+	_ = store.Put(context.Background(), &Entry{Key: "k3", Prompt: "p", Embedding: []float32{1, 0}, TenantID: "t2", Model: "m1", ScoringVersion: "v1"}, time.Hour)
+	if n, _ := store.PurgeTenant(context.Background(), "t1"); n == 0 {
+		t.Error("purge should remove t1 entries")
+	}
+	if got, _ := store.Search(context.Background(), scopeOf("t2", "m1"), []float32{1, 0}, 0.9, 5); len(got) != 1 {
+		t.Error("purge of t1 must not touch t2")
+	}
+}

--- a/pkg/aiqg/semcache/memstore.go
+++ b/pkg/aiqg/semcache/memstore.go
@@ -1,0 +1,116 @@
+package semcache
+
+import (
+	"context"
+	"math"
+	"sort"
+	"sync"
+	"time"
+)
+
+// MemoryStore is a brute-force FLAT cosine VectorStore held in one process.
+//
+// FLAT (exact brute force) is what the design mandates at this scale — at
+// 10k–100k entries it is exact, with no recall loss on a correctness-sensitive
+// path (§7.2). This implementation is per-pod, so it is NOT production-viable
+// (a per-replica cache divides the hit rate by replica count, §7). It exists to
+// (a) unit-test the cascade + L2 gate without infra, and (b) drive S1 shadow
+// mode on a single replica until the shared Redis 8 / pgvector store lands.
+type MemoryStore struct {
+	mu      sync.RWMutex
+	entries map[string]storedEntry
+	maxKeys int
+}
+
+type storedEntry struct {
+	e       Entry
+	expires time.Time
+}
+
+// NewMemoryStore bounds the map at maxKeys (<=0 → 8192).
+func NewMemoryStore(maxKeys int) *MemoryStore {
+	if maxKeys <= 0 {
+		maxKeys = 8192
+	}
+	return &MemoryStore{entries: make(map[string]storedEntry), maxKeys: maxKeys}
+}
+
+func (s *MemoryStore) Put(_ context.Context, e *Entry, ttl time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.entries[e.Key]; !exists && len(s.entries) >= s.maxKeys {
+		for k := range s.entries { // evict one arbitrary entry (recompute cost only)
+			delete(s.entries, k)
+			break
+		}
+	}
+	var exp time.Time
+	if ttl > 0 {
+		exp = timeNow().Add(ttl)
+	}
+	cp := *e
+	s.entries[e.Key] = storedEntry{e: cp, expires: exp}
+	return nil
+}
+
+func (s *MemoryStore) Search(_ context.Context, scope Scope, vec []float32, minSimilarity float64, k int) ([]Candidate, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	now := timeNow()
+	var out []Candidate
+	for _, se := range s.entries {
+		if !se.expires.IsZero() && now.After(se.expires) {
+			continue // passively expired (a reaper prunes lazily; skip here)
+		}
+		// TAG pre-filter — scope isolation is a hard boundary, mirrors the Redis
+		// index's @tenant/@model/@scoring_version filters (§7.3, §8).
+		if se.e.TenantID != scope.TenantID || se.e.Model != scope.Model || se.e.ScoringVersion != scope.ScoringVersion {
+			continue
+		}
+		sim := cosineSimilarity(vec, se.e.Embedding)
+		if sim < minSimilarity {
+			continue
+		}
+		cp := se.e
+		out = append(out, Candidate{Entry: &cp, Similarity: sim})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Similarity > out[j].Similarity })
+	if k > 0 && len(out) > k {
+		out = out[:k]
+	}
+	return out, nil
+}
+
+func (s *MemoryStore) PurgeTenant(_ context.Context, tenantID string) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	n := 0
+	for k, se := range s.entries {
+		if se.e.TenantID == tenantID {
+			delete(s.entries, k)
+			n++
+		}
+	}
+	return n, nil
+}
+
+// timeNow is overridable in tests (TTL expiry without sleeping).
+var timeNow = time.Now
+
+// cosineSimilarity returns cosine similarity in [0,1] for non-negative use,
+// clamped. Mismatched or zero-norm vectors score 0 (never a hit).
+func cosineSimilarity(a, b []float32) float64 {
+	if len(a) == 0 || len(a) != len(b) {
+		return 0
+	}
+	var dot, na, nb float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		na += float64(a[i]) * float64(a[i])
+		nb += float64(b[i]) * float64(b[i])
+	}
+	if na == 0 || nb == 0 {
+		return 0
+	}
+	return clamp01(dot / (math.Sqrt(na) * math.Sqrt(nb)))
+}

--- a/pkg/aiqg/semcache/semcache.go
+++ b/pkg/aiqg/semcache/semcache.go
@@ -1,0 +1,119 @@
+// Package semcache implements the AIQG semantic response cache (C4,
+// docs/AIQG-SEMANTIC-CACHING.md) — serving a stored answer for a prompt that is
+// *semantically similar*, not byte-identical, to one already answered.
+//
+// Semantic caching is the only AIQG lever that can return a WRONG answer, so the
+// design is a CASCADE, not a threshold lookup (§1.1 — no single similarity
+// threshold reaches an acceptable false-hit rate):
+//
+//	L0  exact match      → pkg/aiqg/responsecache (C1). Handled before this package.
+//	L1  candidate gen     → embed + vector RANGE search. A shortlist, not a decision.
+//	L2  verification gate → cheap deterministic guards; ALL must pass (this package).
+//	L3  async judge       → off the critical path; learns. (later stage)
+//
+// This package is the store-agnostic core: the L1/L2 cascade, the L2 guards, the
+// VectorStore + Embedder ports, and an in-process store for tests/shadow. The
+// production vector store (Redis 8 FT.* or pgvector — §7) plugs in behind
+// VectorStore once the infra lands; nothing here depends on that choice.
+//
+// L2 is "the part that makes it correct" (§5). Its guards are LEXICAL on purpose:
+// the failure mode is embedding separation, so the gate must not be another
+// embedding comparison (that's the same sensor twice). The discriminators are
+// entities, numbers, dates and negation — exactly where cosine fails ("Chase
+// Sapphire" vs "Chase Sapphire Reserve" sit at cosine 0.99).
+package semcache
+
+import (
+	"context"
+	"time"
+)
+
+// Entry is one stored semantic-cache record. Prompt is the POST-redaction prompt
+// text (never raw PII — §11), kept so L2's lexical guards can run against it.
+type Entry struct {
+	// Key is the storage key (tenant-namespaced by the store).
+	Key string
+	// Prompt is the canonical post-redaction prompt text of the stored request.
+	Prompt string
+	// Response is the marshaled, post-outbound-scan response (safe to serve).
+	Response []byte
+	// Embedding is the prompt's vector (same model/dim as lookups).
+	Embedding []float32
+	// Scope — must match the incoming request exactly on a hit (L2 guard d).
+	TenantID       string
+	Model          string
+	ScoringVersion string
+	// CreatedAtUnix drives the freshness guard (L2 guard c).
+	CreatedAtUnix int64
+	// ClearScore is the cached CLEAR composite carried with the entry (a hit
+	// serves the cached score, not a recompute — AIQG-CACHING.md §6).
+	ClearScore float64
+}
+
+// Candidate is one L1 search result: an entry plus its similarity to the query.
+// Similarity is cosine similarity in [0,1] (1 = identical); the store converts
+// its native distance metric to this so the cascade speaks one scale.
+type Candidate struct {
+	Entry      *Entry
+	Similarity float64
+}
+
+// VectorStore is the L1 port: a shared, tenant-scoped vector index with TTL.
+// Search is a RANGE query ("everything within the similarity floor"), NOT
+// unbounded KNN — KNN with no floor is a false-hit generator (§7.3).
+type VectorStore interface {
+	// Search returns candidates for (tenant, model, scoringVersion) whose cosine
+	// similarity to vec is >= minSimilarity, most-similar first, capped at k.
+	Search(ctx context.Context, scope Scope, vec []float32, minSimilarity float64, k int) ([]Candidate, error)
+	// Put stores an entry with a TTL.
+	Put(ctx context.Context, e *Entry, ttl time.Duration) error
+	// PurgeTenant flushes a tenant's namespace (right-to-be-forgotten).
+	PurgeTenant(ctx context.Context, tenantID string) (int, error)
+}
+
+// Embedder is the L1 embedding port. Implementations wrap TEI / Ollama; the
+// cascade only needs a text→vector map. Deterministic per (model, text).
+type Embedder interface {
+	Embed(ctx context.Context, text string) ([]float32, error)
+	// Dim is the embedding dimensionality (must match the store's index).
+	Dim() int
+}
+
+// Scope is the exact-match isolation tuple. tenant is the cardinal boundary — a
+// cross-tenant semantic hit is the worst failure (§8), so it is always both a
+// store filter AND an L2 guard.
+type Scope struct {
+	TenantID       string
+	Model          string
+	ScoringVersion string
+}
+
+// Config is the semantic-cache profile (§10). Default zero value is a disabled,
+// shadow-safe cache: Enabled=false serves nothing.
+type Config struct {
+	// Enabled turns the cascade on at all. Default off.
+	Enabled bool
+	// Shadow: run the full cascade (embed, search, L2) and LOG what WOULD have
+	// hit, but SERVE NOTHING (§15 S1). The zero-risk first mode. When false and
+	// Enabled, a passing L2 hit is actually served.
+	Shadow bool
+	// MinSimilarity is the L1 candidate-generation floor (cosine, 0..1). NOT the
+	// accept decision — that's L2. Starting value ~0.95 (§9.3), to be replaced by
+	// calibration, not defended.
+	MinSimilarity float64
+	// CandidateK caps L1 results fed to L2.
+	CandidateK int
+	// TTL bounds entry lifetime (also the freshness ceiling).
+	TTL time.Duration
+}
+
+// clamp01 bounds a similarity to [0,1].
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/pkg/aiqg/semcache/verify.go
+++ b/pkg/aiqg/semcache/verify.go
@@ -1,0 +1,130 @@
+package semcache
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// VerifyResult is the L2 outcome for one candidate.
+type VerifyResult struct {
+	Pass   bool
+	Reason string // the first guard that failed (empty on pass)
+}
+
+// Verify is the L2 verification gate (docs/AIQG-SEMANTIC-CACHING.md §5). A
+// candidate surfaced by L1 similarity is only a semantic hit if it passes ALL of
+// these cheap, deterministic, synchronous guards. They are lexical by design —
+// the failure mode is embedding separation, so the gate uses a different sensor
+// (entities/numbers/dates/negation) than the one that generated the candidate.
+//
+// incoming is the post-redaction prompt of the live request; cand is the stored
+// entry. Order of guards is cheap→discriminative; the first failure short-circuits.
+func Verify(incoming string, cand *Entry, scope Scope, now time.Time, ttl time.Duration) VerifyResult {
+	// d. Scope — exact tenant/model/scoring match. L1 already filtered on these;
+	// re-check as defense in depth (a cross-tenant hit is the worst failure, §8).
+	if cand.TenantID != scope.TenantID || cand.Model != scope.Model || cand.ScoringVersion != scope.ScoringVersion {
+		return VerifyResult{Reason: "scope"}
+	}
+	// c. Freshness — entry age within TTL.
+	if ttl > 0 && cand.CreatedAtUnix > 0 {
+		if now.Unix()-cand.CreatedAtUnix > int64(ttl.Seconds()) {
+			return VerifyResult{Reason: "freshness"}
+		}
+	}
+	// b. Negation — polarity must agree. "is X safe" must not hit "is X not safe".
+	if negationParity(incoming) != negationParity(cand.Prompt) {
+		return VerifyResult{Reason: "negation"}
+	}
+	// a. Entity/number/date guard — the discriminative tokens must match exactly.
+	// Kills "Chase Sapphire" vs "Chase Sapphire Reserve" (cosine 0.99), model
+	// versions, SKUs, plan tiers, dates — which no similarity threshold reaches.
+	if !discriminativeTokensMatch(incoming, cand.Prompt) {
+		return VerifyResult{Reason: "entity_number_date"}
+	}
+	return VerifyResult{Pass: true}
+}
+
+var (
+	// numberish: integers, decimals, money, versions, dates, ranges (4111, 4.5,
+	// 2026-07-18, v3, 123-45-6789 already redacted). Discriminative by definition.
+	reNumberish = regexp.MustCompile(`\d[\w.\-/]*`)
+	// tokenSplit: words for entity extraction.
+	reWord = regexp.MustCompile(`[A-Za-z][A-Za-z'\-]*`)
+	// acronym: 2+ all-caps (SKU, PDF, GPT). Kept as discriminative entities.
+	reAcronym = regexp.MustCompile(`^[A-Z0-9]{2,}$`)
+)
+
+// negationWords are the polarity markers. n't is handled by contraction below.
+var negationWords = map[string]bool{
+	"not": true, "no": true, "never": true, "without": true, "cannot": true,
+	"none": true, "nor": true, "neither": true, "nothing": true,
+}
+
+// negationParity returns count(negations) % 2, so a double negative ("not
+// unsafe") reads the same polarity as none. Contractions (isn't, don't, can't)
+// each count once.
+func negationParity(s string) int {
+	l := strings.ToLower(s)
+	n := strings.Count(l, "n't") // isn't/don't/can't/won't/…
+	for _, w := range reWord.FindAllString(l, -1) {
+		if negationWords[w] {
+			n++
+		}
+	}
+	return n % 2
+}
+
+// discriminativeTokens returns the set of tokens that carry entity/number/date
+// meaning — numbers/versions/dates, all-caps acronyms, and Capitalized words
+// (proper nouns, plan tiers, product names) other than a leading sentence-start
+// capital. Compared case-insensitively so casing noise doesn't cause misses, but
+// presence/absence (the "Reserve" in "Sapphire Reserve") always does.
+func discriminativeTokens(s string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, m := range reNumberish.FindAllString(s, -1) {
+		out["#"+strings.ToLower(m)] = struct{}{}
+	}
+	words := reWord.FindAllStringIndex(s, -1)
+	for i, idx := range words {
+		w := s[idx[0]:idx[1]]
+		isCap := w[0] >= 'A' && w[0] <= 'Z'
+		if !isCap {
+			continue
+		}
+		// Skip a capital only because it opens the prompt (sentence-start), unless
+		// it's an all-caps acronym (those are always meaningful).
+		if i == 0 && !reAcronym.MatchString(w) {
+			continue
+		}
+		if _, stop := entityStopwords[strings.ToLower(w)]; stop {
+			continue
+		}
+		out["@"+strings.ToLower(w)] = struct{}{}
+	}
+	return out
+}
+
+// entityStopwords are Capitalized words that are not discriminative entities —
+// common sentence openers / interrogatives that get capitalized mid-prompt.
+var entityStopwords = map[string]bool{
+	"i": true, "the": true, "a": true, "an": true, "what": true, "when": true,
+	"where": true, "who": true, "why": true, "how": true, "is": true, "are": true,
+	"do": true, "does": true, "can": true, "should": true, "please": true,
+}
+
+// discriminativeTokensMatch is true iff both prompts carry the SAME set of
+// entity/number/date tokens. A token present in one but not the other (a SKU,
+// a plan tier, a version, a date) means they are different questions.
+func discriminativeTokensMatch(a, b string) bool {
+	ta, tb := discriminativeTokens(a), discriminativeTokens(b)
+	if len(ta) != len(tb) {
+		return false
+	}
+	for k := range ta {
+		if _, ok := tb[k]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/aiqg/semcache/verify_test.go
+++ b/pkg/aiqg/semcache/verify_test.go
@@ -1,0 +1,107 @@
+package semcache
+
+import (
+	"testing"
+	"time"
+)
+
+func scopeOf(t, m string) Scope { return Scope{TenantID: t, Model: m, ScoringVersion: "v1"} }
+
+func entryOf(prompt, tenant, model string) *Entry {
+	return &Entry{Prompt: prompt, TenantID: tenant, Model: model, ScoringVersion: "v1", CreatedAtUnix: time.Now().Unix()}
+}
+
+func TestVerify_EntityGuard_SapphireReserve(t *testing.T) {
+	sc := scopeOf("t1", "m1")
+	now := time.Now()
+	// The canonical counterexample: cosine 0.99, different answers. L2 must reject.
+	cand := entryOf("What are the fees on the Chase Sapphire Reserve card?", "t1", "m1")
+	incoming := "What are the fees on the Chase Sapphire card?"
+	if r := Verify(incoming, cand, sc, now, time.Hour); r.Pass {
+		t.Fatal("must reject Sapphire vs Sapphire Reserve (entity guard)")
+	} else if r.Reason != "entity_number_date" {
+		t.Errorf("expected entity_number_date rejection, got %q", r.Reason)
+	}
+	// The exact same question must pass.
+	if r := Verify(cand.Prompt, cand, sc, now, time.Hour); !r.Pass {
+		t.Errorf("identical prompt must pass: %+v", r)
+	}
+}
+
+func TestVerify_NumbersAndDatesAndVersions(t *testing.T) {
+	sc := scopeOf("t1", "m1")
+	now := time.Now()
+	cases := []struct{ inc, cand string }{
+		{"invoice total for 4 seats", "invoice total for 5 seats"},                   // number
+		{"what changed in release 2026-07-01", "what changed in release 2026-08-01"}, // date
+		{"how do I use GPT-4 tools", "how do I use GPT-5 tools"},                     // version/SKU
+	}
+	for _, c := range cases {
+		r := Verify(c.inc, entryOf(c.cand, "t1", "m1"), sc, now, time.Hour)
+		if r.Pass {
+			t.Errorf("must reject differing number/date/version: %q vs %q", c.inc, c.cand)
+		}
+	}
+	// Same numbers/dates → the entity guard doesn't block (other guards apply).
+	if r := Verify("invoice total for 5 seats", entryOf("invoice total for 5 seats", "t1", "m1"), sc, now, time.Hour); !r.Pass {
+		t.Errorf("identical number prompt should pass: %+v", r)
+	}
+}
+
+func TestVerify_NegationGuard(t *testing.T) {
+	sc := scopeOf("t1", "m1")
+	now := time.Now()
+	if r := Verify("is aspirin safe for kids", entryOf("is aspirin not safe for kids", "t1", "m1"), sc, now, time.Hour); r.Pass {
+		t.Fatal("polarity disagreement must reject (negation guard)")
+	} else if r.Reason != "negation" {
+		t.Errorf("expected negation rejection, got %q", r.Reason)
+	}
+	// Contraction counts as negation.
+	if r := Verify("can I return this", entryOf("can't I return this", "t1", "m1"), sc, now, time.Hour); r.Pass {
+		t.Error("contraction n't must flip polarity")
+	}
+	// Double negation has the same parity as none → not blocked by negation.
+	r := Verify("this is not unusual", entryOf("this is not unusual", "t1", "m1"), sc, now, time.Hour)
+	if !r.Pass {
+		t.Errorf("identical double-negation prompt should pass: %+v", r)
+	}
+}
+
+func TestVerify_ScopeGuard(t *testing.T) {
+	now := time.Now()
+	cand := entryOf("hello world", "t1", "m1")
+	// Cross-tenant — the cardinal failure. Must reject even with identical text.
+	if r := Verify("hello world", cand, scopeOf("t2", "m1"), now, time.Hour); r.Pass || r.Reason != "scope" {
+		t.Errorf("cross-tenant must reject with scope reason: %+v", r)
+	}
+	// Cross-model.
+	if r := Verify("hello world", cand, scopeOf("t1", "m2"), now, time.Hour); r.Pass || r.Reason != "scope" {
+		t.Errorf("cross-model must reject with scope reason: %+v", r)
+	}
+}
+
+func TestVerify_Freshness(t *testing.T) {
+	sc := scopeOf("t1", "m1")
+	now := time.Now()
+	stale := entryOf("hello world", "t1", "m1")
+	stale.CreatedAtUnix = now.Add(-2 * time.Hour).Unix()
+	if r := Verify("hello world", stale, sc, now, time.Hour); r.Pass || r.Reason != "freshness" {
+		t.Errorf("stale entry must reject with freshness reason: %+v", r)
+	}
+	fresh := entryOf("hello world", "t1", "m1")
+	fresh.CreatedAtUnix = now.Add(-1 * time.Minute).Unix()
+	if r := Verify("hello world", fresh, sc, now, time.Hour); !r.Pass {
+		t.Errorf("fresh entry should pass: %+v", r)
+	}
+}
+
+func TestVerify_ParaphrasePasses(t *testing.T) {
+	// A genuine paraphrase with the SAME entities/numbers/polarity should pass L2
+	// (L1 similarity is what gates whether it even reaches here).
+	sc := scopeOf("t1", "m1")
+	now := time.Now()
+	r := Verify("how do I reset my password", entryOf("how can I reset my password", "t1", "m1"), sc, now, time.Hour)
+	if !r.Pass {
+		t.Errorf("clean paraphrase should pass L2: %+v", r)
+	}
+}


### PR DESCRIPTION
First slice of **C4** (docs/AIQG-SEMANTIC-CACHING.md). Semantic caching is the only AIQG lever that can return a **wrong answer**, so the design is a **cascade**, not a threshold lookup (no single similarity threshold reaches an acceptable false-hit rate — §1.1). This builds the store-agnostic correctness core in `pkg/aiqg/semcache`:

- **L1 candidate generation** — embed + vector *range* search (a shortlist, not a decision), behind a `VectorStore` port so Redis 8 `FT.*` / pgvector plug in later.
- **L2 verification gate** (§5, "the part that makes it correct") — cheap, deterministic, **lexical** guards (a different sensor than the embedding that surfaced the candidate): entity/number/date match, negation polarity, freshness, and exact tenant/model/scoring scope.
- **MemoryStore** — brute-force FLAT cosine (exact at this scale, §7.2) for tests + single-replica shadow. `Embedder` port for TEI/Ollama.
- **Cascade** with a **shadow mode** (run L1+L2, log what *would* hit, serve nothing — §15 S1) and fail-open semantics.

**Tests** cover the design's adversarial cases: "Chase Sapphire" vs "Chase Sapphire **Reserve**" (cosine 0.99, must MISS), negation flip, differing number/date/version, tenant + model isolation, TTL/freshness, clean-paraphrase hits. `nohs -race` + lint green.

**Not wired into the request path yet.** S1 shadow deployment is gated on **S0 infra**: a *shared* vector store (Redis 8 or pgvector + licensing sign-off) and a production `Embedder`. Redaction — the other S0 prereq — is already deployed (G1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)