### PR TITLE
feat(aiqg): per-tenant judge daily budgets

### DIFF
--- a/internal/server/semjudge.go
+++ b/internal/server/semjudge.go
@@ -108,6 +108,8 @@ func (s *Server) enqueueForJudge(scope semcache.Scope, prompt string, out semcac
 		Similarity:   out.Similarity,
 		Observed:     out.State,
 		RejectReason: out.RejectReason,
+		// Per-tenant daily cap (0 = none; the global ceiling still applies).
+		DailyUSD: cc.JudgeDailyUSD(0),
 	})
 }
 

--- a/pkg/aiqg/cacheconfig/cacheconfig.go
+++ b/pkg/aiqg/cacheconfig/cacheconfig.go
@@ -106,6 +106,16 @@ func (c *Config) JudgeSampleRate(global float64) float64 {
 	return global
 }
 
+// JudgeDailyUSD returns the tenant's per-tenant judge daily spend cap, or global
+// when unset. Pass global=0 to mean "no per-tenant cap unless the tenant set one"
+// — the judge loop's global ceiling still applies on top.
+func (c *Config) JudgeDailyUSD(global float64) float64 {
+	if c != nil && c.Judge != nil && c.Judge.DailyUSD != nil {
+		return *c.Judge.DailyUSD
+	}
+	return global
+}
+
 // Loader fetches a tenant's cache config. Implementations wrap the dashboard's
 // internal endpoint; the interface keeps the resolver testable.
 type Loader interface {

--- a/pkg/aiqg/cacheconfig/cacheconfig_test.go
+++ b/pkg/aiqg/cacheconfig/cacheconfig_test.go
@@ -153,4 +153,11 @@ func TestJudgeHelpers_Override(t *testing.T) {
 	if c2.JudgeSampleRate(0.25) != 0.25 {
 		t.Error("unset sample rate should fall back to global")
 	}
+	// Per-tenant daily cap: override wins; unset falls back to the passed default.
+	if c := (&Config{Judge: &JudgeConfig{DailyUSD: fptr(0.25)}}); c.JudgeDailyUSD(0) != 0.25 {
+		t.Errorf("judge.daily_usd override should win: got %v", c.JudgeDailyUSD(0))
+	}
+	if nilC.JudgeDailyUSD(0) != 0 {
+		t.Error("unset daily cap with global 0 should be 0 (no per-tenant cap)")
+	}
 }

--- a/pkg/aiqg/semcache/budget_test.go
+++ b/pkg/aiqg/semcache/budget_test.go
@@ -113,3 +113,40 @@ func TestLoop_StopsGradingAtDailyCap(t *testing.T) {
 		t.Errorf("SpentUSD=%.3f, want ~0.50", st.SpentUSD)
 	}
 }
+
+// TestLoop_PerTenantBudget: a per-tenant cap binds one tenant independently while
+// the global ceiling is generous — a capped tenant stops after ~1 grade, an
+// uncapped tenant keeps grading.
+func TestLoop_PerTenantBudget(t *testing.T) {
+	grader := GraderFunc(func(_ context.Context, _ Sample) (Verdict, error) {
+		return Verdict{Correct: true, CostUSD: 0.50}, nil // each grade spends $0.50
+	})
+	loop := NewLoop(grader,
+		PairSinkFunc(func(context.Context, JudgedPair) error { return nil }),
+		NewSimCalibrator(0, 0),
+		NewDailyBudget(100), // generous GLOBAL ceiling
+		64)
+	go loop.Run(t.Context())
+
+	// Tenant A: $0.50 cap → one grade consumes it. Tenant B: no cap.
+	for range 6 {
+		loop.Enqueue(Sample{Scope: scopeOf("A", "m1"), Query: "qa", CachedAnswer: "x", Similarity: 0.98, Observed: StateShadowHit, DailyUSD: 0.50})
+		loop.Enqueue(Sample{Scope: scopeOf("B", "m1"), Query: "qb", CachedAnswer: "x", Similarity: 0.98, Observed: StateShadowHit, DailyUSD: 0})
+	}
+	waitFor(t, func() bool { return loop.Stats().Graded+loop.Stats().BudgetSkipped >= 12 })
+
+	// Per-tenant accounting isn't in JudgeStats, but the global tallies prove the
+	// cap bound SOMETHING: tenant A's 6 → 1 graded + 5 skipped; tenant B's 6 all
+	// graded. So Graded == 7, BudgetSkipped == 5.
+	st := loop.Stats()
+	if st.Graded != 7 {
+		t.Errorf("Graded=%d, want 7 (1 for capped A + 6 for uncapped B)", st.Graded)
+	}
+	if st.BudgetSkipped != 5 {
+		t.Errorf("BudgetSkipped=%d, want 5 (A's over-cap samples)", st.BudgetSkipped)
+	}
+	// The global budget spent only $3.50 (7 grades) — nowhere near its $100 ceiling.
+	if _, spent, _, _ := loop.Budget(); spent < 3.4 || spent > 3.6 {
+		t.Errorf("global spent=%.2f, want ~3.50", spent)
+	}
+}

--- a/pkg/aiqg/semcache/judge.go
+++ b/pkg/aiqg/semcache/judge.go
@@ -41,6 +41,10 @@ type Sample struct {
 	Observed string
 	// RejectReason is the L2 guard that fired when Observed == StateMiss.
 	RejectReason string
+	// DailyUSD is this sample's tenant's per-tenant judge spend cap for today. 0 =
+	// no per-tenant cap (only the loop's global ceiling applies). Layered ON TOP of
+	// the global budget — a grade must clear both.
+	DailyUSD float64
 }
 
 // wouldServe reports whether this sample is one the cache would (or did) serve —

--- a/pkg/aiqg/semcache/judgeloop.go
+++ b/pkg/aiqg/semcache/judgeloop.go
@@ -14,8 +14,8 @@ type JudgedPair struct {
 	Scope      Scope   `json:"scope"`
 	Similarity float64 `json:"similarity"`
 	Confidence float64 `json:"confidence"`
-	Observed   string  `json:"observed"`      // cascade state that produced the sample
-	Reason     string  `json:"reason"`        // judge's rationale
+	Observed   string  `json:"observed"` // cascade state that produced the sample
+	Reason     string  `json:"reason"`   // judge's rationale
 	AtUnix     int64   `json:"at_unix"`
 }
 
@@ -78,8 +78,19 @@ type Loop struct {
 	budget *DailyBudget
 	queue  chan Sample
 
+	// Per-tenant daily budgets, layered ON TOP of the global `budget`. A tenant
+	// with no cap (Sample.DailyUSD<=0) has no entry — only the global ceiling
+	// bounds it. Keyed by tenant; recreated if the tenant's cap changes.
+	tbMu          sync.Mutex
+	tenantBudgets map[string]*tenantBudgetEntry
+
 	mu    sync.Mutex
 	stats JudgeStats
+}
+
+type tenantBudgetEntry struct {
+	budget *DailyBudget
+	cap    float64
 }
 
 // NewLoop builds the judge loop. queueSize bounds the backlog (excess samples are
@@ -92,12 +103,31 @@ func NewLoop(grader Grader, sink PairSink, cal *SimCalibrator, budget *DailyBudg
 		queueSize = 256
 	}
 	return &Loop{
-		grader: grader,
-		sink:   sink,
-		cal:    cal,
-		budget: budget,
-		queue:  make(chan Sample, queueSize),
+		grader:        grader,
+		sink:          sink,
+		cal:           cal,
+		budget:        budget,
+		queue:         make(chan Sample, queueSize),
+		tenantBudgets: map[string]*tenantBudgetEntry{},
 	}
+}
+
+// tenantBudget returns the per-tenant daily budget for capUSD, get-or-created. A
+// capUSD<=0 means "no per-tenant cap" → nil (nil DailyBudget is unlimited and
+// nil-safe), so only the global ceiling applies. A changed cap recreates the
+// budget (rare; bounded by the resolver TTL).
+func (l *Loop) tenantBudget(tenantID string, capUSD float64) *DailyBudget {
+	if capUSD <= 0 {
+		return nil
+	}
+	l.tbMu.Lock()
+	defer l.tbMu.Unlock()
+	e, ok := l.tenantBudgets[tenantID]
+	if !ok || e.cap != capUSD {
+		e = &tenantBudgetEntry{budget: NewDailyBudget(capUSD), cap: capUSD}
+		l.tenantBudgets[tenantID] = e
+	}
+	return e.budget
 }
 
 func (l *Loop) ready() bool { return l != nil && l.grader != nil && l.sink != nil }
@@ -138,8 +168,10 @@ func (l *Loop) Run(ctx context.Context) {
 func (l *Loop) process(ctx context.Context, s Sample) {
 	// Daily cost governor (§14.1): once today's cap is reached, stop grading until
 	// UTC midnight rolls the budget over. The sample is skipped, not queued — the
-	// judge is a metered luxury, never a backlog that spends tomorrow's budget.
-	if !l.budget.Allow() {
+	// judge is a metered luxury, never a backlog that spends tomorrow's budget. Both
+	// the GLOBAL ceiling and this tenant's per-tenant cap must permit the spend.
+	tb := l.tenantBudget(s.Scope.TenantID, s.DailyUSD)
+	if !l.budget.Allow() || !tb.Allow() {
 		l.bump(func(st *JudgeStats) { st.BudgetSkipped++ })
 		return
 	}
@@ -149,6 +181,7 @@ func (l *Loop) process(ctx context.Context, s Sample) {
 		return
 	}
 	l.budget.Add(v.CostUSD)
+	tb.Add(v.CostUSD)
 	// Tally: a would-serve sample judged incorrect is a false hit (the ground
 	// truth); an L2-rejected sample judged incorrect confirms L2 was right to
 	// reject. Only would-serve verdicts train the threshold — an L2 rejection is


### PR DESCRIPTION
Layers a per-tenant judge spend cap **on top of** the global ceiling — a grade must clear both. Closes the last deferred per-tenant-config item and makes the UI's judge daily-$ field actually per-tenant.

- `Sample.DailyUSD` (tenant's effective cap; 0 = no per-tenant cap).
- `Loop` keeps its global budget (metrics + Alertmanager rule **unchanged**) and adds a per-tenant `DailyBudget` registry keyed by tenant, get-or-created with the sample's cap (recreated on cap change; nil = unlimited, nil-safe). `process()` requires **both** budgets to `Allow()` and charges both; a skip on either bumps `BudgetSkipped`.
- `cacheconfig.JudgeDailyUSD(global)`; `enqueueForJudge` sets `DailyUSD = cc.JudgeDailyUSD(0)`.

The global budget stays the total-opex safety net; per-tenant caps stop one tenant consuming the whole budget. Tests: a capped tenant stops after ~1 grade while an uncapped tenant keeps grading. Build + tests + lint green.