### PR TITLE
feat(aiqg): per-tenant judge enable + sample rate

### DIFF
--- a/internal/server/semjudge.go
+++ b/internal/server/semjudge.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/tributary-ai/llm-router-waf/internal/routing"
 	"github.com/tributary-ai/llm-router-waf/internal/types"
+	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/cacheconfig"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/metrics"
 	"github.com/tributary-ai/llm-router-waf/pkg/aiqg/semcache"
 	"github.com/tributary-ai/llm-router-waf/pkg/clear"
@@ -74,8 +75,14 @@ func buildSemJudge(cfg AIQGSemCacheConfig, fallbackModel string, router *routing
 // judge. The candidate graded is the winning entry on a would-hit, or the
 // L2-rejected near-miss on a miss. No-op when judging is disabled. Runs in the
 // shadow goroutine (already off the request path); Enqueue itself never blocks.
-func (s *Server) enqueueForJudge(scope semcache.Scope, prompt string, out semcache.Outcome) {
+func (s *Server) enqueueForJudge(scope semcache.Scope, prompt string, out semcache.Outcome, cc *cacheconfig.Config) {
 	if s.semJudge == nil {
+		return
+	}
+	// Per-tenant judge control: a tenant may opt OUT of grading (JudgeEnabled) or
+	// dial its own sample rate, over the global defaults. (The Loop's daily $ cap
+	// remains a global opex ceiling — see AIQG_SEMCACHE_JUDGE_DAILY_USD.)
+	if !cc.JudgeEnabled(true) {
 		return
 	}
 	var cand *semcache.Entry
@@ -88,7 +95,9 @@ func (s *Server) enqueueForJudge(scope semcache.Scope, prompt string, out semcac
 	if cand == nil {
 		return
 	}
-	if !s.semJudgeCfg.ShouldSample(out.Similarity, out.State, scope.TenantID+"|"+prompt) {
+	sampleCfg := s.semJudgeCfg
+	sampleCfg.Rate = cc.JudgeSampleRate(s.semJudgeCfg.Rate)
+	if !sampleCfg.ShouldSample(out.Similarity, out.State, scope.TenantID+"|"+prompt) {
 		return
 	}
 	s.semJudge.Enqueue(semcache.Sample{

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1081,7 +1081,7 @@ func (s *Server) runSemanticShadow(ctx context.Context, req *types.ChatRequest, 
 		// truth) and L2-rejected near-misses (L2 precision) in the danger band and
 		// enqueue them for the async grader; Enqueue never blocks and drops when
 		// the queue is full, so this cannot slow the shadow goroutine.
-		s.enqueueForJudge(scope, prompt, out)
+		s.enqueueForJudge(scope, prompt, out, cc)
 	}()
 	return semcache.WithPending(ctx, &semcache.Pending{Scope: scope, Key: key, Prompt: prompt})
 }
@@ -1164,7 +1164,7 @@ func (s *Server) maybeServeSemantic(w http.ResponseWriter, r *http.Request, req 
 	if out.State != semcache.StateSemanticHit || out.Entry == nil {
 		// Not a hit — hand the near-miss/would-hit to the judge (FPR signal) and
 		// let the caller fall through to a live vendor call + store.
-		s.enqueueForJudge(scope, prompt, out)
+		s.enqueueForJudge(scope, prompt, out, cc)
 		return false
 	}
 	resp, ok := writeRawCachedResponse(w, out.Entry.Response, semcache.StateSemanticHit)
@@ -1179,7 +1179,7 @@ func (s *Server) maybeServeSemantic(w http.ResponseWriter, r *http.Request, req 
 		middleware.StampCacheSavings(r.Context(), resp.Usage.PromptTokens, resp.Usage.CompletionTokens, cost)
 	}
 	// Grade served hits too — that is the sampled-FPR ground truth (§14.1).
-	s.enqueueForJudge(scope, prompt, out)
+	s.enqueueForJudge(scope, prompt, out, cc)
 	return true
 }
 

--- a/pkg/aiqg/cacheconfig/cacheconfig_test.go
+++ b/pkg/aiqg/cacheconfig/cacheconfig_test.go
@@ -133,3 +133,24 @@ func TestResolver_NilSafeAndEmptyTenant(t *testing.T) {
 		t.Error("empty tenant must not call the loader")
 	}
 }
+
+func TestJudgeHelpers_Override(t *testing.T) {
+	// nil / unset → global defaults.
+	var nilC *Config
+	if !nilC.JudgeEnabled(true) || nilC.JudgeSampleRate(0.5) != 0.5 {
+		t.Error("nil config should defer judge knobs to global")
+	}
+	// A tenant opts OUT of grading and dials its own sample rate.
+	c := &Config{Judge: &JudgeConfig{Enabled: bptr(false), SampleRate: fptr(0.1)}}
+	if c.JudgeEnabled(true) {
+		t.Error("judge.enabled=false override should win (opt out)")
+	}
+	if c.JudgeSampleRate(1.0) != 0.1 {
+		t.Errorf("judge.sample_rate override should win: got %v want 0.1", c.JudgeSampleRate(1.0))
+	}
+	// Unset sample rate falls back to global even when enabled is set.
+	c2 := &Config{Judge: &JudgeConfig{Enabled: bptr(true)}}
+	if c2.JudgeSampleRate(0.25) != 0.25 {
+		t.Error("unset sample rate should fall back to global")
+	}
+}


### PR DESCRIPTION
Wires the per-tenant L3-judge knobs the cacheconfig model already carried. `enqueueForJudge` now applies the tenant config: `JudgeEnabled` lets a tenant opt OUT of grading even when globally on, and `JudgeSampleRate` overrides the sample rate per request. The Loop's daily $ cap stays a **global** opex ceiling (the judge budget metrics + Alertmanager rule are built around one global budget; per-tenant budgets are a separate refinement). Closes the last per-tenant-config follow-up. Tests + build green.