### PR TITLE
feat(aiqg): L3 async judge + learning loop (C4 S4)

### DIFF
--- a/docs/AIQG-SEMANTIC-CACHING.md
+++ b/docs/AIQG-SEMANTIC-CACHING.md
@@ -1,6 +1,6 @@
 # AIQG — Semantic Response Caching (Design)
 
-Status: **C4 through S1 SHADOW is LIVE; S2 calibration tooling built.**
+Status: **C4 through S1 SHADOW is LIVE; S2 + S4 tooling built (serving still OFF).**
 `pkg/aiqg/semcache` has the full cascade (L1 candidate gen + the L2 verification
 gate + FLAT `MemoryStore` + `RedisStore` on RediSearch FT.* + `OllamaEmbedder`),
 wired into the gateway on the C1 exact-miss in **shadow mode** (logs would-hits,
@@ -12,11 +12,21 @@ near-duplicates at cosine 0.91–0.96 that a threshold-only cache would false-hi
 §9.2) embeds a labeled pair set once, sweeps the threshold with/without L2, and
 recommends the max-hit-rate threshold within an FPR budget. On the seed set it
 quantifies L2's value: cascade hits 0% FPR / 100% hit at threshold 0.80, while
-threshold-only cannot meet a 1% FPR budget at any useful threshold. **Still
-SHADOW-only** — enabling serving needs a real labeled set mined from shadow
-traffic + the L3 judge (§9.2 step 1: calibrate on our own traffic), not the seed
-set. Remaining: S2-enable (on real data), S3 (accounting/UI/streaming), S4 (L3
-async judge — the learning loop).
+threshold-only cannot meet a 1% FPR budget at any useful threshold. **S4**: the
+L3 async-judge / learning loop is built in `pkg/aiqg/semcache` (`judge.go` +
+`learn.go` + `judgeloop.go`) — a bounded, off-critical-path `Loop` samples
+near-misses + would-hits in the danger band, a blind LLM `Grader` grades whether
+the cached answer is correct for the new query, and each verdict (a) records a
+`JudgedPair` to a `PairSink` — **this is the real labeled set §9.2 step 1 needs,
+mined from our own traffic**, (b) tallies the sampled false-hit rate (§14's only
+ground truth) and L2's precision, and (c) trains a vCache-style `SimCalibrator`
+(online-BCE logistic P(correct|sim)) that recommends an L1 threshold for a chosen
+FPR budget. Enqueue never blocks (drops when full — fail-open). **Still
+SHADOW-only** — the judge is opt-in recurring LLM opex (§14.1) and is not yet
+wired to run in the gateway; enabling serving needs the labeled set it produces,
+not the seed set. Remaining: wire the judge into the shadow path + a Redis
+`PairSink` (needs the opex sign-off), S2-enable (on that real data), S3
+(accounting/UI/streaming).
 Gateway feature (`tas-llm-router`). Expands §9 of [`AIQG-CACHING.md`](AIQG-CACHING.md)
 (phase C4) and closes out issue
 [tas-llm-router#97](https://github.com/Tributary-ai-services/tas-llm-router/issues/97).

--- a/pkg/aiqg/semcache/judge.go
+++ b/pkg/aiqg/semcache/judge.go
@@ -1,0 +1,174 @@
+package semcache
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"strings"
+)
+
+// L3 — the async judge (docs/AIQG-SEMANTIC-CACHING.md §5, §14.1). It runs OFF the
+// request's critical path. Near-misses (L2-rejected candidates in the danger
+// band) and would-hits are SAMPLED to a queue; an LLM judge grades, post-hoc,
+// whether the cached answer would have been correct for the new query. Its output
+// is three things at once:
+//
+//   - the LABELED PAIR SET that §9.2 calibration needs — a false hit lives in
+//     exactly this population, so this is the only way to build the second class
+//     of pairs ("looks similar, must NOT share an answer") from our own traffic;
+//   - the sampled FALSE-HIT RATE (§14) — our only ground truth for an enabled route;
+//   - the per-entry threshold-adaptation signal (§9.3, see SimCalibrator).
+//
+// It costs LLM tokens, sampled but real (§14.1) — so it is a deliberately
+// separate, opt-in stage, never on by default.
+
+// Sample is one lookup worth grading: the incoming query and the candidate the
+// cascade surfaced for it. The caller (the shadow/serve path) fills CachedAnswer
+// with the assistant text of the stored response so this package never parses
+// vendor JSON — it stays store- and schema-agnostic.
+type Sample struct {
+	Scope        Scope
+	Query        string  // post-redaction incoming prompt (the semantic key)
+	CachedPrompt string  // the candidate entry's stored prompt (Entry.Prompt)
+	CachedAnswer string  // assistant text of the candidate's stored response
+	Similarity   float64 // L1 cosine similarity of the candidate
+	// Observed is the cascade state that produced this sample: StateShadowHit /
+	// StateSemanticHit (L2 passed — a served/would-serve hit, the FPR numerator) or
+	// StateMiss (L1 candidate that L2 rejected — grades whether L2 was right).
+	Observed string
+	// RejectReason is the L2 guard that fired when Observed == StateMiss.
+	RejectReason string
+}
+
+// wouldServe reports whether this sample is one the cache would (or did) serve —
+// i.e. L2 passed. Only these count toward the sampled false-hit rate; a graded
+// L2-rejected near-miss measures L2's precision, not the cache's FPR.
+func (s Sample) wouldServe() bool {
+	return s.Observed == StateShadowHit || s.Observed == StateSemanticHit
+}
+
+// Verdict is the judge's post-hoc grade of one sample.
+type Verdict struct {
+	// Correct is true when the cached answer would correctly and completely answer
+	// the incoming query. A partially-correct or off-by-an-entity answer is false.
+	Correct bool
+	// Confidence is the judge's self-reported certainty [0,1] (0 when unknown).
+	Confidence float64
+	Reason     string
+}
+
+// Grader grades a sample. Implementations wrap an LLM call; the interface keeps
+// the loop testable and the transport (the router's own client, a direct vendor
+// call, a human queue) swappable.
+type Grader interface {
+	Grade(ctx context.Context, s Sample) (Verdict, error)
+}
+
+// GraderFunc adapts a function to Grader (for tests and simple wirings).
+type GraderFunc func(ctx context.Context, s Sample) (Verdict, error)
+
+// Grade implements Grader.
+func (f GraderFunc) Grade(ctx context.Context, s Sample) (Verdict, error) { return f(ctx, s) }
+
+// ChatFunc is a single-shot LLM call: a system + user prompt in, the model's text
+// out. The caller binds it to the router's own client at wiring time, so this
+// package depends on no server types.
+type ChatFunc func(ctx context.Context, system, user string) (string, error)
+
+// PromptGrader is the default Grader: it asks an LLM, BLIND (§14.1 step 2 — the
+// judge is not told which answer is cached vs fresh, only "does this answer this
+// question"), whether the cached answer is correct for the incoming query.
+type PromptGrader struct{ chat ChatFunc }
+
+// NewPromptGrader binds a PromptGrader to a chat transport.
+func NewPromptGrader(chat ChatFunc) *PromptGrader { return &PromptGrader{chat: chat} }
+
+const judgeSystemPrompt = `You are a strict evaluator for a response cache. You are given a USER QUESTION and a CANDIDATE ANSWER. Decide whether the candidate answer is fully correct and complete for that exact question.
+
+Rules:
+- Judge only whether the answer is correct for THIS question. Do not reward fluent but off-topic answers.
+- Any mismatch of a specific entity, product tier, number, amount, version, or date makes it INCORRECT (e.g. an answer about the base card does not answer a question about the "Reserve" tier).
+- A partial or hedged answer that omits the asked-for specifics is INCORRECT.
+- If you cannot tell, answer false.
+
+Reply with ONLY a JSON object: {"correct": <true|false>, "confidence": <0..1>, "reason": "<short>"}`
+
+// Grade implements Grader via the bound chat transport.
+func (g *PromptGrader) Grade(ctx context.Context, s Sample) (Verdict, error) {
+	if g == nil || g.chat == nil {
+		return Verdict{}, fmt.Errorf("semcache: PromptGrader has no chat transport")
+	}
+	user := fmt.Sprintf("USER QUESTION:\n%s\n\nCANDIDATE ANSWER:\n%s", s.Query, s.CachedAnswer)
+	out, err := g.chat(ctx, judgeSystemPrompt, user)
+	if err != nil {
+		return Verdict{}, err
+	}
+	return parseVerdict(out)
+}
+
+// parseVerdict reads the judge's reply. It prefers the strict JSON contract and
+// falls back to a lexical yes/no scan so a chatty model still yields a usable
+// grade rather than an error (fail toward "incorrect" — never a false hit).
+func parseVerdict(out string) (Verdict, error) {
+	if i := strings.IndexByte(out, '{'); i >= 0 {
+		if j := strings.LastIndexByte(out, '}'); j > i {
+			var raw struct {
+				Correct    bool    `json:"correct"`
+				Confidence float64 `json:"confidence"`
+				Reason     string  `json:"reason"`
+			}
+			if err := json.Unmarshal([]byte(out[i:j+1]), &raw); err == nil {
+				return Verdict{Correct: raw.Correct, Confidence: clamp01(raw.Confidence), Reason: raw.Reason}, nil
+			}
+		}
+	}
+	// Fallback: no parseable JSON. Only an explicit affirmative reads as correct.
+	l := strings.ToLower(out)
+	correct := strings.Contains(l, "\"correct\": true") ||
+		strings.HasPrefix(strings.TrimSpace(l), "true") ||
+		strings.Contains(l, "yes, ") || strings.Contains(l, "answer is correct")
+	return Verdict{Correct: correct, Reason: "parsed from non-JSON reply"}, nil
+}
+
+// SampleConfig governs which lookups are enqueued for grading (§9.2 step 2, §10.1
+// async_judge). The band is the danger zone where genuine near-dupes and true
+// near-misses overlap and only ground truth separates them.
+type SampleConfig struct {
+	// BandLo, BandHi bound the sampled similarity band (the danger zone, ~0.88–0.97).
+	BandLo, BandHi float64
+	// Rate is the fraction of eligible lookups sampled (0..1). Deterministic per
+	// (scope, query) so the same near-miss samples consistently and tests are stable.
+	Rate float64
+	// IncludeHits also samples would-hits ABOVE the band (§14.1 step 1: sample a
+	// small fraction of served semantic hits — that is the served-FPR ground truth).
+	IncludeHits bool
+}
+
+// ShouldSample decides whether a lookup with the given similarity and cascade
+// state is enqueued. It is band membership AND a deterministic rate gate.
+func (sc SampleConfig) ShouldSample(sim float64, state, dedupeKey string) bool {
+	if sc.Rate <= 0 {
+		return false
+	}
+	inBand := sim >= sc.BandLo && sim <= sc.BandHi
+	aboveBand := sim > sc.BandHi
+	served := state == StateShadowHit || state == StateSemanticHit
+	eligible := inBand || (sc.IncludeHits && aboveBand && served)
+	if !eligible {
+		return false
+	}
+	return rateGate(dedupeKey, sc.Rate)
+}
+
+// rateGate is a stable, RNG-free sampler: hash the key into [0,10000) and keep it
+// when below rate*10000. Same key ⇒ same decision (idempotent under retries, and
+// deterministic in tests).
+func rateGate(key string, rate float64) bool {
+	if rate >= 1 {
+		return true
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(key))
+	return int(h.Sum32()%10000) < int(rate*10000)
+}

--- a/pkg/aiqg/semcache/judge_test.go
+++ b/pkg/aiqg/semcache/judge_test.go
@@ -1,0 +1,270 @@
+package semcache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestParseVerdict(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantCorrect bool
+		wantConf    float64
+	}{
+		{"strict json true", `{"correct": true, "confidence": 0.9, "reason": "match"}`, true, 0.9},
+		{"strict json false", `{"correct": false, "confidence": 0.8, "reason": "wrong tier"}`, false, 0.8},
+		{"json with prose around", "Sure!\n{\"correct\": false, \"confidence\": 0.7}\nHope that helps", false, 0.7},
+		{"confidence clamped", `{"correct": true, "confidence": 5}`, true, 1.0},
+		{"non-json affirmative", "true, the answer is correct", true, 0},
+		{"non-json negative", "No — the answer is about a different plan", false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := parseVerdict(tc.in)
+			if err != nil {
+				t.Fatalf("parseVerdict: %v", err)
+			}
+			if v.Correct != tc.wantCorrect {
+				t.Errorf("Correct = %v, want %v", v.Correct, tc.wantCorrect)
+			}
+			if v.Confidence != tc.wantConf {
+				t.Errorf("Confidence = %v, want %v", v.Confidence, tc.wantConf)
+			}
+		})
+	}
+}
+
+func TestPromptGrader_BuildsBlindPrompt(t *testing.T) {
+	var gotSystem, gotUser string
+	g := NewPromptGrader(func(_ context.Context, system, user string) (string, error) {
+		gotSystem, gotUser = system, user
+		return `{"correct": false, "confidence": 0.6, "reason": "different card tier"}`, nil
+	})
+	v, err := g.Grade(context.Background(), Sample{
+		Query:        "What are the fees on the Chase Sapphire Reserve card",
+		CachedAnswer: "The Chase Sapphire card has a $95 annual fee.",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v.Correct {
+		t.Error("expected incorrect verdict for a tier mismatch")
+	}
+	// Blind: the grading prompt must carry the question + candidate answer, and
+	// must NOT reveal that the answer came from a *different* cached question.
+	if gotSystem == "" || gotUser == "" {
+		t.Fatal("grader did not build a prompt")
+	}
+	if !contains(gotUser, "Reserve") || !contains(gotUser, "$95") {
+		t.Errorf("user prompt missing question/answer content: %q", gotUser)
+	}
+	if contains(gotUser, "cached") || contains(gotUser, "similar") {
+		t.Errorf("prompt leaks cache framing (not blind): %q", gotUser)
+	}
+}
+
+func TestPromptGrader_NoTransport(t *testing.T) {
+	var g *PromptGrader
+	if _, err := g.Grade(context.Background(), Sample{}); err == nil {
+		t.Error("expected error from a grader with no chat transport")
+	}
+}
+
+func TestShouldSample(t *testing.T) {
+	sc := SampleConfig{BandLo: 0.88, BandHi: 0.97, Rate: 1.0}
+	// In band, rate 1.0 → always sampled.
+	if !sc.ShouldSample(0.90, StateMiss, "k") {
+		t.Error("in-band near-miss should sample at rate 1.0")
+	}
+	// Below band → never.
+	if sc.ShouldSample(0.80, StateMiss, "k") {
+		t.Error("below-band should not sample")
+	}
+	// Above band, IncludeHits off → not sampled even for a would-hit.
+	if sc.ShouldSample(0.99, StateShadowHit, "k") {
+		t.Error("above-band hit should not sample when IncludeHits is off")
+	}
+	// Above band, IncludeHits on + would-serve → sampled.
+	sc.IncludeHits = true
+	if !sc.ShouldSample(0.99, StateShadowHit, "k") {
+		t.Error("above-band would-hit should sample when IncludeHits is on")
+	}
+	// Above band but a MISS (L2 rejected) is not a served hit → not sampled by the hit rule.
+	if sc.ShouldSample(0.99, StateMiss, "k") {
+		t.Error("above-band L2-rejected should not sample via the hit rule")
+	}
+	// Rate 0 → never.
+	sc.Rate = 0
+	if sc.ShouldSample(0.90, StateMiss, "k") {
+		t.Error("rate 0 should never sample")
+	}
+}
+
+func TestRateGate_DeterministicAndProportional(t *testing.T) {
+	// Same key → same decision (idempotent under retries).
+	first := rateGate("stable-key", 0.5)
+	for range 100 {
+		if rateGate("stable-key", 0.5) != first {
+			t.Fatal("rateGate not deterministic for a fixed key")
+		}
+	}
+	// Rate ~0.2 over many distinct keys lands near 20%.
+	kept := 0
+	const n = 10000
+	for i := range n {
+		if rateGate(itoa(i), 0.2) {
+			kept++
+		}
+	}
+	frac := float64(kept) / n
+	if frac < 0.17 || frac > 0.23 {
+		t.Errorf("rate 0.2 kept %.3f, expected ~0.20", frac)
+	}
+	// Rate >= 1 keeps everything.
+	if !rateGate("x", 1.0) {
+		t.Error("rate 1.0 must keep")
+	}
+}
+
+// TestLoop_EndToEnd drives the full loop: a stub grader that fails would-hits
+// whose answer mentions the wrong tier, and confirms the sampled FPR + labeled
+// pairs come out right, and that a full queue drops rather than blocks.
+func TestLoop_EndToEnd(t *testing.T) {
+	var (
+		mu    sync.Mutex
+		pairs []JudgedPair
+	)
+	sink := PairSinkFunc(func(_ context.Context, p JudgedPair) error {
+		mu.Lock()
+		pairs = append(pairs, p)
+		mu.Unlock()
+		return nil
+	})
+	grader := GraderFunc(func(_ context.Context, s Sample) (Verdict, error) {
+		// Incorrect when the cached answer is about the wrong thing: the base card
+		// (a tier mismatch) or a different seat count (an entity mismatch).
+		wrong := contains(s.CachedAnswer, "base") || contains(s.CachedAnswer, "5 seats")
+		return Verdict{Correct: !wrong, Confidence: 0.9}, nil
+	})
+	loop := NewLoop(grader, sink, NewSimCalibrator(0.5, 1), 8)
+
+	go loop.Run(t.Context())
+
+	// 3 would-hits: 2 correct, 1 false hit (base-card answer).
+	loop.Enqueue(Sample{Query: "reserve fees", CachedAnswer: "reserve fee is $550", Similarity: 0.98, Observed: StateShadowHit})
+	loop.Enqueue(Sample{Query: "shipping time", CachedAnswer: "3-5 business days", Similarity: 0.97, Observed: StateShadowHit})
+	loop.Enqueue(Sample{Query: "reserve fees", CachedAnswer: "the base card fee is $95", Similarity: 0.96, Observed: StateShadowHit})
+	// 1 L2-rejected near-miss the judge agrees is wrong.
+	loop.Enqueue(Sample{Query: "8 seats total", CachedAnswer: "for 5 seats it's $50", Similarity: 0.95, Observed: StateMiss, RejectReason: "entity_number_date"})
+
+	waitFor(t, func() bool { return loop.Stats().Graded >= 4 })
+
+	st := loop.Stats()
+	if st.WouldServe != 3 || st.FalseHits != 1 {
+		t.Errorf("WouldServe=%d FalseHits=%d, want 3/1", st.WouldServe, st.FalseHits)
+	}
+	if got := st.SampledFPR(); got < 0.33 || got > 0.34 {
+		t.Errorf("SampledFPR=%.3f, want ~0.333", got)
+	}
+	if st.L2Rejected != 1 || st.L2Correct != 1 {
+		t.Errorf("L2Rejected=%d L2Correct=%d, want 1/1", st.L2Rejected, st.L2Correct)
+	}
+	if p := st.L2Precision(); p != 1.0 {
+		t.Errorf("L2Precision=%.3f, want 1.0", p)
+	}
+
+	mu.Lock()
+	np := len(pairs)
+	mu.Unlock()
+	if np != 4 {
+		t.Errorf("recorded %d labeled pairs, want 4", np)
+	}
+}
+
+func TestLoop_EnqueueDropsWhenFull(t *testing.T) {
+	// A grader that blocks so the queue can fill.
+	release := make(chan struct{})
+	grader := GraderFunc(func(_ context.Context, _ Sample) (Verdict, error) {
+		<-release
+		return Verdict{Correct: true}, nil
+	})
+	loop := NewLoop(grader, PairSinkFunc(func(context.Context, JudgedPair) error { return nil }), NewSimCalibrator(0, 0), 2)
+	go loop.Run(t.Context())
+
+	// Enqueue far more than capacity while the worker is blocked; Enqueue must
+	// never block, and the excess must be counted as dropped.
+	accepted := 0
+	for i := range 50 {
+		if loop.Enqueue(Sample{Query: itoa(i), Observed: StateShadowHit}) {
+			accepted++
+		}
+	}
+	close(release)
+	if accepted >= 50 {
+		t.Error("expected some samples to be dropped when the queue is full")
+	}
+	if loop.Stats().Dropped == 0 {
+		t.Error("expected Dropped > 0")
+	}
+}
+
+func TestLoop_NilSafe(t *testing.T) {
+	var l *Loop
+	if l.Enqueue(Sample{}) {
+		t.Error("nil loop Enqueue should return false")
+	}
+	if _, ok := l.RecommendThreshold(0.01); ok {
+		t.Error("nil loop should not recommend")
+	}
+	l.Run(context.Background()) // must not panic
+	// A loop missing a grader/sink is not ready.
+	partial := NewLoop(nil, nil, nil, 4)
+	if partial.Enqueue(Sample{}) {
+		t.Error("loop without grader/sink should drop")
+	}
+}
+
+// helpers
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	if neg {
+		b = append([]byte{'-'}, b...)
+	}
+	return string(b)
+}
+
+func waitFor(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := timeNow().Add(2 * time.Second)
+	for timeNow().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatal("condition not met before deadline")
+}

--- a/pkg/aiqg/semcache/judgeloop.go
+++ b/pkg/aiqg/semcache/judgeloop.go
@@ -1,0 +1,199 @@
+package semcache
+
+import (
+	"context"
+	"sync"
+)
+
+// JudgedPair is one graded example: a LabeledPair (the S2 calibration corpus
+// format) enriched with the scope, similarity, and the judge's confidence. The
+// Loop writes these to a PairSink; that sink IS the labeled pair set §9.2 step 1
+// asks for, mined from our own traffic.
+type JudgedPair struct {
+	LabeledPair
+	Scope      Scope   `json:"scope"`
+	Similarity float64 `json:"similarity"`
+	Confidence float64 `json:"confidence"`
+	Observed   string  `json:"observed"`      // cascade state that produced the sample
+	Reason     string  `json:"reason"`        // judge's rationale
+	AtUnix     int64   `json:"at_unix"`
+}
+
+// PairSink persists judged pairs (a Redis list, a log stream, a file). The Loop
+// never blocks on it beyond the worker goroutine; a sink error is counted and
+// dropped, never surfaced to a request.
+type PairSink interface {
+	Record(ctx context.Context, p JudgedPair) error
+}
+
+// PairSinkFunc adapts a function to PairSink.
+type PairSinkFunc func(ctx context.Context, p JudgedPair) error
+
+// Record implements PairSink.
+func (f PairSinkFunc) Record(ctx context.Context, p JudgedPair) error { return f(ctx, p) }
+
+// JudgeStats is a snapshot of the loop's counters (feeds §14 metrics).
+type JudgeStats struct {
+	Enqueued  int // samples accepted onto the queue
+	Dropped   int // samples rejected because the queue was full (off-path, never blocks)
+	Graded    int // samples the judge returned a verdict for
+	Errors    int // judge or sink errors
+	WouldServe int // graded samples where L2 passed (the FPR denominator)
+	FalseHits int // of WouldServe, judged incorrect (the FPR numerator, §14 ground truth)
+	L2Rejected int // graded samples where L2 rejected the candidate
+	L2Correct  int // of L2Rejected, judge agreed it would have been wrong (L2 earned its keep)
+}
+
+// SampledFPR is the sampled false-hit rate over would-serve samples — §14's "our
+// only ground truth". Returns 0 when nothing would-serve has been graded yet.
+func (s JudgeStats) SampledFPR() float64 {
+	if s.WouldServe == 0 {
+		return 0
+	}
+	return float64(s.FalseHits) / float64(s.WouldServe)
+}
+
+// L2Precision is the fraction of L2 rejections the judge agreed were genuinely
+// wrong — evidence L2 is rejecting real near-misses, not over-tight (§14: "if it
+// never fires, L1 is over-tight"; if it fires but is usually wrong to, it's too
+// strict). Returns 0 when no L2 rejection has been graded.
+func (s JudgeStats) L2Precision() float64 {
+	if s.L2Rejected == 0 {
+		return 0
+	}
+	return float64(s.L2Correct) / float64(s.L2Rejected)
+}
+
+// Loop is the L3 async judge, operationalized (§14.1). A single worker drains a
+// bounded queue: it grades each sample, records the labeled pair, trains the
+// per-entry threshold calibrator on would-serve verdicts, and tallies the sampled
+// FPR. Enqueue is non-blocking and lossy by design — this runs off the request
+// path, so a full queue drops the sample rather than ever slowing a request.
+type Loop struct {
+	grader Grader
+	sink   PairSink
+	cal    *SimCalibrator
+	queue  chan Sample
+
+	mu    sync.Mutex
+	stats JudgeStats
+}
+
+// NewLoop builds the judge loop. queueSize bounds the backlog (excess samples are
+// dropped and counted). A nil sink or grader yields a loop whose Enqueue is a
+// no-op drop — so a partially-configured deployment fails safe, not panicky.
+func NewLoop(grader Grader, sink PairSink, cal *SimCalibrator, queueSize int) *Loop {
+	if queueSize <= 0 {
+		queueSize = 256
+	}
+	return &Loop{
+		grader: grader,
+		sink:   sink,
+		cal:    cal,
+		queue:  make(chan Sample, queueSize),
+	}
+}
+
+func (l *Loop) ready() bool { return l != nil && l.grader != nil && l.sink != nil }
+
+// Enqueue offers a sample to the judge queue. It NEVER blocks: if the loop isn't
+// ready or the queue is full it drops the sample and returns false. Safe to call
+// from the request path (the drop is the whole point of being off it).
+func (l *Loop) Enqueue(s Sample) bool {
+	if !l.ready() {
+		return false
+	}
+	select {
+	case l.queue <- s:
+		l.bump(func(st *JudgeStats) { st.Enqueued++ })
+		return true
+	default:
+		l.bump(func(st *JudgeStats) { st.Dropped++ })
+		return false
+	}
+}
+
+// Run drains the queue until ctx is cancelled. Call once in a goroutine. Each
+// sample is graded, recorded, and folded into the stats + calibrator.
+func (l *Loop) Run(ctx context.Context) {
+	if !l.ready() {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case s := <-l.queue:
+			l.process(ctx, s)
+		}
+	}
+}
+
+func (l *Loop) process(ctx context.Context, s Sample) {
+	v, err := l.grader.Grade(ctx, s)
+	if err != nil {
+		l.bump(func(st *JudgeStats) { st.Errors++ })
+		return
+	}
+	// Tally: a would-serve sample judged incorrect is a false hit (the ground
+	// truth); an L2-rejected sample judged incorrect confirms L2 was right to
+	// reject. Only would-serve verdicts train the threshold — an L2 rejection is
+	// not a decision the L1 threshold governs.
+	l.bump(func(st *JudgeStats) {
+		st.Graded++
+		switch {
+		case s.wouldServe():
+			st.WouldServe++
+			if !v.Correct {
+				st.FalseHits++
+			}
+		case s.Observed == StateMiss:
+			st.L2Rejected++
+			if !v.Correct {
+				st.L2Correct++
+			}
+		}
+	})
+	if s.wouldServe() {
+		l.cal.Observe(s.Similarity, v.Correct)
+	}
+
+	pair := JudgedPair{
+		LabeledPair: LabeledPair{Query: s.Query, Candidate: s.CachedPrompt, Match: v.Correct},
+		Scope:       s.Scope,
+		Similarity:  s.Similarity,
+		Confidence:  v.Confidence,
+		Observed:    s.Observed,
+		Reason:      v.Reason,
+		AtUnix:      timeNow().Unix(),
+	}
+	if err := l.sink.Record(ctx, pair); err != nil {
+		l.bump(func(st *JudgeStats) { st.Errors++ })
+	}
+}
+
+// Stats returns a snapshot of the counters.
+func (l *Loop) Stats() JudgeStats {
+	if l == nil {
+		return JudgeStats{}
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.stats
+}
+
+// RecommendThreshold surfaces the calibrator's suggested L1 threshold for a
+// false-hit budget (ok=false until it has enough graded signal — see
+// SimCalibrator.RecommendThreshold).
+func (l *Loop) RecommendThreshold(fprBudget float64) (float64, bool) {
+	if l == nil {
+		return 0, false
+	}
+	return l.cal.RecommendThreshold(fprBudget)
+}
+
+func (l *Loop) bump(fn func(*JudgeStats)) {
+	l.mu.Lock()
+	fn(&l.stats)
+	l.mu.Unlock()
+}

--- a/pkg/aiqg/semcache/learn.go
+++ b/pkg/aiqg/semcache/learn.go
@@ -1,0 +1,123 @@
+package semcache
+
+import "math"
+
+// The similarity signal we care about lives in a narrow band near 1.0 (genuine
+// near-dupes cluster ~0.98, near-misses ~0.90). Fitting a logistic on raw
+// similarity there is ill-conditioned — the weight and bias are near-collinear
+// and convergence crawls. Center and scale the feature into O(1) so the fit is
+// well-behaved: feature(sim) = (sim - simCenter) * simScale.
+const (
+	simCenter = 0.90
+	simScale  = 10.0
+)
+
+func simFeature(sim float64) float64 { return (sim - simCenter) * simScale }
+
+// SimCalibrator is the adaptive-threshold mechanism (docs/AIQG-SEMANTIC-CACHING.md
+// §9.3, S4). It fits Pr(correct | similarity) online as a logistic curve —
+// sigmoid(a·sim + b) — over (similarity, correctness) pairs delivered by the L3
+// judge, and turns that fit into a recommended L1 threshold for a chosen
+// false-hit budget.
+//
+// This is vCache's mechanism, and only its mechanism. Its Pr ≥ 1−δ guarantee
+// assumes i.i.d. prompts (false for real traffic — topic drift, bursts, deploys)
+// and a truly sigmoid correctness curve; we take the online-BCE fit and the
+// FPR-budget framing and do NOT quote the bound. The recommendation is a
+// data-backed suggestion for a human to accept, not an auto-applied number.
+//
+// Not safe for concurrent use; the judge Loop owns one and calls it from its
+// single worker goroutine.
+type SimCalibrator struct {
+	a, b   float64 // logit weights: P(correct) = sigmoid(a·sim + b)
+	lr     float64 // learning rate
+	pos    int     // observed correct (would-serve, judged correct)
+	neg    int     // observed incorrect (would-serve, judged a FALSE HIT)
+	warmup int     // min of each class before RecommendThreshold will fire
+}
+
+// NewSimCalibrator returns a calibrator. lr defaults to 0.5, warmup to 20 — a
+// recommendation before ~20 graded examples of each class is noise, so it
+// abstains. a starts positive (similarity should raise P(correct)); b starts so
+// the initial crossover sits near the conservative 0.97 default (§9.3).
+func NewSimCalibrator(lr float64, warmup int) *SimCalibrator {
+	if lr <= 0 {
+		lr = 0.5
+	}
+	if warmup <= 0 {
+		warmup = 20
+	}
+	// Seed the crossover near the §9.3 prior (P≈0.5 at sim 0.97): a·feature(0.97)
+	// + b = 0 with feature(0.97)=0.7 ⇒ b = -0.7a. This only biases the first few
+	// updates; data dominates fast.
+	return &SimCalibrator{a: 1, b: -0.7, lr: lr, warmup: warmup}
+}
+
+// Observe applies one online BCE gradient step for a graded would-serve sample.
+// Only would-serve samples (L2 passed) belong here: an L2-rejected near-miss is
+// not a cache decision the threshold governs, so it must not train the curve.
+func (c *SimCalibrator) Observe(sim float64, correct bool) {
+	if c == nil {
+		return
+	}
+	y := 0.0
+	if correct {
+		y = 1.0
+		c.pos++
+	} else {
+		c.neg++
+	}
+	f := simFeature(sim)
+	p := c.Prob(sim)
+	// dL/dz = (p - y) for BCE with a sigmoid; z = a·feature + b.
+	grad := p - y
+	c.a -= c.lr * grad * f
+	c.b -= c.lr * grad
+}
+
+// Prob returns the fitted P(correct | sim) in (0,1).
+func (c *SimCalibrator) Prob(sim float64) float64 {
+	if c == nil {
+		return 0
+	}
+	return 1 / (1 + math.Exp(-(c.a*simFeature(sim) + c.b)))
+}
+
+// RecommendThreshold returns the smallest similarity whose fitted P(correct) is
+// at least 1−fprBudget — i.e. the loosest threshold that keeps the predicted
+// false-hit rate within budget (§9.2 step 4: fix the FPR budget, maximize hits
+// under it). ok is false until warmup is met in BOTH classes, or when the fitted
+// curve isn't monotonically increasing in similarity (a ≤ 0) — meaning the
+// embedding can't separate this task and the fix is the model/L2/scope, not a
+// number (§9.2 step 5).
+func (c *SimCalibrator) RecommendThreshold(fprBudget float64) (float64, bool) {
+	if c == nil || c.pos < c.warmup || c.neg < c.warmup {
+		return 0, false
+	}
+	if c.a <= 0 {
+		return 0, false
+	}
+	if fprBudget <= 0 {
+		fprBudget = 1e-6
+	}
+	target := 1 - fprBudget // required P(correct)
+	// Solve sigmoid(a·feature(s) + b) = target ⇒ feature(s) = (logit(target) − b)/a,
+	// then invert feature: s = simCenter + feature(s)/simScale.
+	f := (math.Log(target/(1-target)) - c.b) / c.a
+	s := simCenter + f/simScale
+	if s < 0 {
+		s = 0
+	}
+	if s > 1 {
+		return 1, true // even sim 1.0 doesn't clear the budget — effectively don't serve
+	}
+	return round3(s), true
+}
+
+// Counts returns the graded would-serve tallies (correct, false-hit).
+func (c *SimCalibrator) Counts() (correct, falseHit int) {
+	if c == nil {
+		return 0, 0
+	}
+	return c.pos, c.neg
+}

--- a/pkg/aiqg/semcache/learn_test.go
+++ b/pkg/aiqg/semcache/learn_test.go
@@ -1,0 +1,102 @@
+package semcache
+
+import (
+	"math"
+	"testing"
+)
+
+// TestSimCalibrator_LearnsSeparableCurve trains on data where high similarity is
+// reliably correct and low similarity reliably a false hit, then checks the fit
+// is monotone and the recommended threshold sits between the two clusters and
+// tightens as the FPR budget shrinks.
+func TestSimCalibrator_LearnsSeparableCurve(t *testing.T) {
+	c := NewSimCalibrator(0.5, 20)
+	// A clean, separable world: sim >= 0.97 correct, sim <= 0.90 a false hit.
+	for range 200 {
+		c.Observe(0.99, true)
+		c.Observe(0.985, true)
+		c.Observe(0.90, false)
+		c.Observe(0.88, false)
+	}
+	// Monotone: P(correct) rises with similarity.
+	if c.Prob(0.99) <= c.Prob(0.90) {
+		t.Errorf("Prob should increase with similarity: P(0.99)=%.3f P(0.90)=%.3f", c.Prob(0.99), c.Prob(0.90))
+	}
+	// The high cluster reads as mostly-correct, the low cluster as mostly-wrong.
+	if c.Prob(0.99) < 0.8 {
+		t.Errorf("P(correct|0.99)=%.3f, want >=0.8", c.Prob(0.99))
+	}
+	if c.Prob(0.88) > 0.2 {
+		t.Errorf("P(correct|0.88)=%.3f, want <=0.2", c.Prob(0.88))
+	}
+
+	// Recommendation lands between the clusters.
+	th, ok := c.RecommendThreshold(0.05)
+	if !ok {
+		t.Fatal("expected a recommendation after warmup")
+	}
+	if th <= 0.90 || th >= 0.99 {
+		t.Errorf("recommended threshold %.3f should sit between the clusters (0.90, 0.99)", th)
+	}
+	// A tighter budget must not recommend a looser threshold.
+	thTight, ok := c.RecommendThreshold(0.001)
+	if !ok {
+		t.Fatal("expected a recommendation for the tight budget")
+	}
+	if thTight < th-1e-9 {
+		t.Errorf("tighter FPR budget gave a looser threshold: %.3f < %.3f", thTight, th)
+	}
+}
+
+func TestSimCalibrator_AbstainsBeforeWarmup(t *testing.T) {
+	c := NewSimCalibrator(0.5, 20)
+	for range 5 {
+		c.Observe(0.99, true)
+		c.Observe(0.90, false)
+	}
+	if _, ok := c.RecommendThreshold(0.05); ok {
+		t.Error("must abstain before warmup is met in both classes")
+	}
+}
+
+func TestSimCalibrator_AbstainsWhenPositivesOnly(t *testing.T) {
+	// Calibrating on positives alone (no false hits observed) must not yield a
+	// number — it's the §9.2 "tunes straight to threshold 0" trap.
+	c := NewSimCalibrator(0.5, 20)
+	for range 100 {
+		c.Observe(0.99, true)
+	}
+	if _, ok := c.RecommendThreshold(0.05); ok {
+		t.Error("must abstain with no observed false hits (only positives)")
+	}
+}
+
+func TestSimCalibrator_CountsAndProbBounds(t *testing.T) {
+	c := NewSimCalibrator(0.5, 1)
+	c.Observe(0.99, true)
+	c.Observe(0.95, true)
+	c.Observe(0.90, false)
+	pos, neg := c.Counts()
+	if pos != 2 || neg != 1 {
+		t.Errorf("Counts = %d/%d, want 2/1", pos, neg)
+	}
+	for _, s := range []float64{0, 0.5, 0.9, 1} {
+		if p := c.Prob(s); p <= 0 || p >= 1 || math.IsNaN(p) {
+			t.Errorf("Prob(%.2f)=%v out of (0,1)", s, p)
+		}
+	}
+}
+
+func TestSimCalibrator_NilSafe(t *testing.T) {
+	var c *SimCalibrator
+	c.Observe(0.9, true) // no panic
+	if c.Prob(0.9) != 0 {
+		t.Error("nil Prob should be 0")
+	}
+	if _, ok := c.RecommendThreshold(0.05); ok {
+		t.Error("nil calibrator should not recommend")
+	}
+	if pos, neg := c.Counts(); pos != 0 || neg != 0 {
+		t.Error("nil Counts should be 0/0")
+	}
+}


### PR DESCRIPTION
The learning stage — §5 L3, §9.3, §14.1. Off the request's critical path: near-misses (L2-rejected in the danger band) and would-hits are **sampled** to a bounded queue; a **blind** LLM judge grades whether the cached answer would have been correct for the new query. Each verdict does three jobs at once:

1. **Records a labeled pair** (`JudgedPair` → `PairSink`) — this *is* the labeled set §9.2 step 1 requires, mined from our own traffic. A false hit lives in exactly this population; you cannot build the "looks similar, must NOT share an answer" class any other way. **This is what unblocks S2-enable.**
2. **Tallies the sampled false-hit rate** (§14's only ground truth) and **L2's precision** (are its rejections real, or is L1 over-tight?).
3. **Trains a vCache-style `SimCalibrator`** (online-BCE logistic `P(correct|sim)`, §9.3) that recommends an L1 threshold for a chosen FPR budget.

### Files
- **`judge.go`** — `Sample`/`Verdict`/`Grader`; `PromptGrader` builds a *blind* grade prompt (judge isn't told the answer came from a different question) + a lenient JSON/yes-no parse that fails toward "incorrect" (never toward a false hit); `SampleConfig` band + a deterministic, RNG-free, idempotent rate gate.
- **`learn.go`** — `SimCalibrator`. The feature is centered+scaled so the logistic is well-conditioned in the 0.88–0.99 band where the whole signal lives. It **abstains** before warmup, when calibrated on positives alone (the §9.2 "tunes to threshold 0" trap), and when the fitted curve isn't monotone (the embedding can't separate the task → fix the model/L2/scope, not the number, §9.2 step 5).
- **`judgeloop.go`** — `Loop` ties sampler→grader→sink→calibrator; `Enqueue` **never blocks** (drops + counts when full — off-path, fail-open); `Stats` exposes `SampledFPR` / `L2Precision` / recommended threshold.

Store- and schema-agnostic: the caller passes the cached answer text, so the package never parses vendor JSON.

### Tests
Blind prompt construction; verdict parsing (strict JSON, embedded JSON, non-JSON fallback, confidence clamp); sampling determinism + proportionality; end-to-end FPR + labeled-pair + L2-precision accounting; lossy-enqueue-under-load (never blocks); calibrator convergence, monotonicity, budget-tightening, and all three abstention paths; nil-safety throughout. `nohs -race` + lint green.

### Not turned on
**Still SHADOW-only.** The judge is recurring LLM opex (§14.1 — "budget this as permanent opex, not a launch task") and is **not yet wired** to run in the gateway. Wiring it into the shadow path + a Redis `PairSink` is the next slice, gated on that opex decision. This PR is the tested engine, not the switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)