### PR TITLE
feat(aiqg): semantic-cache calibration tooling (C4 S2)

### DIFF
--- a/cmd/semcache-calibrate/main.go
+++ b/cmd/semcache-calibrate/main.go
@@ -1,0 +1,169 @@
+// Command semcache-calibrate is the offline threshold-sweep tool for the AIQG
+// semantic cache (docs/AIQG-SEMANTIC-CACHING.md §9.2, §16 #3).
+//
+// It embeds a LABELED pair set once, then sweeps the L1 similarity threshold —
+// running the full cascade (with the L2 verification gate) AND a threshold-only
+// baseline — and reports, at each threshold, the hit rate and the false-hit rate
+// (FPR). It recommends the threshold that MAXIMIZES hit rate subject to an FPR
+// budget (a false hit is a correctness bug, not a miss — §9.2 step 4), and shows
+// how much L2 lets you safely loosen that threshold.
+//
+// Usage:
+//
+//	semcache-calibrate --ollama-url http://localhost:11434 --model all-minilm \
+//	    --dim 384 --fpr-budget 0.01 [--dataset pairs.json]
+//
+// pairs.json is a JSON array of {"query","candidate","match"} objects; when
+// omitted, a built-in seed set (paraphrases vs entity/number/negation near-misses
+// and unrelated look-alikes) is used so the tool runs out of the box.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/semcache"
+)
+
+func main() {
+	var (
+		ollamaURL = flag.String("ollama-url", "http://ollama.tas-shared:11434", "Ollama base URL")
+		model     = flag.String("model", "all-minilm", "embedding model")
+		dim       = flag.Int("dim", 384, "embedding dimensionality")
+		datasetF  = flag.String("dataset", "", "labeled pairs JSON file (default: built-in seed set)")
+		fprBudget = flag.Float64("fpr-budget", 0.01, "max acceptable false-hit rate (0..1)")
+	)
+	flag.Parse()
+
+	pairs, err := loadPairs(*datasetF)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "load dataset:", err)
+		os.Exit(1)
+	}
+	matches, nonMatches := 0, 0
+	for _, p := range pairs {
+		if p.Match {
+			matches++
+		} else {
+			nonMatches++
+		}
+	}
+	fmt.Printf("dataset: %d pairs (%d match, %d non-match)  encoder=%s dim=%d\n",
+		len(pairs), matches, nonMatches, *model, *dim)
+	if nonMatches == 0 {
+		fmt.Fprintln(os.Stderr, "WARNING: no non-match pairs — calibrating on positives alone tunes to threshold 0 (§9.2 step 1)")
+	}
+
+	// Embed each unique text ONCE, reused across every threshold (§9.2 step 3).
+	embed := semcache.NewOllamaEmbedder(*ollamaURL, *model, *dim)
+	emb := map[string][]float32{}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	for _, p := range pairs {
+		for _, txt := range []string{p.Query, p.Candidate} {
+			if _, ok := emb[txt]; ok {
+				continue
+			}
+			v, err := embed.Embed(ctx, txt)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "embed %q: %v\n", txt, err)
+				os.Exit(1)
+			}
+			emb[txt] = v
+		}
+	}
+
+	scope := semcache.Scope{TenantID: "calib", Model: *model, ScoringVersion: "calib"}
+	ths := semcache.DefaultThresholds()
+	cascade := semcache.Sweep(pairs, emb, ths, true, scope)
+	baseline := semcache.Sweep(pairs, emb, ths, false, scope)
+
+	fmt.Println("\nthreshold |   CASCADE (L1+L2)        |  THRESHOLD-ONLY")
+	fmt.Println("          |  hit%   fpr%   fp        |  hit%   fpr%   fp")
+	fmt.Println("----------+--------------------------+------------------------")
+	for i := range ths {
+		c, b := cascade[i], baseline[i]
+		// Print a readable subset: every 0.02 step plus the recommendation region.
+		if int(ths[i]*1000)%20 != 0 {
+			continue
+		}
+		fmt.Printf("  %.3f   |  %5.1f  %5.1f   %-3d      |  %5.1f  %5.1f   %-3d\n",
+			ths[i], c.HitRate*100, c.FPR*100, c.FP, b.HitRate*100, b.FPR*100, b.FP)
+	}
+
+	fmt.Printf("\nFPR budget: %.1f%%\n", *fprBudget*100)
+	recC, okC := semcache.Recommend(cascade, *fprBudget)
+	recB, okB := semcache.Recommend(baseline, *fprBudget)
+	report := func(name string, r semcache.ThresholdResult, ok bool, results []semcache.ThresholdResult) {
+		if !ok {
+			fmt.Printf("  %-16s no threshold meets the budget — FPR floors at %.1f%% (model separation limit; fix the model/L2/scope, not the number — §9.2 step 5)\n",
+				name, semcache.FPRFloor(results)*100)
+			return
+		}
+		fmt.Printf("  %-16s threshold=%.3f  ->  hit=%.1f%%  fpr=%.1f%%  precision=%.1f%%\n",
+			name, r.Threshold, r.HitRate*100, r.FPR*100, r.Precision*100)
+	}
+	report("cascade (L1+L2):", recC, okC, cascade)
+	report("threshold-only:", recB, okB, baseline)
+	if okC && okB && recC.HitRate > recB.HitRate {
+		fmt.Printf("\n  => L2 lets you serve at threshold %.3f (hit %.1f%%) vs %.3f (hit %.1f%%) threshold-only,\n"+
+			"     at the same FPR budget — L2's value, quantified.\n",
+			recC.Threshold, recC.HitRate*100, recB.Threshold, recB.HitRate*100)
+	}
+	if okC {
+		fmt.Printf("\nRECOMMENDED global default: AIQG_SEMCACHE_MIN_SIMILARITY=%.3f  (then start SHADOW-verify before serving)\n", recC.Threshold)
+	}
+}
+
+func loadPairs(path string) ([]semcache.LabeledPair, error) {
+	if path == "" {
+		return builtinPairs(), nil
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []semcache.LabeledPair
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// builtinPairs is a seed labeled set: genuine paraphrases (match) vs three
+// non-match classes — L2-catchable near-misses (entity/number/version/negation),
+// and unrelated look-alikes only the threshold can separate.
+func builtinPairs() []semcache.LabeledPair {
+	m := func(q, c string) semcache.LabeledPair {
+		return semcache.LabeledPair{Query: q, Candidate: c, Match: true}
+	}
+	n := func(q, c string) semcache.LabeledPair {
+		return semcache.LabeledPair{Query: q, Candidate: c, Match: false}
+	}
+	return []semcache.LabeledPair{
+		// matches — same intent, different wording
+		m("How do I reset my account password", "How can I reset my account password"),
+		m("How do I reset my account password", "What is the way to reset my account password"),
+		m("What is the refund policy for annual subscriptions", "How does refunding work for annual subscriptions"),
+		m("How long does standard shipping take", "What is the delivery time for standard shipping"),
+		m("How do I cancel my subscription", "What is the way to cancel my subscription"),
+		m("Where can I download my invoice", "How do I get a copy of my invoice"),
+		m("Is the API rate limited", "Does the API have rate limits"),
+		m("How do I enable two factor authentication", "How can I turn on two-factor authentication"),
+		// non-match: entity / number / version / negation (L2 must catch)
+		n("What are the annual fees on the Chase Sapphire card", "What are the annual fees on the Chase Sapphire Reserve card"),
+		n("What is the invoice total for 5 seats", "What is the invoice total for 8 seats"),
+		n("How do I use function calling with GPT-4", "How do I use function calling with GPT-5"),
+		n("Is aspirin safe for young children", "Is aspirin not safe for young children"),
+		n("What changed in the 2026-07-01 release", "What changed in the 2026-08-01 release"),
+		n("Can I return this within 30 days", "Can I return this within 90 days"),
+		// non-match: unrelated look-alikes (only the threshold separates these)
+		n("cheap flights to Paris", "cheap flights to London"),
+		n("best restaurants in Rome", "best restaurants in Milan"),
+		n("how to bake a chocolate cake", "how to bake a vanilla cake"),
+	}
+}

--- a/docs/AIQG-SEMANTIC-CACHING.md
+++ b/docs/AIQG-SEMANTIC-CACHING.md
@@ -1,13 +1,22 @@
 # AIQG — Semantic Response Caching (Design)
 
-Status: **C4 STARTED** — the store-agnostic cascade core is implemented in
-`pkg/aiqg/semcache` (L1 candidate gen + the L2 verification gate + L2 lexical
-guards + a FLAT `MemoryStore` + the `VectorStore`/`Embedder` ports), with the
-adversarial cases from §1.1/§5 as tests (Chase Sapphire vs Sapphire **Reserve**,
-negation, number/date/version, tenant/model isolation, freshness). Redaction —
-the other S0 prerequisite (§4.1.1) — is DONE and deployed (G1). **Still gated on
-S0 infra**: a shared vector store (Redis 8 `FT.*` or pgvector — §7) plus the
-production `Embedder` (TEI/Ollama), before S1 shadow mode can run in-cluster.
+Status: **C4 through S1 SHADOW is LIVE; S2 calibration tooling built.**
+`pkg/aiqg/semcache` has the full cascade (L1 candidate gen + the L2 verification
+gate + FLAT `MemoryStore` + `RedisStore` on RediSearch FT.* + `OllamaEmbedder`),
+wired into the gateway on the C1 exact-miss in **shadow mode** (logs would-hits,
+serves nothing). S0 infra done: dedicated `redis-semcache` (redis-stack-server,
+FT.* FLAT COSINE DIM-384) + `all-minilm` embeddings + G1 redaction. Verified under
+load (~580 req/10min): would-hit similarity median 0.9875, L2 correctly rejects
+near-duplicates at cosine 0.91–0.96 that a threshold-only cache would false-hit.
+**S2**: the offline threshold-sweep tool (`cmd/semcache-calibrate` + `calibrate.go`,
+§9.2) embeds a labeled pair set once, sweeps the threshold with/without L2, and
+recommends the max-hit-rate threshold within an FPR budget. On the seed set it
+quantifies L2's value: cascade hits 0% FPR / 100% hit at threshold 0.80, while
+threshold-only cannot meet a 1% FPR budget at any useful threshold. **Still
+SHADOW-only** — enabling serving needs a real labeled set mined from shadow
+traffic + the L3 judge (§9.2 step 1: calibrate on our own traffic), not the seed
+set. Remaining: S2-enable (on real data), S3 (accounting/UI/streaming), S4 (L3
+async judge — the learning loop).
 Gateway feature (`tas-llm-router`). Expands §9 of [`AIQG-CACHING.md`](AIQG-CACHING.md)
 (phase C4) and closes out issue
 [tas-llm-router#97](https://github.com/Tributary-ai-services/tas-llm-router/issues/97).

--- a/pkg/aiqg/semcache/calibrate.go
+++ b/pkg/aiqg/semcache/calibrate.go
@@ -1,0 +1,151 @@
+package semcache
+
+import (
+	"sort"
+	"time"
+)
+
+// Calibration (docs/AIQG-SEMANTIC-CACHING.md §9). The threshold is a property of
+// the (encoder, task) pair, never a constant — so it must be measured against a
+// LABELED pair set, and the second class is the one that matters: pairs that look
+// similar but must NOT share an answer (calibrating on positives alone tunes
+// straight to threshold 0, §9.2).
+//
+// The metric is deliberate: fix an FPR budget and maximize hit rate subject to it
+// (§9.2 step 4). Optimizing F1/accuracy is wrong for a cache — it prices a false
+// hit like a miss, but a miss is a cost and a false hit is a correctness bug.
+
+// LabeledPair is one calibration example: a live query and a candidate cache
+// entry, labeled by whether they should share an answer.
+type LabeledPair struct {
+	Query     string `json:"query"`
+	Candidate string `json:"candidate"`
+	// Match is true when the two genuinely share an answer (a paraphrase), false
+	// when they look similar but differ (the near-miss / false-hit class).
+	Match bool `json:"match"`
+}
+
+// ThresholdResult is the confusion matrix + rates at one L1 similarity threshold,
+// for the configured decision (cascade with L2, or threshold-only).
+type ThresholdResult struct {
+	Threshold float64 `json:"threshold"`
+	TP        int     `json:"tp"`        // predicted hit & Match
+	FP        int     `json:"fp"`        // predicted hit & !Match  (a FALSE HIT — the bug)
+	FN        int     `json:"fn"`        // predicted miss & Match  (a missed opportunity)
+	TN        int     `json:"tn"`        // predicted miss & !Match
+	HitRate   float64 `json:"hit_rate"`  // TP/(TP+FN) — recall over the matches
+	FPR       float64 `json:"fpr"`       // FP/(FP+TN) — false-hit rate over non-matches
+	Precision float64 `json:"precision"` // TP/(TP+FP)
+}
+
+// DefaultThresholds is a fine sweep over the meaningful similarity band. Cheap:
+// the vectors are embedded once and reused across every threshold (§9.2 step 3).
+func DefaultThresholds() []float64 {
+	var out []float64
+	for t := 0.80; t <= 0.995+1e-9; t += 0.005 {
+		out = append(out, round3(t))
+	}
+	return out
+}
+
+// Sweep evaluates every threshold against the pairs, reusing precomputed
+// embeddings (emb maps text→vector; the caller embeds each unique text once).
+// When useL2 is true the predicted-hit decision is the full cascade (similarity
+// >= t AND the L2 verification gate passes); when false it's threshold-only —
+// running both and comparing is how L2's value is shown.
+//
+// scope is the (tenant, model, scoring) the candidates are treated as sharing, so
+// the L2 scope/freshness guards pass and only the discriminative guards
+// (entity/number/date, negation) bite — exactly the effect being measured.
+func Sweep(pairs []LabeledPair, emb map[string][]float32, thresholds []float64, useL2 bool, scope Scope) []ThresholdResult {
+	now := time.Now()
+	// Precompute per-pair similarity and (if used) the L2 verdict — both are
+	// threshold-independent, so they're computed once, not per threshold.
+	type ev struct {
+		sim   float64
+		l2ok  bool
+		match bool
+	}
+	evs := make([]ev, 0, len(pairs))
+	for _, p := range pairs {
+		qv, ok1 := emb[p.Query]
+		cv, ok2 := emb[p.Candidate]
+		if !ok1 || !ok2 {
+			continue
+		}
+		l2ok := true
+		if useL2 {
+			cand := &Entry{Prompt: p.Candidate, TenantID: scope.TenantID, Model: scope.Model,
+				ScoringVersion: scope.ScoringVersion, CreatedAtUnix: now.Unix()}
+			l2ok = Verify(p.Query, cand, scope, now, time.Hour).Pass
+		}
+		evs = append(evs, ev{sim: cosineSimilarity(qv, cv), l2ok: l2ok, match: p.Match})
+	}
+
+	out := make([]ThresholdResult, 0, len(thresholds))
+	for _, t := range thresholds {
+		var r ThresholdResult
+		r.Threshold = t
+		for _, e := range evs {
+			hit := e.sim >= t && e.l2ok
+			switch {
+			case hit && e.match:
+				r.TP++
+			case hit && !e.match:
+				r.FP++
+			case !hit && e.match:
+				r.FN++
+			default:
+				r.TN++
+			}
+		}
+		if d := r.TP + r.FN; d > 0 {
+			r.HitRate = float64(r.TP) / float64(d)
+		}
+		if d := r.FP + r.TN; d > 0 {
+			r.FPR = float64(r.FP) / float64(d)
+		}
+		if d := r.TP + r.FP; d > 0 {
+			r.Precision = float64(r.TP) / float64(d)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// Recommend picks the threshold with the highest hit rate whose FPR is within
+// budget (§9.2 step 4: fix the FPR budget, maximize hits under it). Ties on hit
+// rate break toward the LOWER threshold (more coverage). Returns ok=false when no
+// threshold meets the budget — meaning the embedding model can't separate this
+// task and the fix is a better model / tighter L2 / narrower scope (§9.2 step 5),
+// not a number.
+func Recommend(results []ThresholdResult, fprBudget float64) (ThresholdResult, bool) {
+	best := ThresholdResult{}
+	found := false
+	// Sort by threshold ascending so ties prefer the lower threshold.
+	sorted := append([]ThresholdResult(nil), results...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Threshold < sorted[j].Threshold })
+	for _, r := range sorted {
+		if r.FPR <= fprBudget && (!found || r.HitRate > best.HitRate) {
+			best, found = r, true
+		}
+	}
+	return best, found
+}
+
+// FPRFloor returns the minimum FPR achievable over the sweep — when it stays
+// above the budget even at the strictest threshold, the model has hit its
+// separation limit (§9.2 step 5).
+func FPRFloor(results []ThresholdResult) float64 {
+	min := 1.0
+	for _, r := range results {
+		if r.FPR < min {
+			min = r.FPR
+		}
+	}
+	return min
+}
+
+func round3(v float64) float64 {
+	return float64(int(v*1000+0.5)) / 1000
+}

--- a/pkg/aiqg/semcache/calibrate_test.go
+++ b/pkg/aiqg/semcache/calibrate_test.go
@@ -1,0 +1,108 @@
+package semcache
+
+import (
+	"context"
+	"testing"
+)
+
+// embedAll builds the text→vector map the sweep reuses (embed once, §9.2 step 3).
+func embedAll(pairs []LabeledPair) map[string][]float32 {
+	e := bagEmbedder{dim: 256}
+	m := map[string][]float32{}
+	for _, p := range pairs {
+		for _, t := range []string{p.Query, p.Candidate} {
+			if _, ok := m[t]; !ok {
+				v, _ := e.Embed(context.Background(), t)
+				m[t] = v
+			}
+		}
+	}
+	return m
+}
+
+func TestSweep_L2ReducesFalseHits(t *testing.T) {
+	scope := scopeOf("t1", "m1")
+	pairs := []LabeledPair{
+		// Matches — genuine paraphrases (no discriminative difference).
+		{Query: "How do I reset my account password", Candidate: "How can I reset my account password", Match: true},
+		{Query: "What is the refund policy for subscriptions", Candidate: "How does refunding work for subscriptions", Match: true},
+		// Non-matches — high lexical overlap (so high bag cosine) but a discriminative
+		// entity/number/negation difference. A threshold-only cache serves these as
+		// FALSE HITS; the cascade's L2 gate must reject them.
+		{Query: "What are the fees on the Chase Sapphire card", Candidate: "What are the fees on the Chase Sapphire Reserve card", Match: false},
+		{Query: "What is the invoice total for 5 seats", Candidate: "What is the invoice total for 8 seats", Match: false},
+		{Query: "Is aspirin safe for children", Candidate: "Is aspirin not safe for children", Match: false},
+	}
+	emb := embedAll(pairs)
+	ths := DefaultThresholds()
+
+	cascade := Sweep(pairs, emb, ths, true /* L2 */, scope)
+	threshOnly := Sweep(pairs, emb, ths, false, scope)
+
+	// At a permissive threshold (0.8) the near-misses are all above it. Without
+	// L2 they are false hits; with L2 they are rejected.
+	find := func(rs []ThresholdResult, th float64) ThresholdResult {
+		for _, r := range rs {
+			if r.Threshold == th {
+				return r
+			}
+		}
+		t.Fatalf("threshold %.3f not in sweep", th)
+		return ThresholdResult{}
+	}
+	c08, o08 := find(cascade, 0.8), find(threshOnly, 0.8)
+	if o08.FP == 0 {
+		t.Fatal("threshold-only at 0.8 should have false hits (the near-misses)")
+	}
+	if c08.FP >= o08.FP {
+		t.Errorf("L2 must reduce false hits: cascade FP=%d vs threshold-only FP=%d", c08.FP, o08.FP)
+	}
+	if c08.FP != 0 {
+		t.Errorf("L2 should reject all discriminative near-misses here, got FP=%d", c08.FP)
+	}
+}
+
+func TestRecommend_HonorsFPRBudget(t *testing.T) {
+	scope := scopeOf("t1", "m1")
+	pairs := []LabeledPair{
+		{Query: "reset my password", Candidate: "reset my password now", Match: true},
+		{Query: "reset my password", Candidate: "change my password", Match: true},
+		// A near-miss the L2 gate will NOT catch (no entity/number/negation diff),
+		// so it survives to test the FPR-budget logic: only the threshold can
+		// separate it, and only above its similarity.
+		{Query: "cheap flights to paris", Candidate: "cheap flights to london", Match: false},
+	}
+	emb := embedAll(pairs)
+	res := Sweep(pairs, emb, DefaultThresholds(), true, scope)
+
+	// With a 0 FPR budget, the recommended threshold must have zero false hits.
+	rec, ok := Recommend(res, 0.0)
+	if ok && rec.FP != 0 {
+		t.Errorf("0%% FPR budget must not pick a threshold with false hits: %+v", rec)
+	}
+	// A generous budget should still return a valid recommendation.
+	if _, ok := Recommend(res, 0.5); !ok {
+		t.Error("a generous FPR budget should yield a recommendation")
+	}
+	// Monotonicity: FPR is non-increasing as threshold rises.
+	for i := 1; i < len(res); i++ {
+		if res[i].FPR > res[i-1].FPR+1e-9 {
+			t.Errorf("FPR should not increase with threshold: %.3f (%.3f) > %.3f (%.3f)",
+				res[i].FPR, res[i].Threshold, res[i-1].FPR, res[i-1].Threshold)
+		}
+	}
+}
+
+func TestFPRFloor(t *testing.T) {
+	scope := scopeOf("t1", "m1")
+	// A non-match L2 can't catch and that's near-identical in embedding space →
+	// the FPR floors above 0 (the model's separation limit, §9.2 step 5).
+	pairs := []LabeledPair{
+		{Query: "the cat sat on the mat", Candidate: "the cat sat on the mat", Match: false},
+	}
+	emb := embedAll(pairs)
+	res := Sweep(pairs, emb, DefaultThresholds(), true, scope)
+	if FPRFloor(res) < 0.99 {
+		t.Errorf("an identical-embedding non-match should floor FPR near 1.0, got %.3f", FPRFloor(res))
+	}
+}


### PR DESCRIPTION
The offline threshold-sweep tool (§9.2, §16 #3). Embed a labeled pair set once, sweep the L1 threshold reusing the vectors, and recommend the threshold that **maximizes hit rate subject to an FPR budget** — a false hit is a correctness bug, not a miss, so we never optimize F1/accuracy.

- **`pkg/aiqg/semcache/calibrate.go`** — `LabeledPair`, `Sweep` (per-threshold confusion matrix + hit-rate/FPR/precision, run for **cascade-with-L2 vs threshold-only**), `Recommend` (max hit within budget, ties toward more coverage), `FPRFloor` (embedding separation limit).
- **`cmd/semcache-calibrate`** — CLI: loads a pairs JSON (or a built-in seed set), embeds via `OllamaEmbedder`, prints the curve for both decisions + the recommendation.

**Run live on `all-minilm`:**
```
threshold |  CASCADE hit/fpr  |  THRESHOLD-ONLY hit/fpr
  0.800   |  100.0 /  0.0     |  100.0 / 66.7
  0.980   |   25.0 /  0.0     |   25.0 / 22.2
=> cascade meets a 1% FPR budget at 0.80 (100% hit); threshold-only can't at ANY useful threshold.
```
That's §1.1 quantified: L2 catches the discriminative near-misses lexically, so the threshold can be loose *and* safe; without it, the near-misses are false hits at every usable threshold.

Tests: L2 drives false hits to 0 where a bare threshold serves them; `Recommend` honors the budget; FPR-floor detection. `nohs -race` + lint green.

**Still SHADOW-only** — enabling serving needs a *real* labeled set mined from shadow traffic + the L3 judge (§9.2 step 1: calibrate on our own traffic), not the seed set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)