### PR TITLE
fix(aiqg): stamp semantic_hit before miss on the serve path

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1021,13 +1021,15 @@ func (s *Server) maybeServeFromCache(w http.ResponseWriter, r *http.Request, req
 		}
 	}
 
-	middleware.StampCacheState(r.Context(), "miss")
 	// C4 (L0→L1) on the exact-match miss. A serve-enabled tenant gets a SYNCHRONOUS
-	// semantic-hit serve (cache_state=semantic_hit); everyone else takes the async,
-	// log-only shadow path (which also stashes the store intent).
+	// semantic-hit serve; everyone else takes the async, log-only shadow path.
+	// This MUST run before stamping "miss": StampCacheState is first-write-wins, so
+	// a served hit stamps cache_state=semantic_hit itself and a premature "miss"
+	// here would win and hide the hit from the event stream (§13 reporting).
 	if s.maybeServeSemantic(w, r, req, tenantID, vendor, cc) {
 		return nil
 	}
+	middleware.StampCacheState(r.Context(), "miss")
 	ctx := s.runSemanticShadow(r.Context(), req, tenantID, hash, cc)
 	if !exactEnabled {
 		return r.WithContext(ctx) // C1 store also disabled for this tenant


### PR DESCRIPTION
**Caught by live end-to-end verification** of per-tenant semantic serving.

`maybeServeFromCache` stamped `cache_state="miss"` **before** calling `maybeServeSemantic`. `StampCacheState` is first-write-wins, so a served semantic hit (which stamps `semantic_hit` itself) was recorded as `"miss"` in the event stream. The response served correctly (`X-TAS-Cache: semantic_hit`, set directly in the writer) — but reporting **undercounted semantic hits** and the §13 savings split was invisible.

Fix: move the `maybeServeSemantic` call ahead of the `"miss"` stamp so the served hit's `semantic_hit` stamp wins.

`nohs` build + server tests green. Verified live after redeploy (aiqg-v5.55): the served paraphrase now emits `cache_state=semantic_hit` + `cache_similarity`/`cache_threshold` on the event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)