### PR TITLE
feat(aiqg): per-tenant cache config resolver + semantic serve path (Track B2)

### DIFF
--- a/internal/middleware/aiqg_routing.go
+++ b/internal/middleware/aiqg_routing.go
@@ -119,6 +119,14 @@ type Routing struct {
 	cacheSavedCompletionTokens int
 	cacheSavedCostUSD          float64
 
+	// C4 semantic-hit observability (docs/AIQG-SEMANTIC-CACHING.md §13): on a
+	// cache_state=semantic_hit, the L1 cosine similarity of the served entry and
+	// the threshold that admitted it. Both zero for exact hit / miss / bypass.
+	// semantic_hit MUST stay distinguishable from hit — one is provably correct,
+	// the other probabilistic — so these travel with cache_state.
+	cacheSimilarity float64
+	cacheThreshold  float64
+
 	// experiments (Phase D): the experiment + variant that claimed this
 	// request. Stamped at request time (so the routing override + the event
 	// stamp use one decision). Empty when no experiment claimed it.
@@ -218,6 +226,10 @@ type RoutingSnapshot struct {
 	CacheSavedCompletionTokens int
 	CacheSavedCostUSD          float64
 
+	// C4 semantic-hit similarity + admitting threshold. Zero unless semantic_hit.
+	CacheSimilarity float64
+	CacheThreshold  float64
+
 	// experiments (Phase D): claiming experiment + variant. Empty when none.
 	ExperimentID      string
 	ExperimentVariant string
@@ -261,6 +273,8 @@ func (r *Routing) Snapshot() RoutingSnapshot {
 		CacheSavedPromptTokens:     r.cacheSavedPromptTokens,
 		CacheSavedCompletionTokens: r.cacheSavedCompletionTokens,
 		CacheSavedCostUSD:          r.cacheSavedCostUSD,
+		CacheSimilarity:            r.cacheSimilarity,
+		CacheThreshold:             r.cacheThreshold,
 		ExperimentID:               r.experimentID,
 		ExperimentVariant:          r.experimentVariant,
 	}
@@ -383,6 +397,21 @@ func StampCacheSavings(ctx context.Context, promptTokens, completionTokens int, 
 		r.cacheSavedPromptTokens = promptTokens
 		r.cacheSavedCompletionTokens = completionTokens
 		r.cacheSavedCostUSD = costUSD
+	}
+}
+
+// StampCacheSemantic records the L1 similarity + admitting threshold of a served
+// semantic hit (docs/AIQG-SEMANTIC-CACHING.md §13). First-write-wins.
+func StampCacheSemantic(ctx context.Context, similarity, threshold float64) {
+	r := RoutingFromContext(ctx)
+	if r == nil {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.cacheSimilarity == 0 {
+		r.cacheSimilarity = similarity
+		r.cacheThreshold = threshold
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tributary-ai/llm-router-waf/internal/types"
 	"github.com/tributary-ai/llm-router-waf/internal/workflow"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/events"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/cacheconfig"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/experiments"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/linkage"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
@@ -78,6 +79,17 @@ type Server struct {
 	// and a background worker grades them → labeled pairs + sampled FPR.
 	semJudge    *semcache.Loop
 	semJudgeCfg semcache.SampleConfig
+
+	// cacheCfgResolver resolves per-tenant cache overrides from aiqg-dashboard-be
+	// (docs/AIQG-SEMANTIC-CACHING.md §3, §10). Nil when the dashboard isn't wired,
+	// in which case every tenant uses the global defaults below. The resolver is
+	// the safe per-tenant enablement path for semantic SERVING.
+	cacheCfgResolver *cacheconfig.Resolver
+	// semGlobal* are the gateway's global C4 defaults; per-tenant overrides layer
+	// over these (nil override field = the global value).
+	semGlobalEnabled bool
+	semGlobalShadow  bool
+	semGlobalMinSim  float64
 }
 
 // ServerConfig holds server configuration
@@ -434,6 +446,11 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 						CandidateK:    5,
 						TTL:           ttl,
 					}, store, embed)
+					// Remember the global C4 defaults so per-tenant overrides can
+					// layer over them (cacheconfig resolver, below).
+					server.semGlobalEnabled = true
+					server.semGlobalShadow = config.AIQG.SemCache.Shadow
+					server.semGlobalMinSim = minSim
 					logger.WithFields(logrus.Fields{
 						"redis_addr":     opt.Addr,
 						"shadow":         config.AIQG.SemCache.Shadow,
@@ -464,6 +481,17 @@ func NewServer(router *routing.Router, config *ServerConfig, logger *logrus.Logg
 			experimentResolver = experiments.NewResolver(loader, 0) // 0 = 30s TTL default
 			logger.WithField("dashboard_url", config.AIQG.DashboardURL).
 				Info("AIQG experiments resolver enabled (Phase D)")
+		}
+
+		// Per-tenant cache-config resolver (docs/AIQG-SEMANTIC-CACHING.md §3, §10).
+		// Reuses the dashboard URL + internal auth token; polls /internal/cache-config
+		// on a TTL and applies C1/C4 overrides per request — the safe per-tenant path
+		// to opt a tenant into semantic SERVING. Nil when the dashboard isn't wired.
+		if config.AIQG.DashboardURL != "" && config.AIQG.DashboardInternalAuthToken != "" {
+			ccLoader := cacheconfig.NewHTTPLoader(config.AIQG.DashboardURL, config.AIQG.DashboardInternalAuthToken)
+			server.cacheCfgResolver = cacheconfig.NewResolver(ccLoader, 0) // 0 = 30s TTL default
+			logger.WithField("dashboard_url", config.AIQG.DashboardURL).
+				Info("AIQG per-tenant cache-config resolver enabled")
 		}
 
 		server.aiqgMiddleware = middleware.NewAIQG(middleware.AIQGConfig{
@@ -966,34 +994,44 @@ func (s *Server) maybeServeFromCache(w http.ResponseWriter, r *http.Request, req
 	}
 
 	tenantID := s.extractTenantID(r)
+	// Per-tenant overrides (nil-safe: no resolver / no row → global defaults).
+	cc := s.cacheCfgResolver.ForTenant(r.Context(), tenantID)
+	exactEnabled := cc.ExactEnabled(s.respCacheCfg.Enabled)
+
 	hash := responsecache.KeyHash(tenantID, vendor, req, events.ScoringVersion, variant)
 	middleware.StampCacheKeyHash(r.Context(), hash)
 
-	if entry, ok, err := s.respCache.Get(r.Context(), tenantID, hash); err != nil {
-		s.logger.WithError(err).WithField("request_id", req.ID).Warn("response cache lookup failed; treating as miss")
-	} else if ok {
-		// Stamp before writing: writeCachedResponse calls WriteHeader, which
-		// flushes headers, so X-TAS-Cache must be set inside it (before the flush)
-		// — not here after it.
-		if s.writeCachedResponse(w, entry) {
-			middleware.StampCacheState(r.Context(), "hit")
-			// C2: record the avoided cost — what the vendor call would have billed,
-			// priced from the cached entry's token counts (docs/AIQG-CACHING.md §6).
-			if cost, priced := clear.DollarCost(vendor, entry.Model, entry.PromptTokens, entry.CompletionTokens); priced {
+	// C1 exact-match lookup — skipped when this tenant has disabled the exact
+	// cache (per-tenant override); the request then flows to the semantic path.
+	if exactEnabled {
+		if entry, ok, err := s.respCache.Get(r.Context(), tenantID, hash); err != nil {
+			s.logger.WithError(err).WithField("request_id", req.ID).Warn("response cache lookup failed; treating as miss")
+		} else if ok {
+			// Stamp before writing: writeCachedResponse calls WriteHeader, which
+			// flushes headers, so X-TAS-Cache must be set inside it (before the flush).
+			if s.writeCachedResponse(w, entry) {
+				middleware.StampCacheState(r.Context(), "hit")
+				// C2: record the avoided cost — what the vendor call would have billed,
+				// priced from the cached entry's token counts (docs/AIQG-CACHING.md §6).
+				cost, _ := clear.DollarCost(vendor, entry.Model, entry.PromptTokens, entry.CompletionTokens)
 				middleware.StampCacheSavings(r.Context(), entry.PromptTokens, entry.CompletionTokens, cost)
-			} else {
-				middleware.StampCacheSavings(r.Context(), entry.PromptTokens, entry.CompletionTokens, 0)
+				return nil
 			}
-			return nil
+			// A corrupt/undecodable entry falls through to a live call.
 		}
-		// A corrupt/undecodable entry falls through to a live call.
 	}
 
 	middleware.StampCacheState(r.Context(), "miss")
-	// C4 (L0→L1): on the exact-match miss, run the semantic cascade. In shadow
-	// mode it embeds/searches/L2s off the latency path and only LOGS would-hits;
-	// it also stashes the store intent so the produced response is indexed.
-	ctx := s.runSemanticShadow(r.Context(), req, tenantID, hash)
+	// C4 (L0→L1) on the exact-match miss. A serve-enabled tenant gets a SYNCHRONOUS
+	// semantic-hit serve (cache_state=semantic_hit); everyone else takes the async,
+	// log-only shadow path (which also stashes the store intent).
+	if s.maybeServeSemantic(w, r, req, tenantID, vendor, cc) {
+		return nil
+	}
+	ctx := s.runSemanticShadow(r.Context(), req, tenantID, hash, cc)
+	if !exactEnabled {
+		return r.WithContext(ctx) // C1 store also disabled for this tenant
+	}
 	return r.WithContext(responsecache.WithPending(ctx, tenantID, hash))
 }
 
@@ -1001,8 +1039,8 @@ func (s *Server) maybeServeFromCache(w http.ResponseWriter, r *http.Request, req
 // prompt + scope are computed synchronously and stashed for the store; the
 // embed+search+L2 lookup runs async (off the request latency path) and logs what
 // WOULD have hit. Returns ctx carrying the store intent. No-op when disabled.
-func (s *Server) runSemanticShadow(ctx context.Context, req *types.ChatRequest, tenantID, key string) context.Context {
-	if s.semCache == nil {
+func (s *Server) runSemanticShadow(ctx context.Context, req *types.ChatRequest, tenantID, key string, cc *cacheconfig.Config) context.Context {
+	if s.semCache == nil || !cc.SemanticEnabled(s.semGlobalEnabled) {
 		return ctx
 	}
 	prompt := lastUserText(req.Messages) // the question is the semantic key
@@ -1010,13 +1048,17 @@ func (s *Server) runSemanticShadow(ctx context.Context, req *types.ChatRequest, 
 		return ctx
 	}
 	scope := semcache.Scope{TenantID: tenantID, Model: req.Model, ScoringVersion: events.ScoringVersion}
+	// Per-tenant threshold; shadow is forced on here (this is the log-only path —
+	// a serve-enabled tenant was already handled synchronously in maybeServeSemantic).
+	minSim := cc.SemanticMinSimilarity(s.semGlobalMinSim)
+	shadow := true
 
 	lctx := context.WithoutCancel(ctx)
 	reqID, model := req.ID, req.Model
 	go func() {
 		cctx, cancel := context.WithTimeout(lctx, 15*time.Second)
 		defer cancel()
-		out := s.semCache.Lookup(cctx, scope, prompt)
+		out := s.semCache.LookupWithOptions(cctx, scope, prompt, semcache.LookupOptions{Shadow: &shadow, MinSimilarity: &minSim})
 		switch out.State {
 		case semcache.StateShadowHit, semcache.StateSemanticHit:
 			s.logger.WithFields(logrus.Fields{
@@ -1073,14 +1115,69 @@ func (s *Server) storeSemantic(r *http.Request, resp *types.ChatResponse) {
 // the vendor wasn't called, so cost/latency accounting stays ~0 (§6), and the
 // cache_state=hit split lets dashboards surface the saving explicitly.
 func (s *Server) writeCachedResponse(w http.ResponseWriter, entry *responsecache.Entry) bool {
+	_, ok := writeRawCachedResponse(w, entry.Response, "hit")
+	return ok
+}
+
+// writeRawCachedResponse writes a stored response body to the client, setting the
+// X-TAS-Cache header (its value distinguishes an exact "hit" from a "semantic_hit"
+// — the header must precede WriteHeader, which flushes headers). It returns the
+// decoded response (so the caller can read Usage for savings) and false when the
+// body can't be decoded, so the caller falls through to a live vendor call.
+func writeRawCachedResponse(w http.ResponseWriter, body []byte, cacheHeader string) (*types.ChatResponse, bool) {
 	var resp types.ChatResponse
-	if err := json.Unmarshal(entry.Response, &resp); err != nil {
-		return false
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, false
 	}
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-TAS-Cache", "hit") // must precede WriteHeader (it flushes headers)
+	w.Header().Set("X-TAS-Cache", cacheHeader)
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(&resp)
+	return &resp, true
+}
+
+// maybeServeSemantic serves a C4 semantic hit when the tenant is serve-enabled
+// (Semantic.Enabled && !Shadow). Returns true when it served (caller stops).
+// Unlike the shadow path, this runs the cascade SYNCHRONOUSLY — serving puts
+// the ~30ms embed+search on the request path, which the design (§6) accepts.
+// Reaches here only on a C1 exact miss, so the request is already C1-eligible
+// (deterministic, non-streaming, no tools — inherited from responsecache.Decide).
+func (s *Server) maybeServeSemantic(w http.ResponseWriter, r *http.Request, req *types.ChatRequest, tenantID, vendor string, cc *cacheconfig.Config) bool {
+	if s.semCache == nil || !cc.SemanticEnabled(s.semGlobalEnabled) {
+		return false
+	}
+	if cc.SemanticShadow(s.semGlobalShadow) {
+		return false // shadow tenants take the async, log-only path
+	}
+	prompt := lastUserText(req.Messages)
+	if prompt == "" {
+		return false
+	}
+	scope := semcache.Scope{TenantID: tenantID, Model: req.Model, ScoringVersion: events.ScoringVersion}
+	minSim := cc.SemanticMinSimilarity(s.semGlobalMinSim)
+	serve := false // Shadow=false → a passing L2 candidate is a semantic_hit
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	out := s.semCache.LookupWithOptions(ctx, scope, prompt, semcache.LookupOptions{Shadow: &serve, MinSimilarity: &minSim})
+	if out.State != semcache.StateSemanticHit || out.Entry == nil {
+		// Not a hit — hand the near-miss/would-hit to the judge (FPR signal) and
+		// let the caller fall through to a live vendor call + store.
+		s.enqueueForJudge(scope, prompt, out)
+		return false
+	}
+	resp, ok := writeRawCachedResponse(w, out.Entry.Response, semcache.StateSemanticHit)
+	if !ok {
+		return false // corrupt entry → fall through to a live call
+	}
+	middleware.StampCacheState(r.Context(), semcache.StateSemanticHit)
+	middleware.StampCacheSemantic(r.Context(), out.Similarity, out.Threshold)
+	// Savings — a probabilistic saving, reported separately from exact hits (§13).
+	if resp.Usage != nil {
+		cost, _ := clear.DollarCost(vendor, out.Entry.Model, resp.Usage.PromptTokens, resp.Usage.CompletionTokens)
+		middleware.StampCacheSavings(r.Context(), resp.Usage.PromptTokens, resp.Usage.CompletionTokens, cost)
+	}
+	// Grade served hits too — that is the sampled-FPR ground truth (§14.1).
+	s.enqueueForJudge(scope, prompt, out)
 	return true
 }
 

--- a/pkg/aiqg/cacheconfig/cacheconfig.go
+++ b/pkg/aiqg/cacheconfig/cacheconfig.go
@@ -1,0 +1,169 @@
+// Package cacheconfig resolves per-tenant cache overrides from aiqg-dashboard-be
+// and applies them over the gateway's global cache defaults. It is the safe,
+// per-tenant enablement path for C4 semantic SERVING (a global flip would turn
+// probabilistic hits on for everyone at once). Mirrors pkg/aiqg/experiments: a
+// TTL cache over an HTTP loader against the dashboard's /internal endpoint.
+//
+// The governing rule everywhere: a nil field means "use the gateway's global
+// default", so a tenant can override just one knob and inherit the rest.
+package cacheconfig
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Config is a tenant's resolved cache overrides (mirrors the dashboard-be
+// aiqg.cache_config spec). Every field is a pointer so absent = global default.
+type Config struct {
+	Exact    *ExactConfig    `json:"exact,omitempty"`
+	Semantic *SemanticConfig `json:"semantic,omitempty"`
+	Judge    *JudgeConfig    `json:"judge,omitempty"`
+}
+
+// ExactConfig overrides the C1 exact-match response cache.
+type ExactConfig struct {
+	Enabled    *bool `json:"enabled,omitempty"`
+	TTLSeconds *int  `json:"ttl_seconds,omitempty"`
+}
+
+// SemanticConfig overrides the C4 semantic cache. Shadow=false means SERVE
+// (probabilistic hits) — the correctness-sensitive opt-in.
+type SemanticConfig struct {
+	Enabled       *bool    `json:"enabled,omitempty"`
+	Shadow        *bool    `json:"shadow,omitempty"`
+	MinSimilarity *float64 `json:"min_similarity,omitempty"`
+}
+
+// JudgeConfig overrides the C4 L3 async-judge sampling for this tenant.
+type JudgeConfig struct {
+	Enabled    *bool    `json:"enabled,omitempty"`
+	SampleRate *float64 `json:"sample_rate,omitempty"`
+	DailyUSD   *float64 `json:"daily_usd,omitempty"`
+}
+
+// --- effective-value helpers: apply a tenant override over a global default ---
+
+// ExactEnabled returns the effective C1 on/off for this tenant.
+func (c *Config) ExactEnabled(global bool) bool {
+	if c != nil && c.Exact != nil && c.Exact.Enabled != nil {
+		return *c.Exact.Enabled
+	}
+	return global
+}
+
+// ExactTTL returns the effective C1 TTL, or the global default when unset/invalid.
+func (c *Config) ExactTTL(global time.Duration) time.Duration {
+	if c != nil && c.Exact != nil && c.Exact.TTLSeconds != nil && *c.Exact.TTLSeconds > 0 {
+		return time.Duration(*c.Exact.TTLSeconds) * time.Second
+	}
+	return global
+}
+
+// SemanticEnabled returns the effective C4 on/off (whether the cascade runs at all).
+func (c *Config) SemanticEnabled(global bool) bool {
+	if c != nil && c.Semantic != nil && c.Semantic.Enabled != nil {
+		return *c.Semantic.Enabled
+	}
+	return global
+}
+
+// SemanticShadow returns the effective shadow mode. True = log-only (serve
+// nothing); false = SERVE semantic hits. The global default is shadow (safe).
+func (c *Config) SemanticShadow(global bool) bool {
+	if c != nil && c.Semantic != nil && c.Semantic.Shadow != nil {
+		return *c.Semantic.Shadow
+	}
+	return global
+}
+
+// SemanticMinSimilarity returns the effective L1 threshold. A per-request
+// override may only TIGHTEN (raise) the floor — a tenant must not be able to
+// widen its own false-hit rate (§10.2) — so the max of override and global wins.
+func (c *Config) SemanticMinSimilarity(global float64) float64 {
+	if c != nil && c.Semantic != nil && c.Semantic.MinSimilarity != nil {
+		if v := *c.Semantic.MinSimilarity; v > global {
+			return v
+		}
+	}
+	return global
+}
+
+// JudgeEnabled returns the effective L3-judge on/off for this tenant.
+func (c *Config) JudgeEnabled(global bool) bool {
+	if c != nil && c.Judge != nil && c.Judge.Enabled != nil {
+		return *c.Judge.Enabled
+	}
+	return global
+}
+
+// JudgeSampleRate returns the effective judge sample rate.
+func (c *Config) JudgeSampleRate(global float64) float64 {
+	if c != nil && c.Judge != nil && c.Judge.SampleRate != nil {
+		return *c.Judge.SampleRate
+	}
+	return global
+}
+
+// Loader fetches a tenant's cache config. Implementations wrap the dashboard's
+// internal endpoint; the interface keeps the resolver testable.
+type Loader interface {
+	ForTenant(ctx context.Context, tenantID string) (*Config, error)
+}
+
+// Resolver caches each tenant's config (TTL). Bounds dashboard load and the
+// worst-case staleness after an edit. Nil-safe: a nil *Resolver returns a nil
+// Config (all global defaults), so callers need no branch.
+type Resolver struct {
+	loader Loader
+	ttl    time.Duration
+	mu     sync.Mutex
+	cache  map[string]cacheEntry
+	now    func() time.Time // injectable for tests
+}
+
+type cacheEntry struct {
+	cfg       *Config
+	expiresAt time.Time
+}
+
+// NewResolver wraps a Loader with a TTL cache. ttl<=0 defaults to 30s (matches
+// the experiments + policy kill-switch propagation target).
+func NewResolver(loader Loader, ttl time.Duration) *Resolver {
+	if ttl <= 0 {
+		ttl = 30 * time.Second
+	}
+	return &Resolver{loader: loader, ttl: ttl, cache: map[string]cacheEntry{}, now: time.Now}
+}
+
+// ForTenant returns the tenant's cache config, or nil when none is set / the
+// tenant is empty / the dashboard is unreachable and nothing is cached. It NEVER
+// fails — a broken config path degrades to the gateway's global defaults, never
+// to a wrong cache decision. A nil return is a valid "all defaults" answer.
+func (r *Resolver) ForTenant(ctx context.Context, tenantID string) *Config {
+	if r == nil || tenantID == "" {
+		return nil
+	}
+	now := r.now()
+	r.mu.Lock()
+	if e, ok := r.cache[tenantID]; ok && now.Before(e.expiresAt) {
+		cfg := e.cfg
+		r.mu.Unlock()
+		return cfg
+	}
+	r.mu.Unlock()
+
+	cfg, err := r.loader.ForTenant(ctx, tenantID)
+	if err != nil {
+		// Degrade: serve any stale cache, else nil (global defaults). Never fail.
+		r.mu.Lock()
+		stale := r.cache[tenantID].cfg
+		r.mu.Unlock()
+		return stale
+	}
+	r.mu.Lock()
+	r.cache[tenantID] = cacheEntry{cfg: cfg, expiresAt: now.Add(r.ttl)}
+	r.mu.Unlock()
+	return cfg
+}

--- a/pkg/aiqg/cacheconfig/cacheconfig_test.go
+++ b/pkg/aiqg/cacheconfig/cacheconfig_test.go
@@ -1,0 +1,135 @@
+package cacheconfig
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type fakeLoader struct {
+	calls int
+	cfg   *Config
+	err   error
+}
+
+func (f *fakeLoader) ForTenant(_ context.Context, _ string) (*Config, error) {
+	f.calls++
+	return f.cfg, f.err
+}
+
+func bptr(b bool) *bool       { return &b }
+func fptr(f float64) *float64 { return &f }
+func iptr(i int) *int         { return &i }
+
+func TestEffectiveHelpers_NilConfigUsesGlobal(t *testing.T) {
+	var c *Config
+	if !c.ExactEnabled(true) {
+		t.Error("nil config should defer to global true")
+	}
+	if c.SemanticShadow(true) != true {
+		t.Error("nil config should defer to global shadow=true")
+	}
+	if c.SemanticMinSimilarity(0.95) != 0.95 {
+		t.Error("nil config should defer to global threshold")
+	}
+	if c.ExactTTL(30*time.Second) != 30*time.Second {
+		t.Error("nil config should defer to global TTL")
+	}
+}
+
+func TestEffectiveHelpers_OverrideComposes(t *testing.T) {
+	// Only semantic.shadow is set; everything else must fall back to global.
+	c := &Config{Semantic: &SemanticConfig{Enabled: bptr(true), Shadow: bptr(false)}}
+	if !c.SemanticEnabled(false) {
+		t.Error("semantic.enabled override should win")
+	}
+	if c.SemanticShadow(true) {
+		t.Error("semantic.shadow=false override should win (serving)")
+	}
+	// min_similarity unset → global.
+	if c.SemanticMinSimilarity(0.97) != 0.97 {
+		t.Error("unset threshold should fall back to global")
+	}
+	// exact unset → global.
+	if !c.ExactEnabled(true) {
+		t.Error("unset exact should fall back to global")
+	}
+}
+
+func TestSemanticMinSimilarity_OnlyTightens(t *testing.T) {
+	// A looser override (below the global floor) must NOT widen the FPR (§10.2).
+	loose := &Config{Semantic: &SemanticConfig{MinSimilarity: fptr(0.80)}}
+	if got := loose.SemanticMinSimilarity(0.95); got != 0.95 {
+		t.Errorf("loose override should be clamped to global: got %v want 0.95", got)
+	}
+	// A tighter override raises the floor.
+	tight := &Config{Semantic: &SemanticConfig{MinSimilarity: fptr(0.99)}}
+	if got := tight.SemanticMinSimilarity(0.95); got != 0.99 {
+		t.Errorf("tighter override should win: got %v want 0.99", got)
+	}
+}
+
+func TestExactTTL_Override(t *testing.T) {
+	c := &Config{Exact: &ExactConfig{TTLSeconds: iptr(600)}}
+	if got := c.ExactTTL(30 * time.Second); got != 600*time.Second {
+		t.Errorf("ttl override: got %v want 600s", got)
+	}
+	// Zero/absent → global.
+	zero := &Config{Exact: &ExactConfig{TTLSeconds: iptr(0)}}
+	if got := zero.ExactTTL(30 * time.Second); got != 30*time.Second {
+		t.Errorf("zero ttl should fall back to global: got %v", got)
+	}
+}
+
+func TestResolver_CachesWithinTTL(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	f := &fakeLoader{cfg: &Config{Semantic: &SemanticConfig{Enabled: bptr(true)}}}
+	r := NewResolver(f, time.Minute)
+	r.now = func() time.Time { return now }
+
+	_ = r.ForTenant(context.Background(), "t1")
+	_ = r.ForTenant(context.Background(), "t1")
+	if f.calls != 1 {
+		t.Errorf("expected 1 loader call within TTL, got %d", f.calls)
+	}
+	// After TTL expiry it reloads.
+	now = now.Add(2 * time.Minute)
+	_ = r.ForTenant(context.Background(), "t1")
+	if f.calls != 2 {
+		t.Errorf("expected a reload after TTL, got %d calls", f.calls)
+	}
+}
+
+func TestResolver_DegradesToStaleOnError(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	good := &Config{Semantic: &SemanticConfig{Shadow: bptr(false)}}
+	f := &fakeLoader{cfg: good}
+	r := NewResolver(f, time.Minute)
+	r.now = func() time.Time { return now }
+
+	if got := r.ForTenant(context.Background(), "t1"); got != good {
+		t.Fatal("first load should return the good config")
+	}
+	// TTL expires and the loader now errors → serve the stale cached config.
+	now = now.Add(2 * time.Minute)
+	f.err = errors.New("dashboard down")
+	if got := r.ForTenant(context.Background(), "t1"); got != good {
+		t.Error("on loader error, resolver must degrade to the stale config, not fail")
+	}
+}
+
+func TestResolver_NilSafeAndEmptyTenant(t *testing.T) {
+	var r *Resolver
+	if r.ForTenant(context.Background(), "t1") != nil {
+		t.Error("nil resolver should return nil (global defaults)")
+	}
+	f := &fakeLoader{cfg: &Config{}}
+	r2 := NewResolver(f, time.Minute)
+	if r2.ForTenant(context.Background(), "") != nil {
+		t.Error("empty tenant should return nil without calling the loader")
+	}
+	if f.calls != 0 {
+		t.Error("empty tenant must not call the loader")
+	}
+}

--- a/pkg/aiqg/cacheconfig/http_loader.go
+++ b/pkg/aiqg/cacheconfig/http_loader.go
@@ -1,0 +1,58 @@
+package cacheconfig
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// HTTPLoader loads per-tenant cache config from aiqg-dashboard-be's internal
+// endpoint (GET /internal/cache-config?tenant=). Reuses the same base URL +
+// Internal-Auth token as the policy/experiments resolvers.
+type HTTPLoader struct {
+	HTTP              *http.Client
+	BaseURL           string
+	InternalAuthToken string
+}
+
+// NewHTTPLoader builds a loader against the dashboard.
+func NewHTTPLoader(baseURL, internalAuthToken string) *HTTPLoader {
+	return &HTTPLoader{
+		HTTP:              &http.Client{Timeout: 2 * time.Second},
+		BaseURL:           strings.TrimRight(baseURL, "/"),
+		InternalAuthToken: internalAuthToken,
+	}
+}
+
+// cacheConfigResponse is the endpoint envelope: {tenant_id, cache_config: {...}}.
+type cacheConfigResponse struct {
+	TenantID    string  `json:"tenant_id"`
+	CacheConfig *Config `json:"cache_config"`
+}
+
+// ForTenant fetches the tenant's config. A 200 with an empty spec decodes to a
+// non-nil, all-nil Config (every field falls back to the global default).
+func (l *HTTPLoader) ForTenant(ctx context.Context, tenantID string) (*Config, error) {
+	url := l.BaseURL + "/internal/cache-config?tenant=" + tenantID
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Internal-Auth", l.InternalAuthToken)
+	resp, err := l.HTTP.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("cacheconfig: dashboard returned status %d", resp.StatusCode)
+	}
+	var out cacheConfigResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("cacheconfig: decode response: %w", err)
+	}
+	return out.CacheConfig, nil
+}

--- a/pkg/aiqg/events/builder.go
+++ b/pkg/aiqg/events/builder.go
@@ -92,6 +92,11 @@ type RoutingView struct {
 	CacheSavedCompletionTokens int
 	CacheSavedCostUSD          float64
 
+	// CacheSimilarity / CacheThreshold — the L1 similarity + admitting threshold
+	// of a served C4 semantic hit (zero unless cache_state=semantic_hit).
+	CacheSimilarity float64
+	CacheThreshold  float64
+
 	// Vendor finish_reason captured from the response. Used both
 	// to populate ResponseEvent.FinishReason (taking precedence
 	// over the BuildOptions value) and to drive clear.Efficacy.
@@ -610,6 +615,8 @@ func Build(r *http.Request, headers AIQGHeadersView, routing RoutingView, token 
 		CacheSavedPromptTokens:     routing.CacheSavedPromptTokens,
 		CacheSavedCompletionTokens: routing.CacheSavedCompletionTokens,
 		CacheSavedCostUSD:          routing.CacheSavedCostUSD,
+		CacheSimilarity:            routing.CacheSimilarity,
+		CacheThreshold:             routing.CacheThreshold,
 		CLEAR:                      clear.Compute(clearInput),
 		ScoringVersion:             ScoringVersion,
 		GatewayVersion:             GatewayVersion,

--- a/pkg/aiqg/events/event.go
+++ b/pkg/aiqg/events/event.go
@@ -231,6 +231,11 @@ type ResponseEvent struct {
 	CacheSavedCompletionTokens int     `json:"cache_saved_completion_tokens,omitempty"`
 	CacheSavedCostUSD          float64 `json:"cache_saved_cost_usd,omitempty"`
 
+	// C4 semantic-hit observability (§13): similarity of the served entry and the
+	// threshold that admitted it. Present only on cache_state=semantic_hit.
+	CacheSimilarity float64 `json:"cache_similarity,omitempty"`
+	CacheThreshold  float64 `json:"cache_threshold,omitempty"`
+
 	// CLEAR scores — populated by pkg/clear.Compute(). A nil *Scores
 	// (rather than a *Scores with all-nil dimension fields) means the
 	// scorer wasn't run at all, which today only happens on the noop

--- a/pkg/aiqg/semcache/cascade.go
+++ b/pkg/aiqg/semcache/cascade.go
@@ -58,15 +58,40 @@ func (c *Cache) ready() bool {
 // logged). False in shadow mode.
 func (c *Cache) Serving() bool { return c.ready() && !c.cfg.Shadow }
 
-// Lookup runs the cascade for one post-redaction prompt. It NEVER mutates the
-// request and NEVER serves in shadow mode. Errors from the embedder/store are
-// swallowed into a miss (a cache must fail open — a broken cache is a slow path,
-// never a wrong answer).
+// LookupOptions overrides the cache's configured behavior for one request —
+// the seam for per-tenant config (pkg/aiqg/cacheconfig). A nil field uses the
+// Cache's global config value.
+type LookupOptions struct {
+	// Shadow overrides shadow mode: true = a passing L2 candidate is a shadow_hit
+	// (logged, not served); false = a semantic_hit (serve). nil = Cache config.
+	Shadow *bool
+	// MinSimilarity overrides the L1 candidate floor. nil = Cache config.
+	MinSimilarity *float64
+}
+
+// Lookup runs the cascade with the Cache's global config (shadow + threshold).
 func (c *Cache) Lookup(ctx context.Context, scope Scope, prompt string) Outcome {
+	return c.LookupWithOptions(ctx, scope, prompt, LookupOptions{})
+}
+
+// LookupWithOptions runs the cascade for one post-redaction prompt, honoring the
+// per-request overrides. It NEVER mutates the request; whether a passing hit is
+// served vs shadow-logged is the caller's decision, driven by the effective
+// Shadow flag. Errors from the embedder/store are swallowed into a miss (a cache
+// must fail open — a broken cache is a slow path, never a wrong answer).
+func (c *Cache) LookupWithOptions(ctx context.Context, scope Scope, prompt string, opts LookupOptions) Outcome {
 	if !c.ready() || prompt == "" {
 		return Outcome{}
 	}
-	out := Outcome{State: StateMiss, Threshold: c.cfg.MinSimilarity}
+	minSim := c.cfg.MinSimilarity
+	if opts.MinSimilarity != nil {
+		minSim = *opts.MinSimilarity
+	}
+	shadow := c.cfg.Shadow
+	if opts.Shadow != nil {
+		shadow = *opts.Shadow
+	}
+	out := Outcome{State: StateMiss, Threshold: minSim}
 
 	// L1 — embed + range search. A shortlist, not a decision.
 	vec, err := c.embed.Embed(ctx, prompt)
@@ -77,7 +102,7 @@ func (c *Cache) Lookup(ctx context.Context, scope Scope, prompt string) Outcome 
 	if k <= 0 {
 		k = 5
 	}
-	cands, err := c.store.Search(ctx, scope, vec, c.cfg.MinSimilarity, k)
+	cands, err := c.store.Search(ctx, scope, vec, minSim, k)
 	if err != nil || len(cands) == 0 {
 		return out
 	}
@@ -92,7 +117,7 @@ func (c *Cache) Lookup(ctx context.Context, scope Scope, prompt string) Outcome 
 	for i, cand := range cands {
 		res := Verify(prompt, cand.Entry, scope, now, c.cfg.TTL)
 		if res.Pass {
-			if c.cfg.Shadow {
+			if shadow {
 				out.State = StateShadowHit // would have hit — logged, not served
 			} else {
 				out.State = StateSemanticHit

--- a/pkg/aiqg/semcache/lookup_options_test.go
+++ b/pkg/aiqg/semcache/lookup_options_test.go
@@ -1,0 +1,53 @@
+package semcache
+
+import (
+	"context"
+	"testing"
+)
+
+// A per-request Shadow override flips a shadow-configured cache into serving
+// (semantic_hit) — the seam per-tenant serve-enablement uses.
+func TestLookupWithOptions_ShadowOverrideServes(t *testing.T) {
+	c, _ := newCache(t, true /* global shadow */)
+	sc := scopeOf("t1", "m1")
+	seed(t, c, sc, "how do I reset my password", `{"ok":1}`)
+
+	// Global shadow → shadow_hit.
+	if out := c.Lookup(context.Background(), sc, "how can I reset my password"); out.State != StateShadowHit {
+		t.Fatalf("global shadow: state=%q want shadow_hit", out.State)
+	}
+	// Override Shadow=false → semantic_hit (serve).
+	serve := false
+	out := c.LookupWithOptions(context.Background(), sc, "how can I reset my password", LookupOptions{Shadow: &serve})
+	if out.State != StateSemanticHit {
+		t.Errorf("shadow override: state=%q want semantic_hit", out.State)
+	}
+	if out.Entry == nil {
+		t.Error("a semantic hit must carry the winning entry to serve")
+	}
+	if out.Threshold != 0.8 {
+		t.Errorf("threshold should reflect the effective floor, got %v", out.Threshold)
+	}
+}
+
+// A per-request MinSimilarity override raises the L1 floor above a candidate's
+// similarity, turning a would-hit into a miss (no candidate clears the floor).
+func TestLookupWithOptions_ThresholdOverrideTightens(t *testing.T) {
+	c, _ := newCache(t, false)
+	sc := scopeOf("t1", "m1")
+	seed(t, c, sc, "how do I reset my password", `{"ok":1}`)
+
+	// At the default 0.8 floor the paraphrase hits.
+	if out := c.Lookup(context.Background(), sc, "how can I reset my password"); out.State != StateSemanticHit {
+		t.Fatalf("baseline should hit, got %q (sim=%.3f)", out.State, out.Similarity)
+	}
+	// Raise the floor to ~1.0 → the paraphrase no longer clears L1 → miss.
+	tight := 0.999
+	out := c.LookupWithOptions(context.Background(), sc, "how can I reset my password", LookupOptions{MinSimilarity: &tight})
+	if out.State != StateMiss {
+		t.Errorf("tightened threshold should miss, got %q (sim=%.3f)", out.State, out.Similarity)
+	}
+	if out.Threshold != tight {
+		t.Errorf("outcome threshold=%v want %v", out.Threshold, tight)
+	}
+}


### PR DESCRIPTION
The gateway side of per-tenant cache config: resolve each tenant's overrides from aiqg-dashboard-be (PR #90) and apply them per request. This is the **safe per-tenant way to opt a tenant into C4 semantic serving** — a global flip turns probabilistic hits on for everyone at once. An absent override field = the global default, so partial overrides compose.

### What's here
- **`pkg/aiqg/cacheconfig`** — `Config` (pointer-field `exact`/`semantic`/`judge`) + effective-value helpers (`ExactEnabled`/`SemanticShadow`/`SemanticMinSimilarity`/… over a global) + `Loader`/`HTTPLoader` (`GET /internal/cache-config?tenant=`) + a TTL `Resolver`. Mirrors `pkg/aiqg/experiments`; nil-safe, degrades to stale/global, **never fails**. Threshold overrides may only **tighten** (`max(override, global)`) — a tenant can't widen its own false-hit rate (§10.2).
- **`semcache.LookupWithOptions(Shadow, MinSimilarity)`** overrides shadow/threshold per request; `Lookup` delegates with the global config.
- **`server.go`** — build the resolver next to the experiments resolver; capture the global C4 defaults; apply per request in `maybeServeFromCache`: per-tenant **C1 disable** skips the exact lookup+store, and a **serve-enabled** tenant gets a synchronous `maybeServeSemantic` (`cache_state=semantic_hit` + savings), while everyone else keeps the async log-only shadow path (`runSemanticShadow` now takes the tenant config for its threshold). `writeRawCachedResponse` shares the response writer.
- **Semantic-hit observability (§13, folds in Track A1)** — `cache_similarity` + `cache_threshold` travel with `cache_state` through the routing sidecar (`StampCacheSemantic`) → events builder → `ResponseEvent` payload. `semantic_hit` stays **distinct** from exact `hit` — one is provably correct, the other probabilistic.

### Safety
Reaches the semantic path only on a C1 exact miss, so requests are already C1-eligible (deterministic, non-streaming, no tools). **Serving stays default-off**: no tenant serves a semantic hit until its `cache_config` sets `semantic.enabled` + `shadow=false`. The stored entries are already post-redaction, so serving them honors the privacy precondition.

Tests: resolver TTL/degrade/nil + effective-value composition + threshold-only-tightens; `LookupWithOptions` shadow-override-serves + threshold-tightens. `nohs` build + tests + lint green.

Companion: dashboard-be #90 (merged), aiqg-ui settings screen (B3) next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)