### PR TITLE
fix(aiqg): carry cache_similarity/threshold through routingView

### DIFF
--- a/internal/middleware/aiqg.go
+++ b/internal/middleware/aiqg.go
@@ -824,6 +824,8 @@ func routingView(r *Routing) events.RoutingView {
 		CacheSavedPromptTokens:     s.CacheSavedPromptTokens,
 		CacheSavedCompletionTokens: s.CacheSavedCompletionTokens,
 		CacheSavedCostUSD:          s.CacheSavedCostUSD,
+		CacheSimilarity:            s.CacheSimilarity,
+		CacheThreshold:             s.CacheThreshold,
 		FinishReason:               s.FinishReason,
 		AttemptCount:               s.AttemptCount,
 		FallbackUsed:               s.FallbackUsed,

--- a/internal/middleware/aiqg_routing_test.go
+++ b/internal/middleware/aiqg_routing_test.go
@@ -284,3 +284,30 @@ func TestRouting_ConcurrentStamps(t *testing.T) {
 		t.Errorf("concurrent stamps produced inconsistent state: %#v", s)
 	}
 }
+
+// TestRoutingView_CarriesSemanticCacheFields guards the sidecar → events.RoutingView
+// copy (routingView) for the C4 fields. Regression: that copy carried cache_saved_*
+// but DROPPED cache_similarity/cache_threshold, so served semantic hits lost their
+// similarity/threshold on the event stream while savings survived.
+func TestRoutingView_CarriesSemanticCacheFields(t *testing.T) {
+	r := &Routing{}
+	ctx := WithRouting(context.Background(), r)
+	StampCacheState(ctx, "semantic_hit")
+	StampCacheSemantic(ctx, 0.983, 0.9)
+	StampCacheSavings(ctx, 20, 60, 0.00025)
+
+	v := routingView(r)
+	if v.CacheState != "semantic_hit" {
+		t.Errorf("CacheState = %q, want semantic_hit", v.CacheState)
+	}
+	if v.CacheSimilarity != 0.983 {
+		t.Errorf("CacheSimilarity dropped in routingView: got %v want 0.983", v.CacheSimilarity)
+	}
+	if v.CacheThreshold != 0.9 {
+		t.Errorf("CacheThreshold dropped in routingView: got %v want 0.9", v.CacheThreshold)
+	}
+	// Sanity: the savings field that always propagated still does.
+	if v.CacheSavedCostUSD != 0.00025 {
+		t.Errorf("CacheSavedCostUSD = %v, want 0.00025", v.CacheSavedCostUSD)
+	}
+}


### PR DESCRIPTION
The sidecar → `events.RoutingView` copy (`routingView`) carried `cache_saved_*` but **dropped** `cache_similarity`/`cache_threshold` — the one hop of the four-hop chain (sidecar → Snapshot → routingView → ResponseEvent) that never got the two fields added in #119. Served semantic hits emitted `cache_state=semantic_hit` + savings but no similarity/threshold, so the §13 danger-band observability was invisible even though the serve worked.

Fix: add the two fields to `routingView`. Regression test asserts `routingView` carries them (alongside the savings field that always did). **Caught by live event inspection after the deploy.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)