### PR TITLE
feat(aiqg): semantic-cache production adapters (RedisStore + OllamaEmbedder, C4)

### DIFF
--- a/pkg/aiqg/semcache/ollama_embedder.go
+++ b/pkg/aiqg/semcache/ollama_embedder.go
@@ -1,0 +1,67 @@
+package semcache
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// OllamaEmbedder is the production Embedder — it calls an Ollama server's
+// embeddings endpoint. We reuse the all-minilm model already deployed for the
+// payload-reduction extractor (384-dim, matching the FLAT index's DIM 384). It
+// is general-purpose, not cache-match-tuned (the design prefers langcache-embed);
+// adequate for S1 shadow-mode data collection, upgradeable before serving.
+type OllamaEmbedder struct {
+	baseURL string
+	model   string
+	dim     int
+	hc      *http.Client
+}
+
+// NewOllamaEmbedder targets baseURL (e.g. http://ollama.tas-shared:11434) with
+// model (e.g. all-minilm). dim must match the vector index dimensionality.
+func NewOllamaEmbedder(baseURL, model string, dim int) *OllamaEmbedder {
+	return &OllamaEmbedder{
+		baseURL: baseURL, model: model, dim: dim,
+		hc: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+func (o *OllamaEmbedder) Dim() int { return o.dim }
+
+// Embed returns the prompt's embedding. Uses Ollama's /api/embed (batch shape);
+// a non-2xx or a dimension mismatch is an error so the caller treats it as a
+// cache miss rather than indexing a bad vector.
+func (o *OllamaEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	body, _ := json.Marshal(map[string]any{"model": o.model, "input": text})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.baseURL+"/api/embed", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := o.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("ollama embed: status %d", resp.StatusCode)
+	}
+	var out struct {
+		Embeddings [][]float32 `json:"embeddings"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if len(out.Embeddings) == 0 || len(out.Embeddings[0]) == 0 {
+		return nil, fmt.Errorf("ollama embed: empty embedding")
+	}
+	v := out.Embeddings[0]
+	if len(v) != o.dim {
+		return nil, fmt.Errorf("ollama embed: dim %d != index dim %d (wrong model?)", len(v), o.dim)
+	}
+	return v, nil
+}

--- a/pkg/aiqg/semcache/redis_store.go
+++ b/pkg/aiqg/semcache/redis_store.go
@@ -1,0 +1,187 @@
+package semcache
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// keyPrefix namespaces every entry; the tenant segment follows so a purge scans
+// aiqg:scache:{tenant}:*.
+const keyPrefix = "aiqg:scache"
+
+// DefaultIndex is the RediSearch index name.
+const DefaultIndex = "aiqg_scache_idx"
+
+// RedisStore is the production VectorStore: a shared, tenant-scoped RediSearch
+// FLAT vector index with per-key TTL (docs/AIQG-SEMANTIC-CACHING.md §7.2/§7.3).
+// FLAT (exact brute force) is correct at 10k–100k entries — no recall loss on a
+// correctness-sensitive path, no HNSW tuning. Lives on the dedicated
+// redis-semcache instance (redis-stack-server), not shared redis.
+type RedisStore struct {
+	rc    redis.UniversalClient
+	index string
+	dim   int
+}
+
+// NewRedisStore wraps a redis-stack client. Call EnsureIndex once at startup.
+func NewRedisStore(rc redis.UniversalClient, dim int) *RedisStore {
+	return &RedisStore{rc: rc, index: DefaultIndex, dim: dim}
+}
+
+// EnsureIndex creates the FLAT COSINE vector index idempotently (a re-create on
+// an existing index is treated as success — RediSearch rebuilds the index from
+// the HASH keys on load, so a restart just re-warms).
+func (s *RedisStore) EnsureIndex(ctx context.Context) error {
+	err := s.rc.FTCreate(ctx, s.index,
+		&redis.FTCreateOptions{OnHash: true, Prefix: []any{keyPrefix + ":"}},
+		&redis.FieldSchema{FieldName: "tenant", FieldType: redis.SearchFieldTypeTag},
+		&redis.FieldSchema{FieldName: "model", FieldType: redis.SearchFieldTypeTag},
+		&redis.FieldSchema{FieldName: "scoring_version", FieldType: redis.SearchFieldTypeTag},
+		&redis.FieldSchema{FieldName: "embedding", FieldType: redis.SearchFieldTypeVector,
+			VectorArgs: &redis.FTVectorArgs{FlatOptions: &redis.FTFlatOptions{
+				Type: "FLOAT32", Dim: s.dim, DistanceMetric: "COSINE",
+			}}},
+	).Err()
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "already exists") {
+		return nil
+	}
+	return err
+}
+
+func (s *RedisStore) redisKey(tenantID, hash string) string {
+	return keyPrefix + ":" + tenantID + ":" + hash
+}
+
+func (s *RedisStore) Put(ctx context.Context, e *Entry, ttl time.Duration) error {
+	key := s.redisKey(e.TenantID, e.Key)
+	fields := map[string]any{
+		"tenant":          e.TenantID,
+		"model":           e.Model,
+		"scoring_version": e.ScoringVersion,
+		"prompt":          e.Prompt,
+		"response":        string(e.Response),
+		"embedding":       float32sToBytes(e.Embedding),
+		"created_at":      e.CreatedAtUnix,
+		"clear_score":     e.ClearScore,
+	}
+	if err := s.rc.HSet(ctx, key, fields).Err(); err != nil {
+		return err
+	}
+	if ttl > 0 {
+		return s.rc.Expire(ctx, key, ttl).Err()
+	}
+	return nil
+}
+
+func (s *RedisStore) Search(ctx context.Context, scope Scope, vec []float32, minSimilarity float64, k int) ([]Candidate, error) {
+	if len(vec) == 0 {
+		return nil, nil
+	}
+	if k <= 0 {
+		k = 5
+	}
+	// Redis cosine DISTANCE = 1 - cosine similarity; a range query of "within
+	// radius" is the cache primitive (not KNN — KNN with no floor is a false-hit
+	// generator, §7.3). radius = 1 - minSimilarity.
+	radius := 1.0 - minSimilarity
+	query := "(@tenant:{" + escapeTag(scope.TenantID) + "} @model:{" + escapeTag(scope.Model) +
+		"} @scoring_version:{" + escapeTag(scope.ScoringVersion) +
+		"} @embedding:[VECTOR_RANGE $radius $vec]=>{$YIELD_DISTANCE_AS: dist})"
+
+	res, err := s.rc.FTSearchWithArgs(ctx, s.index, query, &redis.FTSearchOptions{
+		Return: []redis.FTSearchReturn{
+			{FieldName: "dist"}, {FieldName: "prompt"}, {FieldName: "response"},
+			{FieldName: "created_at"}, {FieldName: "clear_score"},
+			{FieldName: "tenant"}, {FieldName: "model"}, {FieldName: "scoring_version"},
+		},
+		SortBy:         []redis.FTSearchSortBy{{FieldName: "dist", Asc: true}},
+		LimitOffset:    0,
+		Limit:          k,
+		DialectVersion: 2,
+		Params:         map[string]any{"radius": radius, "vec": float32sToBytes(vec)},
+	}).Result()
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Candidate, 0, len(res.Docs))
+	for _, d := range res.Docs {
+		f := d.Fields
+		dist, _ := strconv.ParseFloat(f["dist"], 64)
+		sim := clamp01(1.0 - dist)
+		if sim < minSimilarity {
+			continue
+		}
+		createdAt, _ := strconv.ParseInt(f["created_at"], 10, 64)
+		clearScore, _ := strconv.ParseFloat(f["clear_score"], 64)
+		out = append(out, Candidate{
+			Similarity: sim,
+			Entry: &Entry{
+				Key:            d.ID,
+				Prompt:         f["prompt"],
+				Response:       []byte(f["response"]),
+				TenantID:       f["tenant"],
+				Model:          f["model"],
+				ScoringVersion: f["scoring_version"],
+				CreatedAtUnix:  createdAt,
+				ClearScore:     clearScore,
+			},
+		})
+	}
+	return out, nil
+}
+
+// PurgeTenant deletes a tenant's namespace via SCAN + DEL (RediSearch drops the
+// docs from the index on key delete).
+func (s *RedisStore) PurgeTenant(ctx context.Context, tenantID string) (int, error) {
+	pattern := keyPrefix + ":" + tenantID + ":*"
+	var cursor uint64
+	total := 0
+	for {
+		keys, next, err := s.rc.Scan(ctx, cursor, pattern, 256).Result()
+		if err != nil {
+			return total, err
+		}
+		if len(keys) > 0 {
+			if err := s.rc.Del(ctx, keys...).Err(); err != nil {
+				return total, err
+			}
+			total += len(keys)
+		}
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return total, nil
+}
+
+// float32sToBytes encodes a vector as the little-endian FLOAT32 blob RediSearch
+// expects for both storage and the query vector.
+func float32sToBytes(v []float32) []byte {
+	b := make([]byte, 4*len(v))
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(f))
+	}
+	return b
+}
+
+// escapeTag escapes RediSearch TAG special characters so a tenant/model value
+// with hyphens (UUIDs) or punctuation matches as a literal, not query syntax.
+func escapeTag(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch r {
+		case '-', '.', ':', '/', '@', '{', '}', '|', ' ', '\\', '"', '\'':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}

--- a/pkg/aiqg/semcache/redis_store_integration_test.go
+++ b/pkg/aiqg/semcache/redis_store_integration_test.go
@@ -1,0 +1,86 @@
+package semcache
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// TestRedisStore_Integration exercises the real RediSearch FLAT vector index. It
+// is skipped unless REDIS_SEMCACHE_ADDR points at a redis-stack instance (run it
+// via a port-forward to redis-semcache). Uses a throwaway index name so it never
+// collides with the production index.
+func TestRedisStore_Integration(t *testing.T) {
+	addr := os.Getenv("REDIS_SEMCACHE_ADDR")
+	if addr == "" {
+		t.Skip("set REDIS_SEMCACHE_ADDR to run the RediSearch integration test")
+	}
+	ctx := context.Background()
+	rc := redis.NewClient(&redis.Options{Addr: addr})
+	defer rc.Close()
+
+	s := &RedisStore{rc: rc, index: "aiqg_scache_itest", dim: 4}
+	_ = rc.FTDropIndex(ctx, s.index) // clean slate (ignore error)
+	if err := s.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex: %v", err)
+	}
+	// EnsureIndex must be idempotent.
+	if err := s.EnsureIndex(ctx); err != nil {
+		t.Fatalf("EnsureIndex idempotent: %v", err)
+	}
+
+	put := func(key, tenant, prompt string, vec []float32) {
+		e := &Entry{Key: key, Prompt: prompt, Response: []byte("resp-" + key), Embedding: vec,
+			TenantID: tenant, Model: "m1", ScoringVersion: "v1", CreatedAtUnix: time.Now().Unix()}
+		if err := s.Put(ctx, e, time.Hour); err != nil {
+			t.Fatalf("put %s: %v", key, err)
+		}
+	}
+	// Two near-identical vectors under t1, one orthogonal, one under t2.
+	put("a", "t1", "how do I reset my password", []float32{1, 0, 0, 0})
+	put("b", "t1", "how can I reset my password", []float32{0.99, 0.05, 0, 0})
+	put("c", "t1", "unrelated question about billing", []float32{0, 1, 0, 0})
+	put("d", "t2", "how do I reset my password", []float32{1, 0, 0, 0})
+
+	// Range search under t1 for a vector close to a/b, floor 0.9.
+	cands, err := s.Search(ctx, Scope{TenantID: "t1", Model: "m1", ScoringVersion: "v1"},
+		[]float32{1, 0, 0, 0}, 0.9, 5)
+	if err != nil {
+		t.Fatalf("search: %v", err)
+	}
+	if len(cands) < 2 {
+		t.Fatalf("expected >=2 similar candidates (a,b), got %d: %+v", len(cands), cands)
+	}
+	// Top candidate is the exact match, and the orthogonal 'c' must be excluded.
+	if cands[0].Similarity < 0.99 {
+		t.Errorf("top similarity should be ~1.0, got %.3f", cands[0].Similarity)
+	}
+	for _, c := range cands {
+		if c.Entry.Key == s.redisKey("t1", "c") {
+			t.Error("orthogonal entry c must be below the 0.9 floor")
+		}
+		if c.Entry.TenantID != "t1" {
+			t.Errorf("tenant isolation violated: got %s", c.Entry.TenantID)
+		}
+	}
+
+	// Tenant isolation: t2's identical vector must not appear for t1.
+	for _, c := range cands {
+		if c.Entry.Key == s.redisKey("t2", "d") {
+			t.Fatal("cross-tenant leak: t2 entry returned for t1 search")
+		}
+	}
+
+	// Purge scoping.
+	n, err := s.PurgeTenant(ctx, "t1")
+	if err != nil || n < 3 {
+		t.Fatalf("purge t1: n=%d err=%v", n, err)
+	}
+	if got, _ := s.Search(ctx, Scope{TenantID: "t2", Model: "m1", ScoringVersion: "v1"}, []float32{1, 0, 0, 0}, 0.9, 5); len(got) != 1 {
+		t.Errorf("purge of t1 must leave t2 intact, got %d", len(got))
+	}
+	_ = rc.FTDropIndex(ctx, s.index)
+}


### PR DESCRIPTION
The store-agnostic cascade core (#110) plugs into concrete adapters now that S0 infra exists (a dedicated `redis-semcache` = redis-stack-server with FT.*):

- **RedisStore** — production `VectorStore` on a RediSearch **FLAT COSINE DIM-384** index (§7.2/§7.3). `EnsureIndex` (idempotent `FT.CREATE`), `Put` (`HSET` + per-key `EXPIRE`), `Search` (`FT.SEARCH VECTOR_RANGE` — the *range* query is the cache primitive, not KNN), `PurgeTenant`. TAG pre-filter on tenant/model/scoring is the scope-isolation boundary; tag values escaped so UUIDs match literally.
- **OllamaEmbedder** — production `Embedder`, reusing the `all-minilm` model already deployed for payload reduction (384-dim, matches the index).

**Validated live**: the RedisStore integration test (env-gated on `REDIS_SEMCACHE_ADDR`) passes against the deployed `redis-semcache` — FLAT vector-range search, tenant isolation, and purge all work; `all-minilm` confirmed 384-dim. `nohs -race` + lint green.

Infra manifests (Redis 8 upgrade of redis-shared + the new redis-semcache) are a companion aether-shared PR. **Next**: S1 shadow wiring in `server.go` + config + gateway deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)