### PR TITLE
fix(aiqg): key response caches on the resolved tenant (not empty)

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -225,6 +225,15 @@ func handleAIQG(cfg AIQGConfig, next http.Handler, w http.ResponseWriter, r *htt
 	// by the completion handler's goroutine and read by the deferred emit.
 	reductionMeasurement := &reductionMeasurementHolder{}
 	ctx = withReductionMeasurement(ctx, reductionMeasurement)
+
+	// Stash the resolved tenant so downstream handlers (the response caches,
+	// which tenant-namespace their keys) get the AIQG-resolved tenant — it lives
+	// in the Path-A token, not security.GetAuthInfo, so extractTenantID can't
+	// find it otherwise. Empty tenant would collapse every tenant's cache into
+	// one namespace (a cross-tenant leak).
+	if resolvedToken != nil && resolvedToken.TenantID != "" {
+		ctx = withResolvedTenant(ctx, resolvedToken.TenantID)
+	}
 	if cfg.PolicyResolver != nil && resolvedToken != nil {
 		res, err := cfg.PolicyResolver.Resolve(ctx, policy.ResolveRequest{
 			TenantID:           resolvedToken.TenantID,
@@ -620,6 +629,21 @@ type reductionMeasurementCtxKey struct{}
 
 func withReductionMeasurement(ctx context.Context, h *reductionMeasurementHolder) context.Context {
 	return context.WithValue(ctx, reductionMeasurementCtxKey{}, h)
+}
+
+type resolvedTenantCtxKey struct{}
+
+func withResolvedTenant(ctx context.Context, tenantID string) context.Context {
+	return context.WithValue(ctx, resolvedTenantCtxKey{}, tenantID)
+}
+
+// ResolvedTenantFromContext returns the AIQG Path-A resolved tenant id, or ""
+// when not in AIQG mode / unresolved. Handlers that tenant-namespace state (the
+// response caches) read this because the tenant lives in the AIQG token, not
+// security.GetAuthInfo.
+func ResolvedTenantFromContext(ctx context.Context) string {
+	t, _ := ctx.Value(resolvedTenantCtxKey{}).(string)
+	return t
 }
 
 // ExpectReductionMeasurement signals that a shadow measurement goroutine has

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1061,8 +1061,14 @@ func (s *Server) writeCachedResponse(w http.ResponseWriter, entry *responsecache
 	return true
 }
 
-// extractTenantID extracts tenant ID from request context or headers.
+// extractTenantID extracts tenant ID from request context or headers. In AIQG
+// mode the tenant is resolved from the Path-A token (not security.GetAuthInfo),
+// so that resolution wins — otherwise the response caches would namespace every
+// AIQG tenant's entries under one empty-tenant key (a cross-tenant leak).
 func (s *Server) extractTenantID(r *http.Request) string {
+	if tid := middleware.ResolvedTenantFromContext(r.Context()); tid != "" {
+		return tid
+	}
 	if authInfo, ok := security.GetAuthInfo(r.Context()); ok && authInfo.Metadata != nil {
 		if tid, exists := authInfo.Metadata["tenant_id"]; exists {
 			return tid


### PR DESCRIPTION
extractTenantID returned "" for AIQG Path-A requests (tenant lives in the TAS-Auth token, not security.GetAuthInfo), so both response caches namespaced every tenant under one empty-tenant key — a latent cross-tenant leak since C1, and the reason C4's `@tenant:{}` FT.SEARCH matched nothing (silent shadow miss). The AIQG middleware now stashes the resolved tenant on the context and extractTenantID prefers it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)