### PR TITLE
feat(aiqg): wire the L3 judge into the gateway shadow path (C4 S4)

### DIFF
--- a/docs/AIQG-SEMANTIC-CACHING.md
+++ b/docs/AIQG-SEMANTIC-CACHING.md
@@ -24,11 +24,16 @@ ground truth) and L2's precision, and (c) trains a vCache-style `SimCalibrator`
 FPR budget. Enqueue never blocks (drops when full — fail-open), and a
 `DailyBudget` hard-caps judge spend per UTC day (`AIQG_SEMCACHE_JUDGE_DAILY_USD`,
 default **$0.50**; the loop stops grading — `BudgetSkipped` — once the cap is hit
-and resets at midnight UTC). **Still SHADOW-only** — the judge is opt-in recurring
-LLM opex (§14.1) and is not yet wired to run in the gateway; enabling serving needs the labeled set it produces,
-not the seed set. Remaining: wire the judge into the shadow path + a Redis
-`PairSink` (needs the opex sign-off), S2-enable (on that real data), S3
-(accounting/UI/streaming).
+and resets at midnight UTC). The judge is opt-in recurring LLM opex (§14.1), so
+it is **default-off** (`AIQG_SEMCACHE_JUDGE_ENABLED`); when on it is **wired into
+the shadow path** — `enqueueForJudge` samples would-hits + L2-rejected near-misses
+in the 0.88–0.97 band, the grader routes through the gateway's own client (priced
+from real token usage), labeled pairs land in the `redis-semcache` list
+`aiqg:scache:labeled_pairs`, and the loop counters (incl.
+`aiqg_semcache_judge_budget_skipped_total` — the daily-cap tripwire — and the
+sampled FPR) export on `/aiqg/metrics`. **Serving is still OFF** (cache stays
+shadow). Remaining: run the judge to accumulate a real labeled set → S2-enable on
+that data, S3 (accounting/UI/streaming).
 Gateway feature (`tas-llm-router`). Expands §9 of [`AIQG-CACHING.md`](AIQG-CACHING.md)
 (phase C4) and closes out issue
 [tas-llm-router#97](https://github.com/Tributary-ai-services/tas-llm-router/issues/97).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,17 @@ type AIQGSemCacheConfig struct {
 	// tokens are recurring opex). Default 0.50; 0 (or negative) means unlimited.
 	// When the day's cap is reached the judge stops grading until UTC midnight.
 	JudgeDailyUSD float64 `yaml:"judge_daily_usd"`
+	// JudgeEnabled turns on the L3 async judge (grades sampled near-misses/would-
+	// hits off the hot path → labeled pairs + sampled FPR). Default OFF: it is
+	// recurring LLM opex, opt-in per §14.1. Env AIQG_SEMCACHE_JUDGE_ENABLED.
+	JudgeEnabled bool `yaml:"judge_enabled"`
+	// JudgeModel is the grader model. Empty falls back to the AIQG JudgeModel.
+	// Env AIQG_SEMCACHE_JUDGE_MODEL.
+	JudgeModel string `yaml:"judge_model"`
+	// JudgeSampleRate is the fraction of eligible lookups graded (0..1). Default
+	// 1.0 — at current traffic every data point is wanted. Env
+	// AIQG_SEMCACHE_JUDGE_SAMPLE_RATE.
+	JudgeSampleRate float64 `yaml:"judge_sample_rate"`
 }
 
 // AIQGResponseCacheConfig configures the C1 response cache. Env:
@@ -675,6 +686,21 @@ func (c *Config) loadFromEnv() {
 			c.AIQG.SemCache.JudgeDailyUSD = f
 		}
 	}
+	if v := os.Getenv("AIQG_SEMCACHE_JUDGE_ENABLED"); v != "" {
+		c.AIQG.SemCache.JudgeEnabled = v == "true" || v == "1"
+	}
+	if v := os.Getenv("AIQG_SEMCACHE_JUDGE_MODEL"); v != "" {
+		c.AIQG.SemCache.JudgeModel = v
+	}
+	// Sample rate defaults to 1.0 (grade everything) unless set; env overrides.
+	if c.AIQG.SemCache.JudgeSampleRate == 0 {
+		c.AIQG.SemCache.JudgeSampleRate = 1.0
+	}
+	if v := os.Getenv("AIQG_SEMCACHE_JUDGE_SAMPLE_RATE"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			c.AIQG.SemCache.JudgeSampleRate = f
+		}
+	}
 	if u := os.Getenv("AIQG_DASHBOARD_URL"); u != "" {
 		c.AIQG.DashboardURL = u
 	}
@@ -881,9 +907,12 @@ func (c *Config) ToAIQGServerConfig() *server.AIQGServerConfig {
 			TTL:           c.AIQG.SemCache.TTL,
 			RedisURL:      c.AIQG.SemCache.RedisURL,
 			OllamaURL:     c.AIQG.SemCache.OllamaURL,
-			EmbedModel:    c.AIQG.SemCache.EmbedModel,
-			Dim:           c.AIQG.SemCache.Dim,
-			JudgeDailyUSD: c.AIQG.SemCache.JudgeDailyUSD,
+			EmbedModel:      c.AIQG.SemCache.EmbedModel,
+			Dim:             c.AIQG.SemCache.Dim,
+			JudgeDailyUSD:   c.AIQG.SemCache.JudgeDailyUSD,
+			JudgeEnabled:    c.AIQG.SemCache.JudgeEnabled,
+			JudgeModel:      c.AIQG.SemCache.JudgeModel,
+			JudgeSampleRate: c.AIQG.SemCache.JudgeSampleRate,
 		},
 	}
 	if len(c.AIQG.Tokens) > 0 {

--- a/internal/server/semjudge.go
+++ b/internal/server/semjudge.go
@@ -1,0 +1,275 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/redis/go-redis/v9"
+	"github.com/sirupsen/logrus"
+
+	"github.com/tributary-ai/llm-router-waf/internal/routing"
+	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/semcache"
+	"github.com/tributary-ai/llm-router-waf/pkg/clear"
+)
+
+// L3 judge wiring (docs/AIQG-SEMANTIC-CACHING.md §5, §14.1). This is the seam
+// between the store-agnostic semcache.Loop and the gateway: the grader is bound
+// to the router's own client (priced from real token usage), the labeled pairs
+// land in Redis, and the loop's counters are exported to Prometheus so the daily
+// budget and the sampled FPR are observable. The judge is opt-in (opex) and never
+// touches the request path — it only reads what the shadow cascade already
+// computed and enqueues it, off-latency.
+
+// The danger band sampled for grading (§9.2): near-misses here and would-hits at
+// or above it. Fixed for now; promote to config if a route needs its own band.
+const (
+	semJudgeBandLo = 0.88
+	semJudgeBandHi = 0.97
+	semJudgeQueue  = 512
+)
+
+// buildSemJudge constructs the L3 judge loop for the semantic cache, or returns
+// (nil, nil) when judging is disabled or misconfigured (no grader model). The
+// caller starts the loop's Run goroutine and enqueues samples from the shadow
+// path. scRedis is the dedicated semcache Redis (the pair sink shares it).
+func buildSemJudge(cfg AIQGSemCacheConfig, fallbackModel string, router *routing.Router, scRedis *redis.Client, log *logrus.Logger) (*semcache.Loop, semcache.SampleConfig) {
+	sampleCfg := semcache.SampleConfig{
+		BandLo:      semJudgeBandLo,
+		BandHi:      semJudgeBandHi,
+		Rate:        cfg.JudgeSampleRate,
+		IncludeHits: true, // would-hits above the band are the served-FPR ground truth
+	}
+	if !cfg.JudgeEnabled {
+		return nil, sampleCfg
+	}
+	model := cfg.JudgeModel
+	if model == "" {
+		model = fallbackModel
+	}
+	if model == "" {
+		log.Warn("AIQG semcache judge enabled but no judge model (AIQG_SEMCACHE_JUDGE_MODEL / AIQG_JUDGE_MODEL); judge disabled")
+		return nil, sampleCfg
+	}
+
+	grader := semcache.NewPromptGrader((&semJudgeGrader{router: router, model: model}).chat)
+	sink := &redisPairSink{rdb: scRedis, key: "aiqg:scache:labeled_pairs", max: 50000}
+	budget := semcache.NewDailyBudget(cfg.JudgeDailyUSD)
+	loop := semcache.NewLoop(grader, sink, semcache.NewSimCalibrator(0.5, 20), budget, semJudgeQueue)
+
+	log.WithFields(logrus.Fields{
+		"model":       model,
+		"sample_rate": cfg.JudgeSampleRate,
+		"band":        fmt.Sprintf("[%.2f,%.2f]", semJudgeBandLo, semJudgeBandHi),
+		"daily_usd":   cfg.JudgeDailyUSD,
+	}).Info("AIQG semantic-cache L3 judge enabled (off-path; grades sampled near-misses → labeled pairs + sampled FPR)")
+	return loop, sampleCfg
+}
+
+// enqueueForJudge samples one shadow lookup and, if selected, hands it to the L3
+// judge. The candidate graded is the winning entry on a would-hit, or the
+// L2-rejected near-miss on a miss. No-op when judging is disabled. Runs in the
+// shadow goroutine (already off the request path); Enqueue itself never blocks.
+func (s *Server) enqueueForJudge(scope semcache.Scope, prompt string, out semcache.Outcome) {
+	if s.semJudge == nil {
+		return
+	}
+	var cand *semcache.Entry
+	switch out.State {
+	case semcache.StateShadowHit, semcache.StateSemanticHit:
+		cand = out.Entry
+	case semcache.StateMiss:
+		cand = out.TopCandidate
+	}
+	if cand == nil {
+		return
+	}
+	if !s.semJudgeCfg.ShouldSample(out.Similarity, out.State, scope.TenantID+"|"+prompt) {
+		return
+	}
+	s.semJudge.Enqueue(semcache.Sample{
+		Scope:        scope,
+		Query:        prompt,
+		CachedPrompt: cand.Prompt,
+		CachedAnswer: answerFromResponseBytes(cand.Response),
+		Similarity:   out.Similarity,
+		Observed:     out.State,
+		RejectReason: out.RejectReason,
+	})
+}
+
+// answerFromResponseBytes pulls the assistant text out of a stored response blob
+// (a marshaled types.ChatResponse) so the judge grades the answer that would have
+// been served — keeping semcache free of the vendor response schema.
+func answerFromResponseBytes(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	var resp types.ChatResponse
+	if err := json.Unmarshal(b, &resp); err != nil {
+		return ""
+	}
+	return extractResponseContent(&resp)
+}
+
+// semJudgeGrader routes a grade prompt through the gateway's own router (the
+// configured provider key, never a customer key), matching the judge-quality
+// layer's routerCompletion, and prices the call from the vendor's reported token
+// usage — so semcache never imports a pricing table.
+type semJudgeGrader struct {
+	router *routing.Router
+	model  string
+}
+
+// chat is a semcache.ChatFunc: system+user in, (text, costUSD, err) out.
+func (g *semJudgeGrader) chat(ctx context.Context, system, user string) (string, float64, error) {
+	maxTokens := 200
+	var temp float32 // 0 → deterministic grade
+	req := &types.ChatRequest{
+		Model:       g.model,
+		MaxTokens:   &maxTokens,
+		Temperature: &temp, // deterministic grade
+		Messages: []types.Message{
+			{Role: "system", Content: system},
+			{Role: "user", Content: user},
+		},
+	}
+	_, provider, err := g.router.Route(ctx, req)
+	if err != nil {
+		return "", 0, fmt.Errorf("semjudge route: %w", err)
+	}
+	resp, err := provider.ChatCompletion(ctx, req)
+	if err != nil {
+		return "", 0, fmt.Errorf("semjudge completion: %w", err)
+	}
+	var costUSD float64
+	if resp.Usage != nil {
+		if c, ok := clear.DollarCost(provider.GetProviderName(), g.model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens); ok {
+			costUSD = c
+		}
+	}
+	return extractResponseContent(resp), costUSD, nil
+}
+
+// redisPairSink appends judged pairs to a capped Redis list — the labeled set
+// §9.2 needs, mined from live traffic. LPUSH + periodic LTRIM bounds it; a sink
+// error is returned (the loop counts it) but never reaches a request.
+type redisPairSink struct {
+	rdb *redis.Client
+	key string
+	max int64
+}
+
+// Record implements semcache.PairSink.
+func (s *redisPairSink) Record(ctx context.Context, p semcache.JudgedPair) error {
+	if s == nil || s.rdb == nil {
+		return nil
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	cctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	pipe := s.rdb.Pipeline()
+	pipe.LPush(cctx, s.key, b)
+	if s.max > 0 {
+		pipe.LTrim(cctx, s.key, 0, s.max-1) // keep the newest `max`
+	}
+	_, err = pipe.Exec(cctx)
+	return err
+}
+
+// semJudgeCollector exports the loop's in-memory counters to Prometheus on each
+// scrape (the loop owns the source of truth; this is a live view, not a mirror).
+// Registered on the AIQG registry so /aiqg/metrics carries it.
+type semJudgeCollector struct {
+	loop *semcache.Loop
+
+	graded        *prometheus.Desc
+	budgetSkipped *prometheus.Desc
+	dropped       *prometheus.Desc
+	errors        *prometheus.Desc
+	wouldServe    *prometheus.Desc
+	falseHits     *prometheus.Desc
+	l2Rejected    *prometheus.Desc
+	l2Correct     *prometheus.Desc
+	spentUSD      *prometheus.Desc
+	budgetCap     *prometheus.Desc
+	budgetSpent   *prometheus.Desc
+	budgetRemain  *prometheus.Desc
+}
+
+func newSemJudgeCollector(loop *semcache.Loop) *semJudgeCollector {
+	d := func(name, help string) *prometheus.Desc { return prometheus.NewDesc(name, help, nil, nil) }
+	return &semJudgeCollector{
+		loop:          loop,
+		graded:        d("aiqg_semcache_judge_graded_total", "L3 judge grades completed."),
+		budgetSkipped: d("aiqg_semcache_judge_budget_skipped_total", "Samples skipped because the daily judge $ cap was reached."),
+		dropped:       d("aiqg_semcache_judge_dropped_total", "Samples dropped because the judge queue was full."),
+		errors:        d("aiqg_semcache_judge_errors_total", "Judge or pair-sink errors."),
+		wouldServe:    d("aiqg_semcache_judge_would_serve_total", "Graded samples where L2 passed (the sampled-FPR denominator)."),
+		falseHits:     d("aiqg_semcache_judge_false_hits_total", "Of would-serve grades, those the judge ruled incorrect (sampled false hits)."),
+		l2Rejected:    d("aiqg_semcache_judge_l2_rejected_total", "Graded samples where L2 rejected the candidate."),
+		l2Correct:     d("aiqg_semcache_judge_l2_correct_total", "Of L2-rejected grades, those the judge agreed were wrong (L2 precision)."),
+		spentUSD:      d("aiqg_semcache_judge_spent_usd_total", "Lifetime judge spend this process (USD)."),
+		budgetCap:     d("aiqg_semcache_judge_budget_cap_usd", "Configured daily judge spend cap (USD); 0 = unlimited."),
+		budgetSpent:   d("aiqg_semcache_judge_budget_spent_usd", "Judge spend so far today (USD, resets at UTC midnight)."),
+		budgetRemain:  d("aiqg_semcache_judge_budget_remaining_usd", "Remaining judge budget today (USD)."),
+	}
+}
+
+// Describe implements prometheus.Collector.
+func (c *semJudgeCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- c.graded
+	ch <- c.budgetSkipped
+	ch <- c.dropped
+	ch <- c.errors
+	ch <- c.wouldServe
+	ch <- c.falseHits
+	ch <- c.l2Rejected
+	ch <- c.l2Correct
+	ch <- c.spentUSD
+	ch <- c.budgetCap
+	ch <- c.budgetSpent
+	ch <- c.budgetRemain
+}
+
+// Collect implements prometheus.Collector — reads the loop live on each scrape.
+func (c *semJudgeCollector) Collect(ch chan<- prometheus.Metric) {
+	st := c.loop.Stats()
+	capUSD, spent, remaining, _ := c.loop.Budget()
+	counter := func(desc *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v)
+	}
+	gauge := func(desc *prometheus.Desc, v float64) {
+		ch <- prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, v)
+	}
+	counter(c.graded, float64(st.Graded))
+	counter(c.budgetSkipped, float64(st.BudgetSkipped))
+	counter(c.dropped, float64(st.Dropped))
+	counter(c.errors, float64(st.Errors))
+	counter(c.wouldServe, float64(st.WouldServe))
+	counter(c.falseHits, float64(st.FalseHits))
+	counter(c.l2Rejected, float64(st.L2Rejected))
+	counter(c.l2Correct, float64(st.L2Correct))
+	counter(c.spentUSD, st.SpentUSD)
+	gauge(c.budgetCap, capUSD)
+	gauge(c.budgetSpent, spent)
+	gauge(c.budgetRemain, remaining)
+}
+
+// registerSemJudgeMetrics wires the collector onto the AIQG registry. Idempotent
+// enough for one call at startup; a duplicate registration is logged, not fatal.
+func registerSemJudgeMetrics(loop *semcache.Loop, log *logrus.Logger) {
+	if loop == nil {
+		return
+	}
+	if err := metrics.Registry.Register(newSemJudgeCollector(loop)); err != nil {
+		log.WithError(err).Warn("AIQG semcache judge: metric registration failed")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,11 @@ type Server struct {
 	// Nil when disabled. Runs on the C1 exact-miss path (L0→L1). In shadow mode
 	// it logs would-hits and serves nothing.
 	semCache *semcache.Cache
+	// semJudge is the C4 L3 async judge (§5, §14.1). Nil unless judging is enabled.
+	// Off the hot path: the shadow lookup enqueues sampled near-misses/would-hits
+	// and a background worker grades them → labeled pairs + sampled FPR.
+	semJudge    *semcache.Loop
+	semJudgeCfg semcache.SampleConfig
 }
 
 // ServerConfig holds server configuration
@@ -228,9 +233,12 @@ type AIQGSemCacheConfig struct {
 	TTL           time.Duration `yaml:"ttl"`
 	RedisURL      string        `yaml:"redis_url"`   // redis-semcache (redis-stack)
 	OllamaURL     string        `yaml:"ollama_url"`  // embeddings server
-	EmbedModel    string        `yaml:"embed_model"`     // all-minilm
-	Dim           int           `yaml:"dim"`             // 384
-	JudgeDailyUSD float64       `yaml:"judge_daily_usd"` // L3 judge daily $ cap (§14.1); 0 = unlimited
+	EmbedModel      string        `yaml:"embed_model"`       // all-minilm
+	Dim             int           `yaml:"dim"`               // 384
+	JudgeDailyUSD   float64       `yaml:"judge_daily_usd"`   // L3 judge daily $ cap (§14.1); 0 = unlimited
+	JudgeEnabled    bool          `yaml:"judge_enabled"`     // L3 async judge on (opt-in opex)
+	JudgeModel      string        `yaml:"judge_model"`       // grader model; empty → AIQG JudgeModel
+	JudgeSampleRate float64       `yaml:"judge_sample_rate"` // fraction of eligible lookups graded
 }
 
 // AIQGKafkaConfig configures the Kafka emitter. Brokers + topic are
@@ -433,6 +441,15 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 						"embed_model":    config.AIQG.SemCache.EmbedModel,
 						"dim":            dim,
 					}).Info("AIQG semantic cache enabled (C4 — shadow: logs would-hits, serves nothing)")
+
+					// C4 L3 judge (§5, §14.1): opt-in, off the hot path. Grades
+					// sampled near-misses/would-hits → labeled pairs (Redis) + the
+					// sampled FPR, under a hard daily $ cap. Nil when disabled.
+					server.semJudge, server.semJudgeCfg = buildSemJudge(config.AIQG.SemCache, config.AIQG.JudgeModel, router, scRedis, logger)
+					if server.semJudge != nil {
+						go server.semJudge.Run(context.Background())
+						registerSemJudgeMetrics(server.semJudge, logger)
+					}
 				}
 			}
 		}
@@ -1016,6 +1033,11 @@ func (s *Server) runSemanticShadow(ctx context.Context, req *types.ChatRequest, 
 				}).Info("aiqg semantic shadow: near-miss rejected by L2")
 			}
 		}
+		// L3 judge (§5, §14.1): off-path, opt-in. Sample would-hits (FPR ground
+		// truth) and L2-rejected near-misses (L2 precision) in the danger band and
+		// enqueue them for the async grader; Enqueue never blocks and drops when
+		// the queue is full, so this cannot slow the shadow goroutine.
+		s.enqueueForJudge(scope, prompt, out)
 	}()
 	return semcache.WithPending(ctx, &semcache.Pending{Scope: scope, Key: key, Prompt: prompt})
 }

--- a/pkg/aiqg/semcache/cascade.go
+++ b/pkg/aiqg/semcache/cascade.go
@@ -15,6 +15,10 @@ type Outcome struct {
 	State string
 	// Entry is the winning entry — set only for semantic_hit and shadow_hit.
 	Entry *Entry
+	// TopCandidate is the closest L1 candidate regardless of the L2 verdict (set
+	// whenever any candidate was generated). On a miss it carries the near-miss
+	// that L2 rejected, so the L3 judge can grade whether the rejection was right.
+	TopCandidate *Entry
 	// Similarity is the L1 cosine similarity of the top candidate considered.
 	Similarity float64
 	// Threshold is the L1 floor in force (for the event / danger-band chart).
@@ -83,7 +87,8 @@ func (c *Cache) Lookup(ctx context.Context, scope Scope, prompt string) Outcome 
 	// the strongest rejected candidate failed (for shadow analysis).
 	now := timeNow()
 	out.Similarity = cands[0].Similarity
-	out.RejectReason = "" // set below if the top candidate fails
+	out.TopCandidate = cands[0].Entry // the closest match, hit or miss (for L3)
+	out.RejectReason = ""             // set below if the top candidate fails
 	for i, cand := range cands {
 		res := Verify(prompt, cand.Entry, scope, now, c.cfg.TTL)
 		if res.Pass {


### PR DESCRIPTION
Turns the tested L3 engine on — **opt-in, default off** (`AIQG_SEMCACHE_JUDGE_ENABLED`). When enabled, the semantic-cache shadow lookup enqueues sampled **would-hits** (FPR ground truth) and **L2-rejected near-misses** (L2 precision) in the 0.88–0.97 danger band; a background worker grades them and writes labeled pairs to `redis-semcache`. Grading is recurring LLM opex (§14.1), hence default off and hard-capped by the daily budget.

### What's wired
- **`internal/server/semjudge.go`** (new):
  - `semJudgeGrader` routes the grade through the gateway's **own router** (configured provider key, never a customer key — mirrors the quality-judge `routerCompletion`) and prices it from the vendor's reported token usage via `clear.DollarCost`, so `semcache` imports no pricing table.
  - `redisPairSink` LPUSH+LTRIM a capped list `aiqg:scache:labeled_pairs` — the labeled set §9.2 needs.
  - `semJudgeCollector` exports the loop's counters live on `/aiqg/metrics`: **`aiqg_semcache_judge_budget_skipped_total`** (daily-cap tripwire), `_would_serve`/`_false_hits` (sampled FPR), `_l2_rejected`/`_l2_correct` (L2 precision), `_spent_usd`, and `_budget_{cap,spent,remaining}_usd`.
- **`server.go`** builds + `Run`s the loop and registers the collector when the semantic cache is up; `enqueueForJudge` samples one shadow outcome and hands it off — **never blocks**.
- **`semcache/cascade.go`**: `Outcome.TopCandidate` exposes the closest L1 candidate on a miss so the judge can grade the near-miss L2 rejected.
- **config**: `AIQG_SEMCACHE_JUDGE_ENABLED` (default off), `_JUDGE_MODEL` (falls back to `AIQG_JUDGE_MODEL`), `_JUDGE_SAMPLE_RATE` (default 1.0); daily cap from the existing `AIQG_SEMCACHE_JUDGE_DAILY_USD` ($0.50).

### Safety
Off the hot path throughout: enqueue is lossy, grading is async, a judge/sink failure only means no label lands. **Serving stays OFF** — the cache is still shadow. `nohs` tests + build green; the new file is lint-clean.

Grafana panel + Alertmanager rule for `budget_skipped` land in a companion `aether-shared` PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)