### PR TITLE
fix(aiqg): harden L3 judge JSON parsing (prefill + robust decode)

### DIFF
--- a/internal/server/semjudge.go
+++ b/internal/server/semjudge.go
@@ -125,18 +125,25 @@ type semJudgeGrader struct {
 	model  string
 }
 
-// chat is a semcache.ChatFunc: system+user in, (text, costUSD, err) out.
-func (g *semJudgeGrader) chat(ctx context.Context, system, user string) (string, float64, error) {
+// chat is a semcache.ChatFunc: system+user (+ optional assistant prefill) in,
+// (text, costUSD, err) out. A non-empty prefill is sent as a trailing assistant
+// turn so the model must continue from it — Anthropic honors this and returns
+// only the continuation (no opening brace), which the grader stitches back.
+func (g *semJudgeGrader) chat(ctx context.Context, system, user, prefill string) (string, float64, error) {
 	maxTokens := 200
 	var temp float32 // 0 → deterministic grade
+	msgs := []types.Message{
+		{Role: "system", Content: system},
+		{Role: "user", Content: user},
+	}
+	if prefill != "" {
+		msgs = append(msgs, types.Message{Role: "assistant", Content: prefill})
+	}
 	req := &types.ChatRequest{
 		Model:       g.model,
 		MaxTokens:   &maxTokens,
 		Temperature: &temp, // deterministic grade
-		Messages: []types.Message{
-			{Role: "system", Content: system},
-			{Role: "user", Content: user},
-		},
+		Messages:    msgs,
 	}
 	_, provider, err := g.router.Route(ctx, req)
 	if err != nil {

--- a/pkg/aiqg/semcache/judge.go
+++ b/pkg/aiqg/semcache/judge.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -79,7 +81,14 @@ func (f GraderFunc) Grade(ctx context.Context, s Sample) (Verdict, error) { retu
 // caller binds it to the router's own client at wiring time, so this package
 // depends on no server types and no pricing table. Return costUSD 0 if unknown —
 // the budget then meters by grade count only if a flat per-grade cost is set.
-type ChatFunc func(ctx context.Context, system, user string) (text string, costUSD float64, err error)
+//
+// prefill, when non-empty, is text the transport MUST seed the assistant's reply
+// with (an Anthropic-style response prefill). The grader uses it to force the
+// model to begin its answer mid-JSON ("{"), which is the reliable way to stop a
+// chatty model from wrapping the verdict in prose. A transport whose provider
+// can't prefill may ignore it — parseVerdict tolerates both the prefilled and
+// the full-object shapes.
+type ChatFunc func(ctx context.Context, system, user, prefill string) (text string, costUSD float64, err error)
 
 // PromptGrader is the default Grader: it asks an LLM, BLIND (§14.1 step 2 — the
 // judge is not told which answer is cached vs fresh, only "does this answer this
@@ -94,10 +103,17 @@ const judgeSystemPrompt = `You are a strict evaluator for a response cache. You 
 Rules:
 - Judge only whether the answer is correct for THIS question. Do not reward fluent but off-topic answers.
 - Any mismatch of a specific entity, product tier, number, amount, version, or date makes it INCORRECT (e.g. an answer about the base card does not answer a question about the "Reserve" tier).
-- A partial or hedged answer that omits the asked-for specifics is INCORRECT.
+- A partial, truncated, or hedged answer that omits the asked-for specifics is INCORRECT.
 - If you cannot tell, answer false.
 
-Reply with ONLY a JSON object: {"correct": <true|false>, "confidence": <0..1>, "reason": "<short>"}`
+Output format — follow EXACTLY:
+- Respond with a SINGLE minified JSON object and NOTHING else. No prose, no explanation, no markdown, no code fences.
+- Schema: {"correct":true|false,"confidence":0.0-1.0,"reason":"<=10 words"}
+- Example of a valid reply: {"correct":false,"confidence":0.9,"reason":"answer covers base tier, not Reserve"}`
+
+// jsonPrefill seeds the assistant reply so the model must continue mid-object —
+// the reliable way to stop a chatty model from wrapping the verdict in prose.
+const jsonPrefill = `{"correct":`
 
 // Grade implements Grader via the bound chat transport.
 func (g *PromptGrader) Grade(ctx context.Context, s Sample) (Verdict, error) {
@@ -105,9 +121,15 @@ func (g *PromptGrader) Grade(ctx context.Context, s Sample) (Verdict, error) {
 		return Verdict{}, fmt.Errorf("semcache: PromptGrader has no chat transport")
 	}
 	user := fmt.Sprintf("USER QUESTION:\n%s\n\nCANDIDATE ANSWER:\n%s", s.Query, s.CachedAnswer)
-	out, costUSD, err := g.chat(ctx, judgeSystemPrompt, user)
+	out, costUSD, err := g.chat(ctx, judgeSystemPrompt, user, jsonPrefill)
 	if err != nil {
 		return Verdict{}, err
+	}
+	// If the transport prefilled (the reply continues our "{"..."), the returned
+	// text has no opening brace — stitch the prefill back on. If it ignored the
+	// prefill and returned a whole object, leave it as-is.
+	if !strings.Contains(out, "{") {
+		out = jsonPrefill + out
 	}
 	v, err := parseVerdict(out)
 	if err != nil {
@@ -117,27 +139,50 @@ func (g *PromptGrader) Grade(ctx context.Context, s Sample) (Verdict, error) {
 	return v, nil
 }
 
-// parseVerdict reads the judge's reply. It prefers the strict JSON contract and
-// falls back to a lexical yes/no scan so a chatty model still yields a usable
-// grade rather than an error (fail toward "incorrect" — never a false hit).
+type verdictJSON struct {
+	Correct    bool    `json:"correct"`
+	Confidence float64 `json:"confidence"`
+	Reason     string  `json:"reason"`
+}
+
+var (
+	// reCorrect / reConf salvage the two decision fields from a nearly-JSON reply
+	// (trailing comma, single quotes, unterminated string) that fails strict decode.
+	// Keys may be wrapped in single or double quotes, or none.
+	reCorrect = regexp.MustCompile(`(?i)['"]?correct['"]?\s*[:=]\s*(true|false)`)
+	reConf    = regexp.MustCompile(`(?i)['"]?confidence['"]?\s*[:=]\s*([01](?:\.\d+)?)`)
+)
+
+// parseVerdict reads the judge's reply, hardened against a model that ignores the
+// JSON contract. In order: (1) decode the first JSON object found (json.Decoder
+// stops at the first complete value, so leading/trailing prose and code fences
+// around it are tolerated); (2) regex-salvage the correct/confidence fields from
+// a malformed-but-recognizable reply; (3) a last-ditch lexical scan. Every path
+// fails toward "incorrect" — a parse ambiguity must never manufacture a false hit.
 func parseVerdict(out string) (Verdict, error) {
+	// (1) First complete JSON object anywhere in the reply.
 	if i := strings.IndexByte(out, '{'); i >= 0 {
-		if j := strings.LastIndexByte(out, '}'); j > i {
-			var raw struct {
-				Correct    bool    `json:"correct"`
-				Confidence float64 `json:"confidence"`
-				Reason     string  `json:"reason"`
-			}
-			if err := json.Unmarshal([]byte(out[i:j+1]), &raw); err == nil {
-				return Verdict{Correct: raw.Correct, Confidence: clamp01(raw.Confidence), Reason: raw.Reason}, nil
-			}
+		dec := json.NewDecoder(strings.NewReader(out[i:]))
+		var raw verdictJSON
+		if err := dec.Decode(&raw); err == nil {
+			return Verdict{Correct: raw.Correct, Confidence: clamp01(raw.Confidence), Reason: raw.Reason}, nil
 		}
 	}
-	// Fallback: no parseable JSON. Only an explicit affirmative reads as correct.
+	// (2) Salvage the fields from a malformed reply that still names them.
+	if m := reCorrect.FindStringSubmatch(out); m != nil {
+		v := Verdict{Correct: strings.EqualFold(m[1], "true"), Reason: "salvaged from malformed JSON"}
+		if c := reConf.FindStringSubmatch(out); c != nil {
+			if f, err := strconv.ParseFloat(c[1], 64); err == nil {
+				v.Confidence = clamp01(f)
+			}
+		}
+		return v, nil
+	}
+	// (3) No structure at all — only an explicit affirmative reads as correct.
 	l := strings.ToLower(out)
-	correct := strings.Contains(l, "\"correct\": true") ||
-		strings.HasPrefix(strings.TrimSpace(l), "true") ||
-		strings.Contains(l, "yes, ") || strings.Contains(l, "answer is correct")
+	correct := strings.HasPrefix(strings.TrimSpace(l), "true") ||
+		strings.Contains(l, "correct\":true") || strings.Contains(l, "yes, ") ||
+		strings.Contains(l, "answer is correct")
 	return Verdict{Correct: correct, Reason: "parsed from non-JSON reply"}, nil
 }
 

--- a/pkg/aiqg/semcache/judge_test.go
+++ b/pkg/aiqg/semcache/judge_test.go
@@ -38,9 +38,9 @@ func TestParseVerdict(t *testing.T) {
 }
 
 func TestPromptGrader_BuildsBlindPrompt(t *testing.T) {
-	var gotSystem, gotUser string
-	g := NewPromptGrader(func(_ context.Context, system, user string) (string, float64, error) {
-		gotSystem, gotUser = system, user
+	var gotSystem, gotUser, gotPrefill string
+	g := NewPromptGrader(func(_ context.Context, system, user, prefill string) (string, float64, error) {
+		gotSystem, gotUser, gotPrefill = system, user, prefill
 		return `{"correct": false, "confidence": 0.6, "reason": "different card tier"}`, 0.0007, nil
 	})
 	v, err := g.Grade(context.Background(), Sample{
@@ -66,6 +66,71 @@ func TestPromptGrader_BuildsBlindPrompt(t *testing.T) {
 	}
 	if contains(gotUser, "cached") || contains(gotUser, "similar") {
 		t.Errorf("prompt leaks cache framing (not blind): %q", gotUser)
+	}
+	// The grader must ask the transport to prefill the assistant reply with JSON.
+	if gotPrefill == "" || !contains(gotPrefill, "correct") {
+		t.Errorf("grader did not pass a JSON prefill: %q", gotPrefill)
+	}
+}
+
+// TestPromptGrader_StitchesPrefill: a transport that HONORS the prefill returns
+// only the continuation (no opening brace); the grader must stitch the prefill
+// back and parse it, not fall through to the lexical scan.
+func TestPromptGrader_StitchesPrefill(t *testing.T) {
+	g := NewPromptGrader(func(_ context.Context, _, _, prefill string) (string, float64, error) {
+		// Echo the classic Anthropic prefill behavior: reply continues from prefill.
+		if prefill != `{"correct":` {
+			t.Fatalf("unexpected prefill %q", prefill)
+		}
+		return `true,"confidence":0.88,"reason":"paraphrase"}`, 0, nil
+	})
+	v, err := g.Grade(context.Background(), Sample{Query: "q", CachedAnswer: "a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !v.Correct || v.Confidence != 0.88 {
+		t.Errorf("stitched verdict wrong: %+v", v)
+	}
+	if v.Reason == "parsed from non-JSON reply" {
+		t.Error("should have parsed stitched JSON, not fallen back")
+	}
+}
+
+func TestParseVerdict_Hardened(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantCorrect bool
+		wantConf    float64
+		wantSalvage bool // reason == "salvaged from malformed JSON"
+	}{
+		{"markdown fences", "```json\n{\"correct\": false, \"confidence\": 0.9}\n```", false, 0.9, false},
+		{"leading prose + trailing prose", "Here is my verdict:\n{\"correct\": true, \"confidence\": 0.7}\nHope that helps!", true, 0.7, false},
+		{"prefill-stitched body", `{"correct":false,"confidence":0.95,"reason":"wrong tier"}`, false, 0.95, false},
+		{"trailing comma (malformed) salvaged", `{"correct": true, "confidence": 0.8,}`, true, 0.8, true},
+		{"single quotes salvaged", "{'correct': false, 'confidence': 0.6}", false, 0.6, true},
+		{"reason string with a brace", `{"correct": false, "confidence": 0.5, "reason": "not {complete}"}`, false, 0.5, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := parseVerdict(tc.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if v.Correct != tc.wantCorrect {
+				t.Errorf("Correct=%v want %v", v.Correct, tc.wantCorrect)
+			}
+			if v.Confidence != tc.wantConf {
+				t.Errorf("Confidence=%v want %v", v.Confidence, tc.wantConf)
+			}
+			salvaged := v.Reason == "salvaged from malformed JSON"
+			if salvaged != tc.wantSalvage {
+				t.Errorf("salvage path = %v, want %v (reason=%q)", salvaged, tc.wantSalvage, v.Reason)
+			}
+			if v.Reason == "parsed from non-JSON reply" {
+				t.Errorf("should not have hit the lexical fallback for %q", tc.in)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Live traffic showed **~43% of grades falling back to the lexical parser** because Haiku returned prose with *no JSON at all* — a parser tweak can't rescue a reply with nothing to extract, so this forces JSON at generation time and makes the parser robust to everything else.

### Changes
- **Assistant-turn prefill** — the grader seeds the reply with `{"correct":` via a new `ChatFunc` prefill arg (Anthropic honors a trailing assistant turn and continues from it). `semJudgeGrader` appends it as an assistant message; the grader stitches the prefill back when the transport returns only the continuation, and leaves a full object untouched when a transport ignores the prefill. `{"correct":` ends in `:` — no trailing whitespace, which Anthropic rejects.
- **Stronger system prompt** — explicit "single minified JSON object, no prose, no markdown, no fences" + a worked example.
- **`parseVerdict` rewritten in three tiers**, all failing toward "incorrect" (a parse ambiguity must never manufacture a false hit):
  1. `json.Decoder` decodes the *first complete object*, so leading/trailing prose and code fences around it are tolerated — and a `}` inside the `reason` string no longer truncates it, which the old first-`{`/last-`}` slice did.
  2. Regex salvage of `correct`/`confidence` from a malformed-but-named reply (trailing comma, single quotes).
  3. Lexical scan.

### Tests
Prefill stitching (transport returns only the continuation), plus parse cases for markdown fences, surrounding prose, a brace inside the reason string, a trailing comma, and single-quoted keys. `nohs -race` + lint green.

Deploying next as aiqg-v5.53 to measure the fallback rate drop against the ~43% baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)